### PR TITLE
implement visible filter

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -93,19 +93,27 @@ module Watir
           selector = selector_builder.normalized_selector
 
           idx = selector.delete(:index)
+          visible = selector.delete(:visible)
+
           how, what = selector_builder.build(selector)
 
           if how
             # could build xpath/css for selector
-            if idx
-              @query_scope.wd.find_elements(how, what)[idx]
+            if idx || !visible.nil?
+              idx ||= 0
+              elements = @query_scope.wd.find_elements(how, what)
+              elements = elements.select { |el| visible == el.displayed? } unless visible.nil?
+              elements[idx] unless elements.nil?
             else
               @query_scope.wd.find_element(how, what)
             end
           else
             # can't use xpath, probably a regexp in there
-            if idx
-              wd_find_by_regexp_selector(selector, :select)[idx]
+            if idx || !visible.nil?
+              idx ||= 0
+              elements = wd_find_by_regexp_selector(selector, :select)
+              elements = elements.select { |el| visible == el.displayed? } unless visible.nil?
+              elements[idx] unless elements.nil?
             else
               wd_find_by_regexp_selector(selector, :find)
             end

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -30,6 +30,10 @@ module Watir
             unless what.is_a?(Fixnum)
               raise TypeError, "expected Fixnum, got #{what.inspect}:#{what.class}"
             end
+          when :visible
+            unless what.is_a?(TrueClass) || what.is_a?(FalseClass)
+              raise TypeError, "expected TrueClass or FalseClass, got #{what.inspect}:#{what.class}"
+            end
           else
             unless VALID_WHATS.any? { |t| what.is_a? t }
               raise TypeError, "expected one of #{VALID_WHATS.inspect}, got #{what.inspect}:#{what.class}"
@@ -53,7 +57,7 @@ module Watir
 
         def normalize_selector(how, what)
           case how
-          when :tag_name, :text, :xpath, :index, :class, :label, :css
+          when :tag_name, :text, :xpath, :index, :class, :label, :css, :visible
             # include :class since the valid attribute is 'class_name'
             # include :for since the valid attribute is 'html_for'
             [how, what]


### PR DESCRIPTION
I was going to call this :hidden, but I see that Capybara implements this as :visible, which makes more sense.

This comes up as more and more sites implement as Single Page Apps. For instance there might be a single login page that has modals for both signing in and signing up. They share the same classes and names for elements in the form, but one is visible and the other is hidden. Sometimes it is easy to grab an id from the form or the top element of a modal and do something like:

``` ruby
modal = browser.div(id: "sign-in-modal")
username = modal.text_field(name: "username")
```

Sometimes it is not easy. This would be easier than using indexes, and would allow you to use the same page object (versus subclassing) for both of these when the names of the fields and the actions for each are the same.

Also, I can't figure out how to get the mocks to work in the `element_locator_spec` with this updated implementation, so I'm going to need help with that. :)

The specs need html elements found here: https://github.com/watir/watirspec/pull/91
