### PR TITLE
Run checkers after form submission

### DIFF
--- a/lib/watir-webdriver/elements/form.rb
+++ b/lib/watir-webdriver/elements/form.rb
@@ -11,6 +11,7 @@ module Watir
     def submit
       assert_exists
       @element.submit
+      run_checkers
     end
 
   end # Form


### PR DESCRIPTION
No, we shouldn't be using this method, but if this is supported it should execute the checkers afterward.
