### PR TITLE
Fix random failures on Travis

### DIFF
--- a/lib/watir-webdriver/browser.rb
+++ b/lib/watir-webdriver/browser.rb
@@ -65,7 +65,7 @@ module Watir
     # Goes to the given URL.
     #
     # @example
-    #   browser.goto "www.watir.com"
+    #   browser.goto "github.com/watir/watir"
     #
     # @param [String] uri The url.
     # @return [String] The url you end up at.
@@ -100,9 +100,9 @@ module Watir
     # Returns URL of current page.
     #
     # @example
-    #   browser.goto "www.watir.com"
+    #   browser.goto "github.com/watir/watir"
     #   browser.url
-    #   #=> "http://watir.com/"
+    #   #=> "https://github.com/watir/watir"
     #
     # @return [String]
     #
@@ -116,9 +116,9 @@ module Watir
     # Returns title of current page.
     #
     # @example
-    #   browser.goto "www.watir.com"
+    #   browser.goto "github.com/watir/watir"
     #   browser.title
-    #   #=> "Watir.com | Web Application Testing in Ruby"
+    #   #=> "watir/watir · GitHub"
     #
     # @return [String]
     #

--- a/support/travis.sh
+++ b/support/travis.sh
@@ -6,19 +6,19 @@ set -x
 sh -e /etc/init.d/xvfb start
 git submodule update --init
 
-mkdir ~/.yard
-bundle exec yard config -a autoload_plugins yard-doctest
+if [[ "$RAKE_TASK" = "yard:doctest" ]]; then
+  mkdir ~/.yard
+  bundle exec yard config -a autoload_plugins yard-doctest
+fi
 
 if [[ "$RAKE_TASK" = "spec:chrome" ]]; then
-  export CHROME_REVISION=`curl -s http://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/LAST_CHANGE`
-  export CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
-
+  CHROME_REVISION=`curl -s http://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/LAST_CHANGE`
   curl -L -O "http://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/${CHROME_REVISION}/chrome-linux.zip"
   unzip chrome-linux.zip
 
+  CHROMEDRIVER_VERSION=`curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
   curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
   unzip chromedriver_linux64.zip
-
   mv chromedriver chrome-linux/chromedriver
   chmod +x chrome-linux/chromedriver
 fi


### PR DESCRIPTION
This pull requests changes watir-webdriver documentation to use Github instead of Watir.com because the latter might be slow/inaccessible which causes doctests failures on Travis.

I'm also trying to debug random failure of window switching spec for Chrome that happen on Travis, but no luck so far. @titusfortner If you could take a look, that'd be great.
