### PR TITLE
Return the element itself when #flash is called.

### DIFF
--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -235,6 +235,8 @@ module Watir
         color = (n % 2 == 0) ? "red" : original_color
         driver.execute_script("arguments[0].style.backgroundColor = '#{color}'", @element)
       end
+
+      self
     end
 
     #


### PR DESCRIPTION
This aids in chainability.

Specs at https://github.com/watir/watirspec/pull/38
