### PR TITLE
Undefine #id and #type on Watir::Element instead of on Object

### DIFF
--- a/lib/watir-webdriver.rb
+++ b/lib/watir-webdriver.rb
@@ -81,10 +81,3 @@ require 'watir-webdriver/elements/table_cell'
 require 'watir-webdriver/elements/table_section'
 
 Watir.tag_to_class.freeze
-
-# undefine deprecated methods to use them for Element attributes
-class Object
-  undef_method :id if method_defined? "id"
-  undef_method :type if method_defined? "type"
-end
-

--- a/lib/watir-webdriver/attribute_helper.rb
+++ b/lib/watir-webdriver/attribute_helper.rb
@@ -39,6 +39,13 @@ module Watir
 
     private
 
+    def self.extended(klass)
+      klass.class_eval do
+        # undefine deprecated methods to use them for Element attributes
+        [:id, :type].each { |m| undef_method m if method_defined? m }
+      end
+    end
+
     def define_attribute(type, name)
       method_name    = method_name_for(type, name)
       attribute_name = attribute_for_method(name)


### PR DESCRIPTION
Right now, watir-webdriver undefines `Object#id` and `Object#type` on `Object` itself. That interferes with other libraries that have their own backwards compatibility logic.

This patch isolates that undefinition to the class it was intended for: `Watir::Element`

Thoughts?

I'm not sure where to test this as the original behavior isn't tested. I looked in `spec/element_spec.rb`; but it seemed more integration style.
