### PR TITLE
Updated LICENSE to indicate it is the MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+(the MIT License)
+
 Copyright (c) 2009-2013 Jari Bakken
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
added info on license type, makes things a lot easier for companies with rules about what kind of OS software they can use.   We are using the MIT license, but did not state that.
