### PR TITLE
Gitignore with rvmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 rdoc
 .yardoc
 Gemfile.lock
+.rvmrc


### PR DESCRIPTION
I'd like to add the .rvmrc to the .gitignore file.
