### PR TITLE
implement :children locator to restrict search for child element(s)

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -128,6 +128,10 @@ module Watir
 
           if selector.key? :index
             raise ArgumentError, "can't locate all elements by :index"
+          elsif selector.key?(:children) && (selector.key?(:xpath) || selector.has_key?(:css))
+            raise ArgumentError, "can't combine :children with either :xpath or :css"
+          elsif selector.delete(:children)
+            selector.merge!(xpath: "./#{selector.delete(:tag_name) || '*'}")
           end
 
           how, what = selector_builder.build(selector)

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -33,6 +33,10 @@ module Watir
             unless what.is_a?(Fixnum)
               raise TypeError, "expected Fixnum, got #{what.inspect}:#{what.class}"
             end
+          when :children
+            unless what.kind_of?(TrueClass) || what.kind_of?(FalseClass)
+              raise TypeError, "expected true or false, got #{what.inspect}:#{what.class}"
+            end
           else
             unless VALID_WHATS.any? { |t| what.is_a? t }
               raise TypeError, "expected one of #{VALID_WHATS.inspect}, got #{what.inspect}:#{what.class}"
@@ -56,7 +60,7 @@ module Watir
 
         def normalize_selector(how, what)
           case how
-          when :tag_name, :text, :xpath, :index, :class, :label, :css
+          when :tag_name, :text, :xpath, :index, :class, :label, :css, :children
             # include :class since the valid attribute is 'class_name'
             # include :for since the valid attribute is 'html_for'
             [how, what]

--- a/lib/watir/locators/element/selector_builder/css.rb
+++ b/lib/watir/locators/element/selector_builder/css.rb
@@ -40,7 +40,7 @@ module Watir
           def use_css?(selectors)
             return false unless Watir.prefer_css?
 
-            if selectors.key?(:text) || selectors.key?(:label) || selectors.key?(:index)
+            if %i(text label index children).any? { |how| selectors.key?(how) }
               return false
             end
 

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -415,6 +415,28 @@ describe Watir::Locators::Element::Locator do
                     :dir     , "foo",
                     :title   , 'bar']
       end
+
+      it "handles selector with children" do
+        expect_all :xpath, './*'
+        locate_all children: true
+      end
+      it "handles selector with tag name and children" do
+        expect_all :xpath, './div'
+        locate_all tag_name: "div",
+                   children: true
+      end
+      it "raises exception when combining children with anything" do
+        expect { locate_all children: true,
+                            dir: "foo" }.to raise_error(ArgumentError)
+      end
+      it "raises exception when combining children and xpath" do
+        expect { locate_all children: true,
+                            xpath: ".//*" }.to raise_error(ArgumentError)
+      end
+      it "raises exception when combining children and css" do
+        expect { locate_all children: true,
+                            css: "*" }.to raise_error(ArgumentError)
+      end
     end
 
     describe "with regexp selectors" do


### PR DESCRIPTION
This implements #329 
Removes the need for XPath to find direct child elements, and provides functionality that is the opposite of `#parent` method.

Demand for this feature comes from both [natontesting.com article](https://web.archive.org/web/20120823010857/http://www.natontesting.com/2009/08/19/how-to-get-only-direct-child-objects-in-watir) and @alexhanh
