### PR TITLE
rescue stale elements when selecting from select_list

### DIFF
--- a/lib/watir-webdriver/elements/select.rb
+++ b/lib/watir-webdriver/elements/select.rb
@@ -148,6 +148,8 @@ module Watir
       else
         begin
           e = @element.find_element(:xpath, xpath)
+        rescue Selenium::WebDriver::Error::ObsoleteElementError
+          raise UnknownObjectException, "unable to locate element, using #{selector_string}"
         rescue Selenium::WebDriver::Error::NoSuchElementError
           no_value_found(string)
         end


### PR DESCRIPTION
An element was going stale between the #assert_exists call in Select#select_by and the @element.find_element call in Select#select_by_string

I did a check of all driver.find_element calls, and everything else gets rescued in Element#locate which we addressed on the last pull request; so this should be the only other one we need.
