### PR TITLE
Remove Rubyforge reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ watir-webdriver
 ===============
 
 Watir implementation built on WebDriver's Ruby bindings.
+See https://web.archive.org/web/20140518221755/http://rubyforge.org/pipermail/wtr-development/2009-October/001313.html
 
 [![Gem Version](https://badge.fury.io/rb/watir-webdriver.png)](http://badge.fury.io/rb/watir-webdriver)
 [![Build Status](https://travis-ci.org/watir/watir-webdriver.png?branch=master)](https://travis-ci.org/watir/watir-webdriver)


### PR DESCRIPTION
Rubyforge doesn't exist anymore and Google doesn't have a cached copy of the link
