### PR TITLE
Error checkers

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -340,7 +340,26 @@ module Watir
     #
 
     def run_checkers
-      @error_checkers.each { |e| e.call(self) }
+      @error_checkers.each { |e| e.call(self) } if !@error_checkers.empty? && window.present?
+    end
+
+    #
+    # Executes a block without running error checkers.
+    #
+    # @example
+    #   browser.without_checkers do
+    #     browser.element(:name => "new_user_button").click
+    #   end
+    #
+    # @yieldparam [Watir::Browser]
+    #
+
+    def without_checkers
+      current_checkers = @error_checkers
+      @error_checkers = []
+      yield(self)
+    ensure
+      @error_checkers = current_checkers
     end
 
     #


### PR DESCRIPTION
This Pull Request relies on rewrite in https://github.com/watir/watir-webdriver/pull/282

Current behavior throws an exception if error checker makes a driver call on a window that has been closed
This code does not run error checkers if current window is closed

Current behavior throws an exception if error checker makes a driver call when an alert is present.
This code adds methods to interact with alert (via block) and close it before error checkers are run. This is also advantageous since accepting an alert can update the window, after which we should be running error checkers, anyway.
