### PR TITLE
Wait metaprogrammed

### DIFF
--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -1,7 +1,7 @@
 module Watir
   class Alert
 
-    include EventuallyPresent
+    include ConditionalWaits
 
     def initialize(browser)
       @browser = browser

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -630,6 +630,14 @@ module Watir
       method = meth.to_s
       if method =~ Locators::Element::SelectorBuilder::WILDCARD_ATTRIBUTE
         attribute_value(method.tr('_', '-'), *args)
+      elsif method =~ /^(\w+)_and_(\w+)\?$/
+        if !self.respond_to? "#{$1}?"
+          raise NoMethodError, "undefined method `#{$1}' for #{@element.inspect}:#{@element.class}"
+        elsif !self.respond_to? "#{$2}?"
+          raise NoMethodError, "undefined method `#{$2}' for #{@element.inspect}:#{@element.class}"
+        else
+          self.send("#{$1}?") && self.send("#{$2}?")
+        end
       else
         super
       end

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -9,7 +9,7 @@ module Watir
 
     include Exception
     include Container
-    include EventuallyPresent
+    include ConditionalWaits
 
     #
     # temporarily add :id and :class_name manually since they're no longer specified in the HTML spec.

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -1,6 +1,6 @@
 module Watir
   class Window
-    include EventuallyPresent
+    include ConditionalWaits
 
     def initialize(driver, selector)
       @driver = driver
@@ -202,7 +202,7 @@ module Watir
 
     private
 
-    # Referenced in EventuallyPresent
+    # Referenced in ConditionalWaits
     def selector_string
       @selector.inspect
     end


### PR DESCRIPTION
So this would need documentation and probably some more tests around the edge cases, but this is what I was talking about in our meeting last night as far as supporting `wait_until_*`, `wait_while_*` and `when_*` for the available predicate methods to address #458. 

The first commit passes existing specs just fine with :define_method
The second commit supports dynamic `wait_until_*_and_*` methods with :method_missing
This might be way overkill if the only real use case we have is `present_and_enabled?`

@p0deje - does this look worth pursuing? Or is this down the wrong track?
