### PR TITLE
Fixing hash typo on Cookie#add

### DIFF
--- a/lib/watir-webdriver/cookies.rb
+++ b/lib/watir-webdriver/cookies.rb
@@ -45,7 +45,7 @@ module Watir
         :secure  => opts[:secure],
         :path    => opts[:path],
         :expires => opts[:expires],
-        :domain  => opts[:domain],
+        :domain  => opts[:domain]
       }
 
       @control.add_cookie cookie


### PR DESCRIPTION
Removing additional `,` after the last hash element.
