### PR TITLE
rename tag_name for frames

### DIFF
--- a/lib/watir-webdriver/elements/iframe.rb
+++ b/lib/watir-webdriver/elements/iframe.rb
@@ -5,7 +5,7 @@ module Watir
     def locate
       @parent.assert_exists
 
-      locator = locator_class.new(@parent.wd, @selector.merge(:tag_name => tag_name), self.class.attribute_list)
+      locator = locator_class.new(@parent.wd, @selector.merge(:tag_name => frame_tag), self.class.attribute_list)
       element = locator.locate
       element or raise UnknownFrameException, "unable to locate #{@selector[:tag_name]} using #{selector_string}"
 
@@ -43,7 +43,9 @@ module Watir
       browser.execute_script(*args)
     end
 
-    def tag_name
+    private
+
+    def frame_tag
       'iframe'
     end
 
@@ -65,7 +67,9 @@ module Watir
 
   class Frame < IFrame
 
-    def tag_name
+    private
+
+    def frame_tag
       'frame'
     end
 


### PR DESCRIPTION
I don't believe #293 is the correct fix.

Frame#tag_name and IFrame#tag_name are only there to differentiate which :tag_name is merged into @selector in  IFrame#locator

Element#tag_name makes a wire call, and this hard codes a string result, and is not the desired consistent behavior.

The real issue is that the private #tag_name in the frame file overrides the public Element#tag_name and just needs to be renamed, not made public
