### PR TITLE
@driver.current_url does not work. So a javascript hack is used instead

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -73,7 +73,7 @@ module Watir
     end
 
     def url
-      @driver.current_url
+      @driver.execute_script("return document.location.toString();")
     end
 
     def title


### PR DESCRIPTION
Make the change to URL because @driver.current_url does not work. We should use this while @driver.current_url does not work.
