### PR TITLE
Use #<< as #append on text fields

### DIFF
--- a/lib/watir-webdriver/elements/text_field.rb
+++ b/lib/watir-webdriver/elements/text_field.rb
@@ -28,6 +28,7 @@ module Watir
 
       @element.send_keys(*args)
     end
+    alias_method :<<, :append
 
     #
     # Clear the text field.


### PR DESCRIPTION
What do you think? This is a small DSL change, but in Ruby-style.

``` ruby
@browser.text_field(id: 'test').text # 'test'
@browser.text_field(id: 'test') << ' appended'
@browser.text_field(id: 'test').text # 'test appended'
```

As long as it's just an alias, I didn't add specs for it, but if you tell me to, I will.
