### PR TITLE
shouldn't have to assume element is present when waiting for enabled

### DIFF
--- a/lib/watir/wait.rb
+++ b/lib/watir/wait.rb
@@ -201,7 +201,7 @@ module Watir
       message = "waiting for #{selector_string} to become enabled"
 
       if block_given?
-        Watir::Wait.until(timeout, message) { enabled? }
+        Watir::Wait.until(timeout, message) { present? && enabled? }
         yield self
       else
         WhenEnabledDecorator.new(self, timeout, message)


### PR DESCRIPTION
@Rodney-QAGeek - was there a reason this wasn't included in your original PR?
I've found a few places where I needed to nest them, which I think should be default? `when_present.when_enabled`
