### PR TITLE
Loosen text_field type requirements

### DIFF
--- a/lib/watir-webdriver/locators/text_field_locator.rb
+++ b/lib/watir-webdriver/locators/text_field_locator.rb
@@ -1,7 +1,7 @@
 module Watir
   class TextFieldLocator < ElementLocator
 
-    NON_TEXT_TYPES     = %w[file radio checkbox submit reset image button hidden datetime date month week time datetime-local range color]
+    NON_TEXT_TYPES = %w[file radio checkbox submit reset image button hidden range color]
     # TODO: better way of finding input text fields?
     NEGATIVE_TYPE_EXPR = NON_TEXT_TYPES.map { |type| "%s!=%s" % [XpathSupport.downcase('@type'), type.inspect] }.join(' and ')
 


### PR DESCRIPTION
This fixes #295 and also allows to use `#text_field` for a bunch of other input types.

@jarib I'm not pushing this directly since there might be some reason for you to restrict the types. Feel free to merge otherwise.

Specs are in watir/watirspec#53
