### PR TITLE
Remove duplicate check for id

### DIFF
--- a/lib/watir-webdriver/locators/element_locator.rb
+++ b/lib/watir-webdriver/locators/element_locator.rb
@@ -253,8 +253,6 @@ module Watir
       return if tag_name && !tag_name_matches?(element.tag_name.downcase, tag_name)
 
       element
-    rescue Selenium::WebDriver::Error::NoSuchElementError
-      nil
     end
 
     def all_elements


### PR DESCRIPTION
When would we get a NoSuchElementError when checking by id, and then find the element we check with xpath or css? The specs all seem to pass without this extra check.

The specific issue I'm seeing is a result of this Chrome bug - https://code.google.com/p/chromedriver/issues/detail?id=963

On the first lookup, our FramedDriver#switch! puts the driver in the context of the frame, and returns false
When the element is referenced with an id, it looks it up again. FramedDriver#switch! tries to move to the context of the frame it is already on, and Chrome incorrectly raises an UnknownError instead of a NoSuchFrameError.

You can see the failure with this watirspec (Chrome only):
        browser.goto(WatirSpec.url_for("iframes.html"))
        expect(browser.iframe.element(:id, "no_such_id")).to_not exist

The 2 possible workarounds I have are 
1) remove this code, which might be needed for something that I don't know about
2) rescue UnknownError in #switch! which is not desirable for reasons we've already discussed with other Chrome bug workaround options
