### PR TITLE
remove non-supported methods from Image

### DIFF
--- a/lib/watir/elements/image.rb
+++ b/lib/watir/elements/image.rb
@@ -27,32 +27,6 @@ module Watir
       driver.execute_script "return arguments[0].width", @element
     end
 
-    #
-    # Returns the image's height in pixels.
-    #
-    # @return [Fixnum] width
-    #
-
-    def height
-      assert_exists
-      driver.execute_script "return arguments[0].height", @element
-    end
-
-    def file_created_date
-      assert_exists
-      raise NotImplementedError, "not currently supported by Selenium"
-    end
-
-    def file_size
-      assert_exists
-      raise NotImplementedError, "not currently supported by Selenium"
-    end
-
-    def save(path)
-      assert_exists
-      raise NotImplementedError, "not currently supported by Selenium"
-    end
-
   end # Image
 
   module Container


### PR DESCRIPTION
As referenced in #446

I think these were implemented in watir-classic, and shouldn't need to stay in the project with exceptions. Goes along with: https://github.com/watir/watirspec/pull/89
