### PR TITLE
Added methods to wait for page load

### DIFF
--- a/lib/watir-webdriver/wait.rb
+++ b/lib/watir-webdriver/wait.rb
@@ -148,7 +148,7 @@ module Watir
         #angular not used in the application, continue as normal
       end
     end
-    
+
 
     #
     # Make calls to the browser waiting for ajax to complete

--- a/lib/watir-webdriver/wait.rb
+++ b/lib/watir-webdriver/wait.rb
@@ -139,15 +139,16 @@ module Watir
       begin
         browser.execute_script("angular.element(#{angular_element}).scope().pageFinishedRendering = false")
         browser.execute_script("angular.getTestability(#{angular_element}).whenStable(function(){angular.element(#{angular_element}).scope().pageFinishedRendering = true})")
+        Watir::Wait.until(timeout, "waiting for angular to render") {
+          browser.execute_script("return angular.element(#{angular_element}).scope().pageFinishedRendering")
+        }
+      rescue Selenium::WebDriver::Error::InvalidElementStateError
+        #no ng-app found on page, continue as normal
+      rescue Selenium::WebDriver::Error::JavascriptError
+        #angular not used in the application, continue as normal
       end
-      Watir::Wait.until(timeout, "waiting for angular to render") {
-        browser.execute_script("return angular.element(#{angular_element}).scope().pageFinishedRendering")
-      }
-    rescue Selenium::WebDriver::Error::InvalidElementStateError
-      #no ng-app found on page, continue as normal
-    rescue Selenium::WebDriver::Error::JavascriptError
-      #angular not used in the application, continue as normal
     end
+    
 
     #
     # Make calls to the browser waiting for ajax to complete


### PR DESCRIPTION
Added methods to be used in conjunction with after_hooks to wait for browser rendering to complete.

They are:
wait_for_page_load
wait_for_angular_completion
wait_for_ajax_completion

and the associated code to go along with them.
