### PR TITLE
Nested text nodes

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -465,17 +465,17 @@ module Watir
 
       if tag_name == "input"
         klass = case elem.attribute(:type)
-          when *Button::VALID_TYPES
-            Button
-          when 'checkbox'
-            CheckBox
-          when 'radio'
-            Radio
-          when 'file'
-            FileField
-          else
-            TextField
-          end
+                when *Button::VALID_TYPES
+                  Button
+                when 'checkbox'
+                  CheckBox
+                when 'radio'
+                  Radio
+                when 'file'
+                  FileField
+                else
+                  TextField
+                end
       else
         klass = Watir.element_class_for(tag_name)
       end
@@ -548,10 +548,18 @@ module Watir
       selector_builder = selector_builder_class.new(@parent, @selector, self.class.attribute_list)
       locator = locator_class.new(@parent, @selector, selector_builder, element_validator)
 
-      locator.locate
+      located = locator.locate
+
+      @selector.key?(:text) ? locate_nested_text_node(located) : located
     end
 
     private
+
+    def locate_nested_text_node(located_parent)
+      return nil unless located_parent
+      sub_parent = self.class.new(@parent, element: located_parent)
+      self.class.new(sub_parent, @selector).locate || located_parent
+    end
 
     def locator_class
       Kernel.const_get("#{Watir.locator_namespace}::#{element_class_name}::Locator")

--- a/spec/click_spec.rb
+++ b/spec/click_spec.rb
@@ -7,13 +7,16 @@ describe Watir::Element do
     }
 
     let(:clicker) { browser.element(id: "click-logger") }
-    let(:log)     { browser.element(id: "log").ps.map { |e| e.text } }
+    let(:log) { browser.element(id: "log").ps.map { |e| e.text } }
 
-    bug "https://github.com/watir/watir/issues/343", :webdriver do
-      it "clicks an element with text in nested text node using text selector" do
-        browser.element(text: "Can You Click This?").click
-        expect(browser.element(text: "You Clicked It!")).to exist
-      end
+    it "clicks an element with regex in nested text node using text selector" do
+      browser.div(text: /Can You Click/).click
+      expect(browser.div(text: "You Clicked It!")).to exist
+    end
+
+    it "clicks an element with string in nested text node using text selector" do
+      browser.element(text: "Can You Click This?").click
+      expect(browser.element(text: "You Clicked It!")).to exist
     end
   end
 end


### PR DESCRIPTION
I was thinking about this guy when [discussing it on stackoverflow](http://stackoverflow.com/questions/39027914/does-watir-webdriver-have-a-wildcard-tag/39028316#39028316)

This is my proposed solution for: #343 

Instead of returning the first text node that matches the text, this code takes that element and iteratively finds the first child until no more matching child is present.
1. This much more closely follows the Principle of Least Astonishment
2. for `text: String` when the nested element is hidden (and the text is not actually displayed on the page), it will now always locate the element, but correctly return false for `#present?`
3. for `text: Regexp` when `#can_convert_regexp_to_contains?` is true, the same behavior as string 
4. for `text: Regexp` otherwise, it will still not even locate an element with text in the DOM that is not visible on the page (so this PR does not solve #342, the fix for which is in #447)
5. This PR now allows access to specific nested child elements without relying on xpath(see [this failing spec](https://github.com/titusfortner/watir-webdriver/blob/master/spec/click_spec.rb#L13-L16) that now passes). 
6. Currently `browser.element(text: /foo/)` returns the html element if the text exists on the page. After this PR it should return the element expected, though it could be significantly non-performant. I thought about adding a warning to that effect, but if someone wants something slow that's up to them to determine and at least it will work after this PR.
7. Note: this is not backward compatible, but I would not expect this to be a significant issue.
