### PR TITLE
strip out whitespaces

### DIFF
--- a/lib/watir-webdriver/alert.rb
+++ b/lib/watir-webdriver/alert.rb
@@ -21,7 +21,7 @@ module Watir
 
     def text
       assert_exists
-      @alert.text
+      @alert.text.strip
     end
 
     #

--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -170,7 +170,7 @@ module Watir
     #
 
     def text
-      @driver.find_element(:tag_name, "body").text
+      @driver.find_element(:tag_name, "body").text.strip
     end
 
     #

--- a/lib/watir-webdriver/elements/button.rb
+++ b/lib/watir-webdriver/elements/button.rb
@@ -29,9 +29,9 @@ module Watir
 
       case tn
       when 'input'
-        @element.attribute(:value)
+        @element.attribute(:value).strip
       when 'button'
-        @element.text
+        @element.text.strip
       else
         raise Exception::Error, "unknown tag name for button: #{tn}"
       end

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -84,7 +84,7 @@ module Watir
 
     def text
       assert_exists
-      @element.text
+      @element.text.strip
     end
 
     #

--- a/lib/watir-webdriver/elements/option.rb
+++ b/lib/watir-webdriver/elements/option.rb
@@ -73,9 +73,9 @@ module Watir
       attribute = [:label, :text].find { |a| attribute? a }
 
       if attribute
-        @element.attribute(attribute)
+        @element.attribute(attribute).strip
       else
-        @element.text
+        @element.text.strip
       end
     end
 


### PR DESCRIPTION
We've had some issues with whitespaces in some of our tests. If Watir is intended to represent what a user sees on a page, then it should not be an issue for the test framework to remove something they can't see.
