### PR TITLE
better selector_string

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -551,6 +551,14 @@ module Watir
       locator.locate
     end
 
+    def selector_string
+      if @parent.is_a?(Browser)
+        @selector.inspect
+      else
+        "#{parent.selector_string} --> #{@selector.inspect}"
+      end
+    end
+
     private
 
     def locator_class
@@ -573,10 +581,6 @@ module Watir
 
     def element_class_name
       self.class.name.split('::').last
-    end
-
-    def selector_string
-      @selector.inspect
     end
 
     # Ensure the driver is in the desired browser context

--- a/lib/watir/elements/text_field.rb
+++ b/lib/watir/elements/text_field.rb
@@ -7,13 +7,18 @@ module Watir
     inherit_attributes_from Watir::TextArea
     remove_method :type # we want Input#type here, which was overriden by TextArea's attributes
 
-    private
+    protected
 
     def selector_string
       selector = @selector.dup
       selector[:type] = '(any text type)'
       selector[:tag_name] = "input or textarea"
-      selector.inspect
+
+      if @parent.is_a? Browser
+        selector.inspect
+      else
+        "#{parent.selector_string} --> #{selector.inspect}"
+      end
     end
   end # TextField
 


### PR DESCRIPTION
# selector_string is used in error messages, so it is useful to have the full nested value returned, instead of just the single most nested selector.
