### PR TITLE
support for MS Edge browser

### DIFF
--- a/lib/watir-webdriver/attribute_helper.rb
+++ b/lib/watir-webdriver/attribute_helper.rb
@@ -74,7 +74,7 @@ module Watir
 
     def define_boolean_attribute(mname, aname)
       define_method mname do
-        attribute_value(aname) == "true"
+        attribute_value(aname) =~ /(t|T)rue/
       end
     end
 

--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -346,6 +346,10 @@ module Watir
         driver.switch_to.default_content
         true
       end
+    rescue Selenium::WebDriver::Error::NoSuchWindowError
+      raise unless driver.capabilities.browser_name == 'MicrosoftEdge'
+      driver.switch_to.window(driver.window_handle)
+      retry
     end
     alias_method :ensure_not_stale, :assert_exists
 

--- a/lib/watir-webdriver/elements/element.rb
+++ b/lib/watir-webdriver/elements/element.rb
@@ -125,6 +125,7 @@ module Watir
 
           action.perform
         else
+          @element.location_once_scrolled_into_view if driver.capabilities.browser_name == 'MicrosoftEdge'
           @element.click
         end
       end
@@ -270,6 +271,9 @@ module Watir
     def attribute_value(attribute_name)
       assert_exists
       element_call { @element.attribute attribute_name }
+    rescue Selenium::WebDriver::Error::UnknownError
+      return '' if browser.driver.capabilities.browser_name == 'MicrosoftEdge'
+      raise
     end
 
     #

--- a/lib/watir-webdriver/locators/element_locator.rb
+++ b/lib/watir-webdriver/locators/element_locator.rb
@@ -144,7 +144,13 @@ module Watir
 
       if rx_selector.key?(:label) && should_use_label_element?
         label = label_from_text(rx_selector.delete(:label)) || return
-        if (id = label.attribute(:for))
+        begin
+          id = label.attribute(:for)
+        rescue Selenium::WebDriver::Error::UnknownError
+          raise unless @wd.capabilities.browser_name == 'MicrosoftEdge'
+        end
+
+        if id
           selector[:id] = id
         else
           parent = label
@@ -201,7 +207,12 @@ module Watir
       when :href
         (href = element.attribute(:href)) && href.strip
       else
-        element.attribute(how.to_s.gsub("_", "-").to_sym)
+        begin
+          element.attribute(how.to_s.gsub("_", "-").to_sym)
+        rescue Selenium::WebDriver::Error::UnknownError
+          return nil if @wd.capabilities.browser_name == 'MicrosoftEdge'
+          raise
+        end
       end
     end
 


### PR DESCRIPTION
The biggest issue for Edge support is that the w3c protocol has unknown element values throwing an exception instead of returning nil. I'm not sure if we want to specify this as and edge-only implementation, or if there is anything wrong with always rescuing this call and returning nil.

The location_once_scrolled_into_view is admittedly a workaround for an Edge bug, but it affected many of the specs. Same with retrying when Edge lost contact of the top level browsing context. This latter might not be a bug depending on how you read the w3c spec, but it is hard to say.

Anyway, I want to be able to release this next version with "edge support," but I'm not sure how accommodating we want to be to their current bugs. Maybe we have a separate class that they could be imported only if they are using Edge that overwrites existing classes with Edge specific adjustments?

I've filed 13 bugs with the Edge project so far, so hopefully these things get fixed/improved soon.
