### PR TITLE
Proxy Object should inherit from BasicObject, to avoid clashes with methods on Object. eg present? defined by ActiveSupport

### DIFF
--- a/lib/watir-webdriver/wait.rb
+++ b/lib/watir-webdriver/wait.rb
@@ -95,7 +95,7 @@ module Watir
         raise NoMethodError, "undefined method `#{m}' for #{@element.inspect}:#{@element.class}"
       end
 
-      Watir::Wait.until(@timeout, @message) { @element.present? }
+      ::Watir::Wait.until(@timeout, @message) { @element.present? }
 
       @element.__send__(m, *args, &block)
     end


### PR DESCRIPTION
I hope issue title is descriptive enough.
