### PR TITLE
Rescues Frame Exception in element locate

### DIFF
--- a/lib/watir-webdriver/locators/element_locator.rb
+++ b/lib/watir-webdriver/locators/element_locator.rb
@@ -39,7 +39,7 @@ module Watir
       # It is also used to alter behavior of methods locating more than one type of element
       # (e.g. text_field locates both input and textarea)
       validate_element(element) if element
-    rescue Selenium::WebDriver::Error::NoSuchElementError, Selenium::WebDriver::Error::ObsoleteElementError
+    rescue Selenium::WebDriver::Error::NoSuchElementError, Selenium::WebDriver::Error::ObsoleteElementError, Watir::Exception::UnknownFrameException
       nil
     end
 


### PR DESCRIPTION
I've spent all day trying to recreate this for a spec. If the element itself goes stale, the test throws a StaleElementReferenceError (like it should). I have no idea how in my test the element isn't stale, but comes back as the element not being a frame, when you can see from the debug info I included that getElementTagName returns an iframe right before it tries to switch to it.

I'm also not sure this rescue is the right way to handle this, or if there is a bug somewhere deeper in the code, but this lets my test pass when I do a when_present call.

Stack Trace:

```
expected no Exception, got # {Watir::Exception::UnknownFrameException: no such frame: element is not a frame
  (Session info: chrome=37.0.2062.120)
  (Driver info: chromedriver=2.9.248304,platform=Linux 3.13.0-24-generic x86_64)} with backtrace:
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/elements/iframe.rb:167:in `rescue in switch!'
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/elements/iframe.rb:165:in `switch!'
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/elements/iframe.rb:157:in `method_missing'
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/locators/element_locator.rb:89:in `find_first_by_multiple'
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/locators/element_locator.rb:34:in `locate'
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/elements/element.rb:567:in `locate'
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/elements/element.rb:544:in `assert_exists'
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/elements/element.rb:44:in `exists?'
  # /home/titus/workspace/watir-webdriver/lib/watir-webdriver/elements/element.rb:431:in `present?'
```

This is the debug info I'm pulling from Selenium::WebDriver::Remote::Bridge#execute
Commands: _args 
Returned: raw_execute(_args)['value']

Commands: [:findElement, {}, {:using=>"id", :value=>"menuFrame"}]
Returned: {"ELEMENT"=>"0.6930554306600243-1"}
Commands: [:getElementTagName, {:id=>"0.6930554306600243-1"}]
Returned: iframe
Commands: [:getElementTagName, {:id=>"0.6930554306600243-1"}]
Returned: iframe
Commands: [:isElementDisplayed, {:id=>"0.6930554306600243-1"}]
Returned: true
Commands: [:switchToFrame, {}, {:id=>nil}]
Returned: 
Commands: [:findElement, {}, {:using=>"id", :value=>"menuFrame"}]
Returned: {"ELEMENT"=>"0.6930554306600243-1"}
Commands: [:getElementTagName, {:id=>"0.6930554306600243-1"}]
Returned: iframe
Commands: [:getElementTagName, {:id=>"0.6930554306600243-1"}]
Returned: iframe
Commands: [:switchToFrame, {}, {:id=>#<Selenium::WebDriver::Element:0x..f996a2be419902538 id="0.6930554306600243-1">}]
