### PR TITLE
Make iframe#tag_name and frame#tag_name public

### DIFF
--- a/lib/watir-webdriver/elements/iframe.rb
+++ b/lib/watir-webdriver/elements/iframe.rb
@@ -43,8 +43,6 @@ module Watir
       browser.execute_script(*args)
     end
 
-    private
-
     def tag_name
       'iframe'
     end
@@ -66,8 +64,6 @@ module Watir
 
 
   class Frame < IFrame
-
-    private
 
     def tag_name
       'frame'


### PR DESCRIPTION
As noticed in a [StackOverflow question](http://stackoverflow.com/q/26968929/1200545), for Watir::IFrame and Watir::Frame objects the `tag_name` method is private:

``` ruby
browser.iframe.tag_name
#=> C:/Ruby193/lib/ruby/gems/1.9.1/gems/watir-webdriver-0.6.11/lib/watir-webdriver/elements/element.rb:580:in `method_missing': private method `tag_name' called for #<Watir::IFrame:0x2b45ba8> (NoMethodError)
#=>   from watir-webdriver.rb:16:in `<main>'

browser.frame.tag_name
#=> C:/Ruby193/lib/ruby/gems/1.9.1/gems/watir-webdriver-0.6.11/lib/watir-webdriver/elements/element.rb:580:in `method_missing': private method `tag_name' called for #<Watir::Frame:0x2c25de0> (NoMethodError)
#=>   from watir-webdriver.rb:17:in `<main>'
```

This seems inconsistent with other element types, which have the method as public:

``` ruby
browser.div.tag_name
#=> "div"
```

For consistency, it is proposed that the `tag_name` method be made public.
