### PR TITLE
Issue 434

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -126,31 +126,36 @@ namespace :spec do
   require 'selenium-webdriver'
 
   desc 'Run specs in all browsers'
-  task all_browsers: [:chrome,
-                      :firefox,
-                      :phantomjs,
-                      :remote_chrome,
-                      :remote_firefox,
-                      :remote_phantomjs,
-                      (:safari if Selenium::WebDriver::Platform.os == :macosx),
-                      (:remote_safari if Selenium::WebDriver::Platform.os == :macosx),
-                      (:ie if Selenium::WebDriver::Platform.os == :windows),
-                      (:remote_ie if Selenium::WebDriver::Platform.os == :windows),
-                      (:edge if Selenium::WebDriver::Platform.os == :windows),
-                      (:remote_edge if Selenium::WebDriver::Platform.os == :windows)].compact
+  task all_browsers: [:browsers, :remote_browsers]
+
+  desc 'Run specs locally for all browsers'
+  task browsers: [:chrome,
+                  :firefox,
+                  :phantomjs,
+                  (:safari if Selenium::WebDriver::Platform.os == :macosx),
+                  (:ie if Selenium::WebDriver::Platform.os == :windows),
+                  (:edge if Selenium::WebDriver::Platform.os == :windows)].compact
+
+  desc 'Run specs remotely for all browsers'
+  task remote_browsers: [:remote_chrome,
+             :remote_firefox,
+             :remote_phantomjs,
+             (:remote_safari if Selenium::WebDriver::Platform.os == :macosx),
+             (:remote_ie if Selenium::WebDriver::Platform.os == :windows),
+             (:remote_edge if Selenium::WebDriver::Platform.os == :windows)].compact
 
   %w(firefox marionette chrome safari phantomjs ie edge).each do |browser|
     desc "Run specs in #{browser}"
     task browser do
       ENV['WATIR_WEBDRIVER_BROWSER'] = browser
-      Rake::Task['spec'].execute
+      Rake::Task[:spec].execute
     end
 
     desc "Run specs in Remote #{browser}"
     task "remote_#{browser}" do
       ENV['WATIR_WEBDRIVER_BROWSER'] = 'remote'
       ENV['REMOTE_BROWSER'] =  browser
-      Rake::Task['spec'].execute
+      Rake::Task[:spec].execute
     end
   end
 end

--- a/lib/watir-webdriver/locators/text_field/locator.rb
+++ b/lib/watir-webdriver/locators/text_field/locator.rb
@@ -32,7 +32,9 @@ module Watir
           element = super
 
           if element && !Watir::TextField::NON_TEXT_TYPES.include?(element.attribute(:type))
-            warn "Locating textareas with '#text_field' is deprecated. Please, use '#textarea' method instead."
+            if element.tag_name.downcase == 'textarea'
+              warn "Locating textareas with '#text_field' is deprecated. Please, use '#textarea' method instead."
+            end
             element
           end
         end

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -69,7 +69,6 @@ describe Watir::Locators::Element::Locator do
       end
     end
 
-
     describe "with special cased selectors" do
       it "normalizes space for :text" do
         expect_one :xpath, ".//div[normalize-space()='foo']"

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -114,4 +114,21 @@ describe Watir::Element do
       end
     end
   end
+
+  # TODO - Can remove when decide issue #295
+  describe "warnings" do
+    it "does not return a warning if using text_field for an unspecified text input" do
+       browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+      expect do
+       browser.text_field(id: "new_user_first_name").exists?
+      end.to_not output.to_stderr
+    end
+
+    it "returns a warning if using text_field for textarea" do
+      browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+      expect do
+        browser.text_field(id: "create_user_comment").exists?
+      end.to output.to_stderr
+    end
+  end
 end

--- a/spec/implementation.rb
+++ b/spec/implementation.rb
@@ -21,10 +21,10 @@ class ImplementationConfig
     require 'selenium/server'
 
     @server ||= Selenium::Server.new(remote_server_jar,
-                                     :port       => Selenium::WebDriver::PortProber.above(4444),
-                                     :log        => !!$DEBUG,
-                                     :background => true,
-                                     :timeout    => 60)
+                                     port: Selenium::WebDriver::PortProber.above(4444),
+                                     log: !!$DEBUG,
+                                     background: true,
+                                     timeout: 60)
 
     @server.start
     at_exit { @server.stop }
@@ -50,23 +50,21 @@ class ImplementationConfig
 
   def set_browser_args
     args = case browser
-           when :firefox
-             firefox_args
            when :chrome
              chrome_args
            when :remote
              remote_args
            else
-             [browser, {}]
+             {}
            end
 
     if ENV['SELECTOR_STATS']
       listener = SelectorListener.new
-      args.last.merge!(listener: listener)
+      args.merge!(listener: listener)
       at_exit { listener.report }
     end
 
-    @imp.browser_args = args
+    @imp.browser_args = [browser, args]
   end
 
   def mobile?
@@ -124,14 +122,8 @@ class ImplementationConfig
     browser_instance.close if browser_instance
   end
 
-  def firefox_args
-    [:firefox, {}]
-  end
-
   def chrome_args
-    opts = {
-      args: ["--disable-translate"]
-    }
+    opts = {args: ["--disable-translate"]}
 
     if url = ENV['WATIR_WEBDRIVER_CHROME_SERVER']
       opts[:url] = url
@@ -149,14 +141,14 @@ class ImplementationConfig
       opts[:args] << "--no-sandbox" # https://github.com/travis-ci/travis-ci/issues/938
     end
 
-    [:chrome, opts]
+    opts
   end
 
   def remote_args
     url = ENV["REMOTE_SERVER_URL"] || "http://127.0.0.1:#{@server.port}/wd/hub"
     remote_browser_name = ENV['REMOTE_BROWSER'].to_sym
-    caps =  Selenium::WebDriver::Remote::Capabilities.send(remote_browser_name)
-    [:remote, {url: url, desired_capabilities: caps}]
+    caps = Selenium::WebDriver::Remote::Capabilities.send(remote_browser_name)
+    {url: url, desired_capabilities: caps}
   end
 
   def add_html_routes

--- a/spec/implementation.rb
+++ b/spec/implementation.rb
@@ -146,8 +146,7 @@ class ImplementationConfig
 
   def remote_args
     url = ENV["REMOTE_SERVER_URL"] || "http://127.0.0.1:#{@server.port}/wd/hub"
-    remote_browser_name = ENV['REMOTE_BROWSER'].to_sym
-    caps = Selenium::WebDriver::Remote::Capabilities.send(remote_browser_name)
+    caps = Selenium::WebDriver::Remote::Capabilities.send(remote_browser)
     {url: url, desired_capabilities: caps}
   end
 

--- a/watir-webdriver.gemspec
+++ b/watir-webdriver.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "selenium-webdriver", ">= 2.46.2"
 
-  s.add_development_dependency "rspec", "~> 2.6"
+  s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "yard", "> 0.8.2.1"
   s.add_development_dependency "webidl", ">= 0.1.5"
   s.add_development_dependency "sinatra", "~> 1.0"


### PR DESCRIPTION
@p0deje - Is there a reason we didn't switch to rspec > 3.0? This PR implements a couple specs that requires features in 3.0. Everything (except yardoc) is passing on Travis. Just wanted to double check before merging this.

(This code addresses #434)
