### PR TITLE
Correct documentation for Browser#name return type

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -156,7 +156,7 @@ module Watir
     #   browser.name
     #   #=> :chrome
     #
-    # @return [String]
+    # @return [Symbol]
     #
 
     def name


### PR DESCRIPTION
`Browser#name` returns a symbol rather than a string.
