### PR TITLE
auto re-look up element collections plus update how @element stored

### DIFF
--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -311,11 +311,6 @@ module Watir
         true
       end
     end
-    alias_method :ensure_not_stale, :assert_exists
-
-    def reset!
-      # no-op
-    end
 
     def browser
       self

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -81,7 +81,9 @@ module Watir
 
     def to_a
       # TODO: optimize - lazy element_class instance?
-      @to_a ||= elements.map { |e| element_class.new(@query_scope, element: e) }
+      @to_a ||= elements.map.with_index do |e, idx|
+        element_class.new(@query_scope, @selector.merge(element: e, index: idx))
+      end
     end
 
     private

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -2,6 +2,7 @@ module Watir
   class IFrame < HTMLElement
 
     def locate
+      return if @selector.empty?
       @query_scope.assert_exists
 
       selector = @selector.merge(tag_name: frame_tag)
@@ -13,6 +14,11 @@ module Watir
       element or raise UnknownFrameException, "unable to locate #{@selector[:tag_name]} using #{selector_string}"
 
       FramedDriver.new(element, driver)
+    end
+
+    def ==(other)
+      return false unless other.is_a?(self.class)
+      wd == other.wd.is_a?(FramedDriver) ? other.wd.send(:wd) : other.wd
     end
 
     def switch_to!
@@ -62,28 +68,6 @@ module Watir
 
 
   class IFrameCollection < ElementCollection
-
-    def to_a
-      # In case `#all_elements` returns empty array, but `#elements`
-      # returns non-empty array (i.e. any frame has loaded between these two calls),
-      # index will return nil. That's why `#all_elements` should always
-      # be called after `#elements.`
-      element_indexes = elements.map { |el| all_elements.index(el) }
-      element_indexes.map { |idx| element_class.new(@query_scope, tag_name: @selector[:tag_name], index: idx) }
-    end
-
-    private
-
-    def all_elements
-      selector = { tag_name: @selector[:tag_name] }
-
-      element_validator = element_validator_class.new
-      selector_builder = selector_builder_class.new(@query_scope, selector, element_class.attribute_list)
-      locator = locator_class.new(@query_scope, selector, selector_builder, element_validator)
-
-      locator.locate_all
-    end
-
   end # IFrameCollection
 
 

--- a/lib/watir/elements/row.rb
+++ b/lib/watir/elements/row.rb
@@ -8,10 +8,10 @@ module Watir
   end # Row
 
   class RowCollection < TableRowCollection
-    def elements
+    def to_a
       # we do this craziness since the xpath used will find direct child rows
       # before any rows inside thead/tbody/tfoot...
-      super.sort_by { |e| e.attribute(:rowIndex).to_i }
+      super.sort_by { |e| e.attribute_value(:rowIndex).to_i }
     end
   end
 end # Watir

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -49,32 +49,18 @@ describe Watir::Element do
     end
   end
 
-  describe "#reset!" do
-    it "successfully relocates collection elements after a reset!" do
-      browser.goto(WatirSpec.url_for("wait.html"))
-      element = browser.div(id: 'foo')
-      expect(element).to exist
-      browser.refresh
-      browser.div(id: 'foo').wait_until_present
-
-      expect(element.exist?).to be false unless Watir.always_locate?
-      element.send :reset!
-      expect(element).to exist
-    end
-  end
-
   describe "#exists?" do
     before do
       browser.goto WatirSpec.url_for('removed_element.html')
     end
 
-    it "returns false when an element from a collection becomes stale" do
+    it "relocates element from a collection when it becomes stale" do
       watir_element = browser.divs(id: "text").first
       expect(watir_element).to exist
 
       browser.refresh
 
-      expect(watir_element).to_not exist
+      expect(watir_element).to exist
     end
 
     it "returns false when tag name does not match id" do
@@ -146,7 +132,7 @@ describe Watir::Element do
       browser.goto(WatirSpec.url_for("wait.html"))
       delegator = browser.divs.last.when_present
       message = delegator.instance_variable_get('@message')
-      expect(message).to match /waiting for {:element=>#<Selenium::WebDriver::Element:0x\S+ id=\S+>} to become present/
+      expect(message).to match /waiting for {:tag_name=>\"div\", :index=>3} to become present/
     end
 
     it "displays selector string for nested element" do


### PR DESCRIPTION
Now that we've gotten rid of `#always_locate`, there are more `@element` variable issues that can be addressed. 

This is one of the most common confusions (many Stack Overflow questions, etc) with Watir - being unable to iterate over a collection when the DOM changes.

The user gets a very helpful message such as:

```
Watir::Exception::UnknownObjectException: unable to locate element, using {:element=>#<Selenium::WebDriver::Element:0x2836d06ee67909a id="0.18715359551127864-1">}
```

This is how IFrameCollection works right now:

```
frames = browser.frames
frame = frames.first
browser.refresh
frame.exists? # => true
```

vs ElementCollection:

```
elements = browser.elements
element = elements.first
browser.refresh
element.exists? # => false
```

I was very proud of fixing some issues with that frames implementation a year and a half ago, but now I realize it was sloppy, and this PR fixes it by using better logic for both frames and elements.

This is completely backward compatible because the new behavior is only replacing what would have previously raised an exception.

The biggest concern with this approach is if you actually change pages unintentionally or the list you are iterating over is dynamic and the collection if re-looked up would be completely different. In either case, the user might access an element that isn't the one they expect.

If we think this is a significant issue I have a few ideas for things we could do. That being said, I think this is an improvement on what we have currently.
