### PR TITLE
Fixes issue with stale elements

### DIFF
--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -502,7 +502,17 @@ module Watir
         return
       end
 
-      @element = (@selector[:element] || locate)
+      if @selector[:element]
+        @element= @selector[:element]
+        assert_not_stale
+        return
+      end
+
+      begin
+        @element = locate
+      rescue Selenium::WebDriver::Error::ObsoleteElementError
+        @element = nil
+      end
 
       unless @element
         raise UnknownObjectException, "unable to locate element, using #{selector_string}"

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -41,6 +41,26 @@ describe Watir::Element do
       button.click
       expect(element).to_not exist
     end
+
+    it "should determine if element constructed with webdriver element is stale" do
+      browser.goto WatirSpec.url_for('removed_element.html', :needs_server => true)
+      element = browser.div(:id => "text")
+      stale_element = browser.element(:element, element.wd)
+      browser.refresh
+      expect(stale_element).to_not exist
+    end
+
+    it "should determine if element getting looked up is stale" do
+      browser.goto WatirSpec.url_for('removed_element.html', :needs_server => true)
+      wd_element = browser.div(:id => "text").wd
+
+      allow(browser.driver).to receive(:find_element).with(:id, 'text') { wd_element }
+
+      browser.refresh
+      stale_element = browser.div(:id, 'text')
+      expect(stale_element).to_not exist
+    end
+
   end
 
   describe "#hover" do


### PR DESCRIPTION
We're intermittently getting this Selenium error when we check for the existence of an element that has gone stale. Expected behavior would be to return a false since the element does not actually exist.

This fix will raise the UnknownObjectException which is rescued to return false in the #exists? method.
