### PR TITLE
Wait in the Watir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 rvm:
-  - 2.1
-  - 2.2
+  - 2.1.9
+  - 2.2.5
   - 2.3.1
 addons:
   firefox: latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ before_script:
 script: bundle exec rake $RAKE_TASK
 env:
   - RAKE_TASK=spec:firefox
+  - RAKE_TASK=spec:firefox RELAXED_LOCATE=false
   - RAKE_TASK=spec:chrome
+  - RAKE_TASK=spec:chrome RELAXED_LOCATE=false
   - RAKE_TASK=spec:phantomjs
+  - RAKE_TASK=spec:phantomjs RELAXED_LOCATE=false
   - RAKE_TASK=yard:doctest

--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -16,11 +16,12 @@ require 'watir/after_hooks'
 
 module Watir
 
-  attr_writer :relaxed_locate, :always_locate, :default_timeout, :prefer_css, :locator_namespace
-
   @relaxed_locate = true
 
   class << self
+
+    attr_writer :relaxed_locate, :always_locate, :default_timeout, :prefer_css, :locator_namespace
+
     #
     # Whether or not Watir should wait for an element to be found or present
     # before taking an action.

--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -45,7 +45,7 @@ module Watir
       warn <<-EOS
 Watir#always_locate is deprecated; elements are always cached and will always
 be re-located if they go stale before use.
-Use Element#stale? or Element#wait_until_stale if needed for flow control.
+Use Element#stale? or Element#wait_until(&:stale?) if needed for flow control.
       EOS
     end
 

--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -14,8 +14,20 @@ require 'watir/screenshot'
 require 'watir/after_hooks'
 
 module Watir
+  @relaxed_locate = true
+
+  attr_writer :relaxed_locate, :always_locate, :default_timeout, :prefer_css, :locator_namespace
 
   class << self
+    #
+    # Whether or not Watir should wait for an element to be found or present
+    # before taking an action.
+    # Defaults to true.
+    #
+
+    def relaxed_locate?
+      @relaxed_locate
+    end
 
     #
     # Whether or not Watir should re-locate a stale Element on use.
@@ -58,6 +70,10 @@ as Selenium locators will be translated to XPath. To continue using CSS Selector
 require the watir_css gem - https://github.com/watir/watir_css
       EOS
     end
+
+    #
+    # Default wait time for wait methods.
+    #
 
     def default_timeout
       @default_timeout ||= 30

--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -1,5 +1,6 @@
 require 'selenium-webdriver'
 
+require 'watir/legacy_wait'
 require 'watir/wait'
 require 'watir/exception'
 require 'watir/xpath_support'
@@ -14,9 +15,10 @@ require 'watir/screenshot'
 require 'watir/after_hooks'
 
 module Watir
-  @relaxed_locate = true
 
   attr_writer :relaxed_locate, :always_locate, :default_timeout, :prefer_css, :locator_namespace
+
+  @relaxed_locate = true
 
   class << self
     #
@@ -38,10 +40,6 @@ module Watir
       true
     end
 
-    def always_locate=(_bool)
-      always_locate_message
-    end
-
     def always_locate_message
       warn <<-EOS
 Watir#always_locate is deprecated; elements are always cached and will always
@@ -57,10 +55,6 @@ Use Element#stale? or Element#wait_until_stale if needed for flow control.
     def prefer_css?
       prefer_css_message
       false
-    end
-
-    def prefer_css=(_bool)
-      prefer_css_message
     end
 
     def prefer_css_message
@@ -80,24 +74,12 @@ require the watir_css gem - https://github.com/watir/watir_css
     end
 
     #
-    # Default wait time for wait methods.
-    #
-
-    def default_timeout=(value)
-      @default_timeout = value
-    end
-
-    def locator_namespace
-      @locator_namespace ||= Watir::Locators
-    end
-
-    #
     # Whether the locators should be used from a different namespace.
     # Defaults to Watir::Locators.
     #
 
-    def locator_namespace=(mod)
-      @locator_namespace = mod
+    def locator_namespace
+      @locator_namespace ||= Watir::Locators
     end
 
     #

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -105,10 +105,12 @@ module Watir
 
       begin
         wait_until(&:exists?)
-      rescue Watir::Wait::TimeoutError
+      rescue Wait::TimeoutError
         unless Watir.default_timeout == 0
-          warn "This test has slept for the duration of the default timeout. "\
-                "If your test is passing, consider using Alert#exists? instead of rescuing this error"
+          message = "This code has slept for the duration of the default timeout "
+          message << "waiting for an Alert to exist. If the test is still passing, "
+          message << "consider using Alert#exists? instead of rescuing UnknownObjectException"
+          warn message
         end
         raise Exception::UnknownObjectException, 'unable to locate alert'
       end

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -1,7 +1,7 @@
 module Watir
   class Alert
-
     include EventuallyPresent
+    include Waitable
 
     def initialize(browser)
       @browser = browser
@@ -101,12 +101,14 @@ module Watir
     end
 
     def wait_for_exists
+      return assert_exists unless Watir.relaxed_locate?
+
       begin
-        Watir::Wait.until { exists? }
+        wait_until(&:exists?)
       rescue Watir::Wait::TimeoutError
         unless Watir.default_timeout == 0
           warn "This test has slept for the duration of the default timeout. "\
-                "If your test is passing, consider using Alert#exists? instead of rescuing this error)"
+                "If your test is passing, consider using Alert#exists? instead of rescuing this error"
         end
         raise Exception::UnknownObjectException, 'unable to locate alert'
       end

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -19,7 +19,7 @@ module Watir
     #
 
     def text
-      assert_exists
+      wait_for_exists
       @alert.text
     end
 
@@ -33,7 +33,7 @@ module Watir
     #
 
     def ok
-      assert_exists
+      wait_for_exists
       @alert.accept
       @browser.after_hooks.run
     end
@@ -48,7 +48,7 @@ module Watir
     #
 
     def close
-      assert_exists
+      wait_for_exists
       @alert.dismiss
       @browser.after_hooks.run
     end
@@ -64,7 +64,7 @@ module Watir
     #
 
     def set(value)
-      assert_exists
+      wait_for_exists
       @alert.send_keys(value)
     end
 
@@ -98,6 +98,18 @@ module Watir
       @alert = @browser.driver.switch_to.alert
     rescue Selenium::WebDriver::Error::NoAlertPresentError
       raise Exception::UnknownObjectException, 'unable to locate alert'
+    end
+
+    def wait_for_exists
+      begin
+        Watir::Wait.until { exists? }
+      rescue Watir::Wait::TimeoutError
+        unless Watir.default_timeout == 0
+          warn "This test has slept for the duration of the default timeout. "\
+                "If your test is passing, consider using Alert#exists? instead of rescuing this error)"
+        end
+        raise Exception::UnknownObjectException, 'unable to locate alert'
+      end
     end
 
   end # Alert

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -311,6 +311,12 @@ module Watir
         true
       end
     end
+    alias_method :wait_for_exists, :assert_exists
+    alias_method :wait_for_present, :assert_exists
+
+    def reset!
+      # no-op
+    end
 
     def browser
       self

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -7,7 +7,7 @@ module Watir
   class Browser
     include Container
     include HasWindow
-    include Waitable
+    include BrowserWaitable
 
     attr_reader :driver
     attr_reader :after_hooks
@@ -211,7 +211,7 @@ module Watir
     #
 
     def wait(timeout = 5)
-      wait_until(timeout, "waiting for document.readyState == 'complete'") do
+      wait_until(timeout: timeout, message: "waiting for document.readyState == 'complete'") do
         ready_state == "complete"
       end
     end
@@ -313,10 +313,6 @@ module Watir
     end
     alias_method :wait_for_exists, :assert_exists
     alias_method :wait_for_present, :assert_exists
-
-    def reset!
-      # no-op
-    end
 
     def browser
       self

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -7,7 +7,7 @@ module Watir
   class Browser
     include Container
     include HasWindow
-    include BrowserWaitable
+    include Waitable
 
     attr_reader :driver
     attr_reader :after_hooks
@@ -60,6 +60,7 @@ module Watir
     rescue
       '#<%s:0x%x closed=%s>' % [self.class, hash*2, @closed.to_s]
     end
+    alias selector_string inspect
 
     #
     # Goes to the given URL.
@@ -205,6 +206,9 @@ module Watir
 
     #
     # Waits until readyState of document is complete.
+    #
+    # @example
+    #   browser.wait
     #
     # @param [Fixnum] timeout
     # @raise [Watir::Wait::TimeoutError] if timeout is exceeded

--- a/lib/watir/elements/checkbox.rb
+++ b/lib/watir/elements/checkbox.rb
@@ -25,7 +25,6 @@ module Watir
     #
 
     def set?
-      assert_exists
       element_call { @element.selected? }
     end
 

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -583,16 +583,9 @@ module Watir
       locator.locate
     end
 
-    protected
-
     def selector_string
       return @selector.inspect if @query_scope.is_a?(Browser)
-      query_scope = if @query_scope.is_a?(IFrame)
-                      @query_scope.element.instance_variable_get("@query_scope")
-                    else
-                      @query_scope
-                    end
-      "#{query_scope.selector_string} --> #{@selector.inspect}"
+      "#{@query_scope.selector_string} --> #{@selector.inspect}"
     end
 
     private

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -110,9 +110,7 @@ module Watir
     #
 
     def click(*modifiers)
-      element_call(:wait_for_present) do
-        assert_enabled
-
+      element_call(:wait_for_enabled) do
         if modifiers.any?
           assert_has_input_devices_for "click(#{modifiers.join ', '})"
 
@@ -304,8 +302,7 @@ module Watir
     #
 
     def send_keys(*args)
-      element_call(:wait_for_present) do
-        assert_writable
+      element_call(:wait_for_writable) do
         @element.send_keys(*args)
       end
     end
@@ -496,47 +493,59 @@ module Watir
 
     protected
 
-    def wait_for_exists(timeout = nil)
+    def wait_for_exists
       return assert_exists unless Watir.relaxed_locate?
       return if exists? # Performance shortcut
 
-      timeout ||= Watir.default_timeout
-      timeout_off = timeout <= 0
-      end_time = Time.now + timeout
-
       begin
-        remaining_time = timeout_off ? 0 : end_time - Time.now
-        Watir::Wait.until(remaining_time) { exists? }
+        @query_scope.wait_for_exists
+        Watir::Wait.until { exists? }
       rescue Watir::Wait::TimeoutError
-        unless timeout_off
+        unless Watir.default_timeout == 0
           warn "This test has slept for the duration of the default timeout. "\
                   "If your test is passing, consider using Element#exists? instead of rescuing this error)"
         end
-        raise unknown_exception, "unable to locate element, using #{selector_string} "\
-                                         "after waiting #{timeout} seconds)"
+        raise unknown_exception, "timed out after #{Watir.default_timeout} seconds "\
+                                         "waiting for #{selector_string} to be located"
       end
     end
 
-    def wait_for_present(timeout = nil)
+    def wait_for_present
       return assert_exists unless Watir.relaxed_locate?
-      return if present? # Performance shortcut
 
-      timeout ||= Watir.default_timeout
-      timeout_off = timeout <= 0
-      end_time = Time.now + timeout
-
+      wait_for_exists
       begin
-        remaining_time = timeout_off ? 0 : end_time - Time.now
-        wait_for_exists(remaining_time)
-        remaining_time = timeout_off ? 0 : end_time - Time.now
-        Watir::Wait.until(remaining_time) { present? }
-      rescue Watir::Wait::TimeoutError
-        unless timeout_off
+        wait_until_present
+      rescue Watir::Wait::TimeoutError => ex
+        unless Watir.default_timeout == 0
           warn "This test has slept for the duration of the default timeout. "\
                   "If your test is passing, consider using Element#present? instead of rescuing this error)"
         end
-        raise unknown_exception, "element located but not visible, using #{selector_string} "\
-                                         "after waiting #{timeout} seconds)"
+        raise unknown_exception, "element located, but timed out after #{Watir.default_timeout} seconds #{ex.msg}"
+      end
+    end
+
+    def wait_for_enabled
+      return assert_enabled if Watir.relaxed_locate?
+
+      wait_for_present
+      begin
+        Watir::Wait.until { @element.enabled? }
+      rescue Watir::Wait::TimeoutError
+        message = "element present, but timed out after #{Watir.default_timeout} seconds waiting for #{selector_string} to be enabled"
+        raise ObjectDisabledException, message
+      end
+    end
+
+    def wait_for_writable
+      return assert_writable unless Watir.relaxed_locate?
+
+      wait_for_enabled
+      begin
+        Watir::Wait.until { !respond_to?(:readonly?) || !readonly? }
+      rescue Watir::Wait::TimeoutError
+        message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds waiting for #{selector_string} to not be readonly"
+        raise ObjectReadOnlyException, message
       end
     end
 
@@ -646,12 +655,14 @@ module Watir
     end
 
     def element_call(exist_check = :wait_for_exists)
+      already_locked = Wait.timer.locked?
+      Wait.timer = Wait::Timer.new(::Time.now + Watir.default_timeout) unless already_locked
       send exist_check
       yield
     rescue Selenium::WebDriver::Error::StaleElementReferenceError
-      @element = locate
-      assert_element_found
       retry
+    ensure
+      Wait.timer.reset! unless already_locked
     end
 
     def method_missing(meth, *args, &blk)

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -498,11 +498,13 @@ module Watir
 
       begin
         @query_scope.wait_for_exists
-        Watir::Wait.until(element: self, &:exists?)
+        wait_until(&:exists?)
       rescue Watir::Wait::TimeoutError
         unless Watir.default_timeout == 0
-          warn "This test has slept for the duration of the default timeout. "\
-                  "If your test is passing, consider using Element#exists? instead of rescuing this error"
+          message = "This code has slept for the duration of the default timeout "
+          message << "waiting for an Element to exist. If the test is still passing, "
+          message << "consider using Element#exists? instead of rescuing UnknownObjectException"
+          warn message
         end
         raise unknown_exception, "timed out after #{Watir.default_timeout} seconds, "\
                                          "waiting for #{selector_string} to be located"
@@ -518,8 +520,10 @@ module Watir
         wait_until_present
       rescue Watir::Wait::TimeoutError => ex
         unless Watir.default_timeout == 0
-          warn "This test has slept for the duration of the default timeout. "\
-                  "If your test is passing, consider using Element#present? instead of rescuing this error"
+          message = "This code has slept for the duration of the default timeout "
+          message << "waiting for an Element to be present. If the test is still passing, "
+          message << "consider using Element#exists? instead of rescuing UnknownObjectException"
+          warn message
         end
         raise unknown_exception, "element located, but #{ex.message}"
       end
@@ -530,7 +534,7 @@ module Watir
 
       wait_for_present
       begin
-        Watir::Wait.until { @element.enabled? }
+        wait_until(&:enabled?)
       rescue Watir::Wait::TimeoutError
         message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector_string} to be enabled"
         raise ObjectDisabledException, message
@@ -542,7 +546,7 @@ module Watir
 
       wait_for_enabled
       begin
-        Watir::Wait.until { !respond_to?(:readonly?) || !readonly? }
+        wait_until { !respond_to?(:readonly?) || !readonly? }
       rescue Watir::Wait::TimeoutError
         message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector_string} to not be readonly"
         raise ObjectReadOnlyException, message

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -110,7 +110,7 @@ module Watir
     #
 
     def click(*modifiers)
-      element_call do
+      element_call(:wait_for_present) do
         assert_enabled
 
         if modifiers.any?
@@ -141,7 +141,7 @@ module Watir
     def double_click
       assert_has_input_devices_for :double_click
 
-      element_call { driver.action.double_click(@element).perform }
+      element_call(:wait_for_present) { driver.action.double_click(@element).perform }
       browser.after_hooks.run
     end
 
@@ -156,7 +156,7 @@ module Watir
     def right_click
       assert_has_input_devices_for :right_click
 
-      element_call { driver.action.context_click(@element).perform }
+      element_call(:wait_for_present) { driver.action.context_click(@element).perform }
       browser.after_hooks.run
     end
 
@@ -171,7 +171,7 @@ module Watir
     def hover
       assert_has_input_devices_for :hover
 
-      element_call { driver.action.move_to(@element).perform }
+      element_call(:wait_for_present) { driver.action.move_to(@element).perform }
     end
 
     #
@@ -188,7 +188,7 @@ module Watir
       assert_is_element other
       assert_has_input_devices_for :drag_and_drop_on
 
-      element_call do
+      element_call(:wait_for_present) do
         driver.action.
                drag_and_drop(@element, other.wd).
                perform
@@ -209,7 +209,7 @@ module Watir
     def drag_and_drop_by(right_by, down_by)
       assert_has_input_devices_for :drag_and_drop_by
 
-      element_call do
+      element_call(:wait_for_present) do
         driver.action.
                drag_and_drop_by(@element, right_by, down_by).
                perform
@@ -304,7 +304,7 @@ module Watir
     #
 
     def send_keys(*args)
-      element_call do
+      element_call(:wait_for_present) do
         assert_writable
         @element.send_keys(*args)
       end
@@ -380,12 +380,14 @@ module Watir
 
     #
     # Returns true if this element is visible on the page.
+    # Raises exception if element does not exist
     #
     # @return [Boolean]
     #
 
     def visible?
-      element_call { @element.displayed? }
+      assert_exists
+      @element.displayed?
     end
 
     #
@@ -396,11 +398,13 @@ module Watir
     #
 
     def enabled?
-      element_call { @element.enabled? }
+      assert_exists
+      @element.enabled?
     end
 
     #
     # Returns true if the element exists and is visible on the page.
+    # Returns false if element does not exist or exists but is not visible
     #
     # @return [Boolean]
     # @see Watir::Wait
@@ -492,6 +496,50 @@ module Watir
 
     protected
 
+    def wait_for_exists(timeout = nil)
+      return assert_exists unless Watir.relaxed_locate?
+      return if exists? # Performance shortcut
+
+      timeout ||= Watir.default_timeout
+      timeout_off = timeout <= 0
+      end_time = Time.now + timeout
+
+      begin
+        remaining_time = timeout_off ? 0 : end_time - Time.now
+        Watir::Wait.until(remaining_time) { exists? }
+      rescue Watir::Wait::TimeoutError
+        unless timeout_off
+          warn "This test has slept for the duration of the default timeout. "\
+                  "If your test is passing, consider using Element#exists? instead of rescuing this error)"
+        end
+        raise unknown_exception, "unable to locate element, using #{selector_string} "\
+                                         "after waiting #{timeout} seconds)"
+      end
+    end
+
+    def wait_for_present(timeout = nil)
+      return assert_exists unless Watir.relaxed_locate?
+      return if present? # Performance shortcut
+
+      timeout ||= Watir.default_timeout
+      timeout_off = timeout <= 0
+      end_time = Time.now + timeout
+
+      begin
+        remaining_time = timeout_off ? 0 : end_time - Time.now
+        wait_for_exists(remaining_time)
+        remaining_time = timeout_off ? 0 : end_time - Time.now
+        Watir::Wait.until(remaining_time) { present? }
+      rescue Watir::Wait::TimeoutError
+        unless timeout_off
+          warn "This test has slept for the duration of the default timeout. "\
+                  "If your test is passing, consider using Element#present? instead of rescuing this error)"
+        end
+        raise unknown_exception, "element located but not visible, using #{selector_string} "\
+                                         "after waiting #{timeout} seconds)"
+      end
+    end
+
     # Ensure that the element exists, making sure that it is not stale and located if necessary
     def assert_exists
       if @element && @selector.empty?
@@ -508,7 +556,7 @@ module Watir
 
     def assert_element_found
       unless @element
-        raise UnknownObjectException, "unable to locate element, using #{selector_string}"
+        raise unknown_exception, "unable to locate element, using #{selector_string}"
       end
     end
 
@@ -535,6 +583,10 @@ module Watir
     end
 
     private
+
+    def unknown_exception
+      Watir::Exception::UnknownObjectException
+    end
 
     def locator_class
       Kernel.const_get("#{Watir.locator_namespace}::#{element_class_name}::Locator")
@@ -593,8 +645,8 @@ module Watir
       end
     end
 
-    def element_call
-      assert_exists
+    def element_call(exist_check = :wait_for_exists)
+      send exist_check
       yield
     rescue Selenium::WebDriver::Error::StaleElementReferenceError
       @element = locate

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -653,7 +653,7 @@ module Watir
 
     def element_call(exist_check = :wait_for_exists)
       already_locked = Wait.timer.locked?
-      Wait.timer = Wait::Timer.new(::Time.now + Watir.default_timeout) unless already_locked
+      Wait.timer = Wait::Timer.new(timeout: Watir.default_timeout) unless already_locked
       begin
         send exist_check
         yield

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -661,12 +661,14 @@ module Watir
     def element_call(exist_check = :wait_for_exists)
       already_locked = Wait.timer.locked?
       Wait.timer = Wait::Timer.new(::Time.now + Watir.default_timeout) unless already_locked
-      send exist_check
-      yield
-    rescue Selenium::WebDriver::Error::StaleElementReferenceError
-      retry
-    ensure
-      Wait.timer.reset! unless already_locked
+      begin
+        send exist_check
+        yield
+      rescue Selenium::WebDriver::Error::StaleElementReferenceError
+        retry
+      ensure
+        Wait.timer.reset! unless already_locked
+      end
     end
 
     def method_missing(meth, *args, &blk)

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -79,7 +79,6 @@ module Watir
     #
 
     def text
-      assert_exists
       element_call { @element.text }
     end
 
@@ -90,7 +89,6 @@ module Watir
     #
 
     def tag_name
-      assert_exists
       element_call { @element.tag_name.downcase }
     end
 
@@ -112,10 +110,9 @@ module Watir
     #
 
     def click(*modifiers)
-      assert_exists
-      assert_enabled
-
       element_call do
+        assert_enabled
+
         if modifiers.any?
           assert_has_input_devices_for "click(#{modifiers.join ', '})"
 
@@ -142,7 +139,6 @@ module Watir
     #
 
     def double_click
-      assert_exists
       assert_has_input_devices_for :double_click
 
       element_call { driver.action.double_click(@element).perform }
@@ -158,7 +154,6 @@ module Watir
     #
 
     def right_click
-      assert_exists
       assert_has_input_devices_for :right_click
 
       element_call { driver.action.context_click(@element).perform }
@@ -174,7 +169,6 @@ module Watir
     #
 
     def hover
-      assert_exists
       assert_has_input_devices_for :hover
 
       element_call { driver.action.move_to(@element).perform }
@@ -192,7 +186,6 @@ module Watir
 
     def drag_and_drop_on(other)
       assert_is_element other
-      assert_exists
       assert_has_input_devices_for :drag_and_drop_on
 
       element_call do
@@ -214,7 +207,6 @@ module Watir
     #
 
     def drag_and_drop_by(right_by, down_by)
-      assert_exists
       assert_has_input_devices_for :drag_and_drop_by
 
       element_call do
@@ -269,7 +261,6 @@ module Watir
     #
 
     def attribute_value(attribute_name)
-      assert_exists
       element_call { @element.attribute attribute_name }
     end
 
@@ -284,7 +275,6 @@ module Watir
     #
 
     def outer_html
-      assert_exists
       element_call { execute_atom(:getOuterHtml, @element) }.strip
     end
 
@@ -301,7 +291,6 @@ module Watir
     #
 
     def inner_html
-      assert_exists
       element_call { execute_atom(:getInnerHtml, @element) }.strip
     end
 
@@ -315,9 +304,10 @@ module Watir
     #
 
     def send_keys(*args)
-      assert_exists
-      assert_writable
-      element_call { @element.send_keys(*args) }
+      element_call do
+        assert_writable
+        @element.send_keys(*args)
+      end
     end
 
     #
@@ -328,7 +318,6 @@ module Watir
     #
 
     def focus
-      assert_exists
       element_call { driver.execute_script "return arguments[0].focus()", @element }
     end
 
@@ -339,7 +328,6 @@ module Watir
     #
 
     def focused?
-      assert_exists
       element_call { @element == driver.switch_to.active_element }
     end
 
@@ -356,7 +344,6 @@ module Watir
     #
 
     def fire_event(event_name)
-      assert_exists
       event_name = event_name.to_s.sub(/^on/, '').downcase
 
       element_call { execute_atom :fireEvent, @element, event_name }
@@ -367,8 +354,6 @@ module Watir
     #
 
     def parent
-      assert_exists
-
       e = element_call { execute_atom :getParentElement, @element }
 
       if e.kind_of?(Selenium::WebDriver::Element)
@@ -400,7 +385,6 @@ module Watir
     #
 
     def visible?
-      assert_exists
       element_call { @element.displayed? }
     end
 
@@ -412,7 +396,6 @@ module Watir
     #
 
     def enabled?
-      assert_exists
       element_call { @element.enabled? }
     end
 
@@ -424,10 +407,8 @@ module Watir
     #
 
     def present?
-      exists? && visible?
-    rescue Selenium::WebDriver::Error::StaleElementReferenceError, UnknownObjectException
-      # if the element disappears between the exists? and visible? calls,
-      # consider it not present.
+      visible?
+    rescue UnknownObjectException
       false
     end
 
@@ -444,7 +425,6 @@ module Watir
 
     def style(property = nil)
       if property
-        assert_exists
         element_call { @element.style property }
       else
         attribute_value("style").to_s.strip
@@ -614,6 +594,7 @@ module Watir
     end
 
     def element_call
+      assert_exists
       yield
     rescue Selenium::WebDriver::Error::StaleElementReferenceError
       @element = locate

--- a/lib/watir/elements/form.rb
+++ b/lib/watir/elements/form.rb
@@ -8,7 +8,6 @@ module Watir
     #
 
     def submit
-      assert_exists
       element_call { @element.submit }
       browser.after_hooks.run
     end

--- a/lib/watir/elements/form.rb
+++ b/lib/watir/elements/form.rb
@@ -8,7 +8,7 @@ module Watir
     #
 
     def submit
-      element_call { @element.submit }
+      element_call(:wait_for_present) { @element.submit }
       browser.after_hooks.run
     end
 

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -11,7 +11,7 @@ module Watir
       locator = locator_class.new(@query_scope, selector, selector_builder, element_validator)
 
       element = locator.locate
-      element or raise UnknownFrameException, "unable to locate #{@selector[:tag_name]} using #{selector_string}"
+      element or raise unknown_exception, "unable to locate #{@selector[:tag_name]} using #{selector_string}"
 
       FramedDriver.new(element, driver)
     end
@@ -50,6 +50,7 @@ module Watir
     #
 
     def html
+      wait_for_exists
       wd.page_source
     end
 
@@ -61,6 +62,10 @@ module Watir
 
     def frame_tag
       'iframe'
+    end
+
+    def unknown_exception
+      Watir::Exception::UnknownFrameException
     end
 
   end # IFrame

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -50,7 +50,6 @@ module Watir
     #
 
     def html
-      assert_exists
       wd.page_source
     end
 

--- a/lib/watir/elements/image.rb
+++ b/lib/watir/elements/image.rb
@@ -23,7 +23,7 @@ module Watir
     #
 
     def width
-      Watir.relaxed_locate? ? wait_for_exists : assert_exists
+      wait_for_exists
       driver.execute_script "return arguments[0].width", @element
     end
 

--- a/lib/watir/elements/image.rb
+++ b/lib/watir/elements/image.rb
@@ -23,7 +23,7 @@ module Watir
     #
 
     def width
-      wait_for_exists
+      Watir.relaxed_locate? ? wait_for_exists : assert_exists
       driver.execute_script "return arguments[0].width", @element
     end
 

--- a/lib/watir/elements/image.rb
+++ b/lib/watir/elements/image.rb
@@ -23,7 +23,7 @@ module Watir
     #
 
     def width
-      assert_exists
+      wait_for_exists
       driver.execute_script "return arguments[0].width", @element
     end
 

--- a/lib/watir/elements/option.rb
+++ b/lib/watir/elements/option.rb
@@ -42,7 +42,6 @@ module Watir
     #
 
     def selected?
-      assert_exists
       element_call { @element.selected? }
     end
 

--- a/lib/watir/elements/radio.rb
+++ b/lib/watir/elements/radio.rb
@@ -16,7 +16,6 @@ module Watir
     #
 
     def set?
-      assert_exists
       element_call { @element.selected? }
     end
 

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -21,7 +21,7 @@ module Watir
     #
 
     def options
-      assert_exists
+      wait_for_exists
       super
     end
 
@@ -212,7 +212,6 @@ module Watir
       element.text
     rescue Selenium::WebDriver::Error::StaleElementReferenceError, Selenium::WebDriver::Error::UnhandledAlertError
       # guard for scenario where selecting the element changes the page, making our element obsolete
-
       ''
     end
 

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -21,7 +21,7 @@ module Watir
     #
 
     def options
-      Watir.relaxed_locate? ? wait_for_exists : assert_exists
+      wait_for_exists
       super
     end
 

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -21,7 +21,7 @@ module Watir
     #
 
     def options
-      wait_for_exists
+      Watir.relaxed_locate? ? wait_for_exists : assert_exists
       super
     end
 

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -7,8 +7,6 @@ module Watir
     #
 
     def clear
-      assert_exists
-
       raise Error, "you can only clear multi-selects" unless multiple?
 
       options.each do |o|
@@ -35,8 +33,6 @@ module Watir
     #
 
     def include?(str_or_rx)
-      assert_exists
-
       element_call do
         @element.find_elements(:tag_name, 'option').any? do |e|
           str_or_rx === e.text || str_or_rx === e.attribute(:label)
@@ -80,8 +76,6 @@ module Watir
     #
 
     def selected?(str_or_rx)
-      assert_exists
-
       match_found = false
 
       element_call do
@@ -125,8 +119,6 @@ module Watir
     private
 
     def select_by(how, str_or_rx)
-      assert_exists
-
       case str_or_rx
       when String, Numeric
         select_by_string(how, str_or_rx.to_s)

--- a/lib/watir/extensions/select_text.rb
+++ b/lib/watir/extensions/select_text.rb
@@ -3,7 +3,7 @@ Watir::Atoms.load :selectText
 module Watir
   class Element
     def select_text(str)
-      assert_exists
+      wait_for_exists
       execute_atom :selectText, @element, str
     end
   end # Element

--- a/lib/watir/extensions/select_text.rb
+++ b/lib/watir/extensions/select_text.rb
@@ -3,7 +3,7 @@ Watir::Atoms.load :selectText
 module Watir
   class Element
     def select_text(str)
-      wait_for_exists
+      Watir.relaxed_locate? ? wait_for_exists : assert_exists
       execute_atom :selectText, @element, str
     end
   end # Element

--- a/lib/watir/extensions/select_text.rb
+++ b/lib/watir/extensions/select_text.rb
@@ -3,7 +3,7 @@ Watir::Atoms.load :selectText
 module Watir
   class Element
     def select_text(str)
-      Watir.relaxed_locate? ? wait_for_exists : assert_exists
+      wait_for_exists
       execute_atom :selectText, @element, str
     end
   end # Element

--- a/lib/watir/legacy_wait.rb
+++ b/lib/watir/legacy_wait.rb
@@ -81,13 +81,14 @@ module Watir
     #
 
     def when_present(timeout = nil)
-      warn '#when_present has been deprecated and is unlikely to be needed; use #wait_until_present if a wait is still needed'
+      warning = '#when_present has been deprecated and is unlikely to be needed; '
+      warning << 'replace this with #wait_until_present if a wait is still needed'
+      warn warning
 
       timeout ||= Watir.default_timeout
       message = "waiting for #{selector_string} to become present"
 
       if block_given?
-        warn "do not pass a block to take actions after a wait"
         Watir::Wait.until(timeout, message) { present? }
         yield self
       else
@@ -108,13 +109,12 @@ module Watir
     #
 
     def when_enabled(timeout = nil)
-      warn '#when_enabled has been deprecated and unlikely to be needed'
+      warn '#when_enabled has been deprecated and is unlikely to be needed'
 
       timeout ||= Watir.default_timeout
       message = "waiting for #{selector_string} to become enabled"
 
       if block_given?
-        warn "do not pass a block to take actions after a wait"
         Watir::Wait.until(timeout, message) { enabled? }
         yield self
       else

--- a/lib/watir/legacy_wait.rb
+++ b/lib/watir/legacy_wait.rb
@@ -1,0 +1,126 @@
+require 'forwardable'
+
+# TODO - remove this file for future release
+module Watir
+
+  class BaseDecorator
+    def initialize(element, timeout, message = nil)
+      @element = element
+      @timeout = timeout
+      @message = message
+    end
+
+    def respond_to?(*args)
+      @element.respond_to?(*args)
+    end
+
+    def method_missing(m, *args, &block)
+      unless @element.respond_to?(m)
+        raise NoMethodError, "undefined method `#{m}' for #{@element.inspect}:#{@element.class}"
+      end
+
+      Watir::Wait.until(@timeout, @message) { wait_until }
+
+      @element.__send__(m, *args, &block)
+    end
+  end
+
+  #
+  # Wraps an Element so that any subsequent method calls are
+  # put on hold until the element is present (exists and is visible) on the page.
+  #
+
+  class WhenPresentDecorator < BaseDecorator
+    def present?
+      Watir::Wait.until(@timeout, @message) { wait_until }
+      true
+    rescue Watir::Wait::TimeoutError
+      false
+    end
+
+    private
+
+    def wait_until
+      @element.present?
+    end
+  end # WhenPresentDecorator
+
+  #
+  # Wraps an Element so that any subsequent method calls are
+  # put on hold until the element is enabled (exists and is enabled) on the page.
+  #
+
+  class WhenEnabledDecorator < BaseDecorator
+
+    private
+
+    def wait_until
+      @element.enabled?
+    end
+  end # WhenEnabledDecorator
+
+  #
+  # Convenience methods for things that eventually become present.
+  #
+  # Includers should implement a public #present? and a (possibly private) #selector_string method.
+  #
+
+  module EventuallyPresent
+    #
+    # Waits until the element is present.
+    #
+    # @example
+    #   browser.text_field(name: "new_user_first_name").when_present.click
+    #   browser.text_field(name: "new_user_first_name").when_present { |field| field.set "Watir" }
+    #   browser.text_field(name: "new_user_first_name").when_present(60).text
+    #
+    # @param [Fixnum] timeout seconds to wait before timing out
+    #
+    # @see Watir::Wait
+    # @see Watir::Element#present?
+    #
+
+    def when_present(timeout = nil)
+      warn '#when_present has been deprecated and is unlikely to be needed; use #wait_until_present if a wait is still needed'
+
+      timeout ||= Watir.default_timeout
+      message = "waiting for #{selector_string} to become present"
+
+      if block_given?
+        warn "do not pass a block to take actions after a wait"
+        Watir::Wait.until(timeout, message) { present? }
+        yield self
+      else
+        WhenPresentDecorator.new(self, timeout, message)
+      end
+    end
+
+    #
+    # Waits until the element is enabled.
+    #
+    # @example
+    #   browser.button(name: "new_user_button_2").when_enabled.click
+    #
+    # @param [Fixnum] timeout seconds to wait before timing out
+    #
+    # @see Watir::Wait
+    # @see Watir::Element#enabled?
+    #
+
+    def when_enabled(timeout = nil)
+      warn '#when_enabled has been deprecated and unlikely to be needed'
+
+      timeout ||= Watir.default_timeout
+      message = "waiting for #{selector_string} to become enabled"
+
+      if block_given?
+        warn "do not pass a block to take actions after a wait"
+        Watir::Wait.until(timeout, message) { enabled? }
+        yield self
+      else
+        WhenEnabledDecorator.new(self, timeout, message)
+      end
+    end
+
+  end # EventuallyPresent
+end # Watir

--- a/lib/watir/row_container.rb
+++ b/lib/watir/row_container.rb
@@ -24,6 +24,8 @@ module Watir
     #
 
     def strings
+      wait_for_exists
+
       rows.inject [] do |res, row|
         res << row.cells.map(&:text)
       end

--- a/lib/watir/row_container.rb
+++ b/lib/watir/row_container.rb
@@ -24,8 +24,6 @@ module Watir
     #
 
     def strings
-      assert_exists
-
       rows.inject [] do |res, row|
         res << row.cells.map(&:text)
       end

--- a/lib/watir/user_editable.rb
+++ b/lib/watir/user_editable.rb
@@ -8,7 +8,7 @@ module Watir
     #
 
     def set(*args)
-      element_call do
+      element_call(:wait_for_present) do
         assert_writable
         @element.clear
         @element.send_keys(*args)
@@ -32,7 +32,7 @@ module Watir
     #
 
     def clear
-      element_call do
+      element_call(:wait_for_present) do
         assert_writable
         @element.clear
       end

--- a/lib/watir/user_editable.rb
+++ b/lib/watir/user_editable.rb
@@ -8,8 +8,11 @@ module Watir
     #
 
     def set(*args)
-      clear
-      element_call { @element.send_keys(*args) }
+      element_call do
+        assert_writable
+        @element.clear
+        @element.send_keys(*args)
+      end
     end
     alias_method :value=, :set
 
@@ -29,9 +32,10 @@ module Watir
     #
 
     def clear
-      assert_exists
-      assert_writable
-      element_call { @element.clear }
+      element_call do
+        assert_writable
+        @element.clear
+      end
     end
 
   end # UserEditable

--- a/lib/watir/user_editable.rb
+++ b/lib/watir/user_editable.rb
@@ -8,8 +8,7 @@ module Watir
     #
 
     def set(*args)
-      element_call(:wait_for_present) do
-        assert_writable
+      element_call(:wait_for_writable) do
         @element.clear
         @element.send_keys(*args)
       end
@@ -32,8 +31,7 @@ module Watir
     #
 
     def clear
-      element_call(:wait_for_present) do
-        assert_writable
+      element_call(:wait_for_writable) do
         @element.clear
       end
     end

--- a/lib/watir/wait.rb
+++ b/lib/watir/wait.rb
@@ -96,7 +96,7 @@ module Watir
     def wait_while(*args, &blk)
       Wait.while(*args, &blk)
     end
-  end
+  end # BrowserWaitable
 
   module Waitable
 
@@ -117,7 +117,7 @@ module Watir
     def wait_until(timeout: nil, message: nil, &blk)
       return self if yield(self) # performance shortcut
       timeout ||= Watir.default_timeout
-      raise TimeoutError, "required condition for #{selector_string} is not met" if timeout == 0
+      raise Wait::TimeoutError, "required condition for #{selector_string} is not met" if timeout == 0
 
       message ||= "waiting for true condition on #{selector_string}"
       Wait.until(timeout: timeout, message: message, element: self, &blk)
@@ -133,7 +133,7 @@ module Watir
     def wait_while(timeout: nil, message: nil, &blk)
       return self unless yield(self) # performance shortcut
       timeout ||= Watir.default_timeout
-      raise TimeoutError, "required condition for #{selector_string} is not met" if timeout == 0
+      raise Wait::TimeoutError, "required condition for #{selector_string} is not met" if timeout == 0
 
       message ||= "waiting for false condition on #{selector_string}"
       Wait.while(timeout: timeout, message: message, element: self, &blk)
@@ -178,28 +178,6 @@ module Watir
       end
       timeout ||= deprecated_timeout
       wait_while(timeout: timeout, &:present?)
-    end
-
-    #
-    # Waits until the element is stale.
-    #
-    # @example
-    #   text_field = browser.text_field(name: "new_user_first_name")
-    #   text_field.present?
-    #   browser.refresh # any action that makes element stale
-    #   text_field.wait_until_stale
-    #
-    # @param [Fixnum] timeout seconds to wait before timing out
-    #
-    # @see Watir::Wait
-    # @see Watir::Element#stale?
-    #
-
-    def wait_until_stale(deprecated_timeout = nil, timeout: nil)
-      if deprecated_timeout
-        warn "Instead of passing arguments into #wait_until_stale method, use keywords"
-      end
-      wait_until(timeout: timeout, &:stale?)
     end
 
   end # Waitable

--- a/lib/watir/wait.rb
+++ b/lib/watir/wait.rb
@@ -96,6 +96,8 @@ module Watir
 
   class BaseDecorator
 
+    ELEMENT_ACTIONS = [:set, :append, :clear, :click, :double_click, :right_click, :send_keys, :focus, :focused?, :submit]
+
     def initialize(element, timeout, message = nil)
       @element = element
       @timeout = timeout
@@ -127,6 +129,11 @@ module Watir
       Watir::Wait.until(@timeout, @message) { wait_until }
       true
     rescue Watir::Wait::TimeoutError
+
+      if @timeout >= Watir.default_timeout && @timeout != 0 && ELEMENT_ACTIONS.include?(m)
+        warn "#when_present might be unnecessary for #{@element.send :selector_string}; elements now automatically wait when taking action - #{m}"
+      end
+
       false
     end
 

--- a/lib/watir/wait/timer.rb
+++ b/lib/watir/wait/timer.rb
@@ -2,8 +2,8 @@ module Watir
   module Wait
     class Timer
 
-      def initialize(end_time = nil)
-        @end_time = end_time
+      def initialize(timeout: nil)
+        @end_time = current_time + timeout if timeout
       end
 
       #

--- a/lib/watir/wait/timer.rb
+++ b/lib/watir/wait/timer.rb
@@ -2,6 +2,10 @@ module Watir
   module Wait
     class Timer
 
+      def initialize(end_time = nil)
+        @end_time = end_time
+      end
+
       #
       # Executes given block until it returns true or exceeds timeout.
       # @param [Fixnum] timeout
@@ -10,8 +14,19 @@ module Watir
       #
 
       def wait(timeout, &block)
-        end_time = current_time + timeout
-        yield(block) until current_time > end_time
+        end_time = @end_time || current_time + timeout
+        loop do
+          yield(block)
+          break if current_time > end_time
+        end
+      end
+
+      def reset!
+        @end_time = nil
+      end
+
+      def locked?
+        !@end_time.nil?
       end
 
       private

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -189,7 +189,7 @@ module Watir
     #
 
     def use(&blk)
-      assert_exists
+      wait_for_exists
       @driver.switch_to.window(handle, &blk)
       self
     end
@@ -238,6 +238,14 @@ module Watir
     rescue Selenium::WebDriver::Error::NoSuchWindowError, Selenium::WebDriver::Error::NoSuchDriverError
       # the window may disappear while we're iterating.
       false
+    end
+
+    def wait_for_exists
+      begin
+        Watir::Wait.until { exists? }
+      rescue Watir::Wait::TimeoutError
+        raise Exception::NoMatchingWindowFoundException, @selector.inspect
+      end
     end
 
   end # Window

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -1,6 +1,7 @@
 module Watir
   class Window
     include EventuallyPresent
+    include Waitable
 
     def initialize(driver, selector)
       @driver = driver
@@ -241,9 +242,10 @@ module Watir
     end
 
     def wait_for_exists
+      return assert_exists unless Watir.relaxed_locate?
       begin
-        Watir::Wait.until { exists? }
-      rescue Watir::Wait::TimeoutError
+        wait_until(&:exists?)
+      rescue TimeoutError
         raise Exception::NoMatchingWindowFoundException, @selector.inspect
       end
     end

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -245,7 +245,7 @@ module Watir
       return assert_exists unless Watir.relaxed_locate?
       begin
         wait_until(&:exists?)
-      rescue TimeoutError
+      rescue Wait::TimeoutError
         raise Exception::NoMatchingWindowFoundException, @selector.inspect
       end
     end

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -77,10 +77,10 @@ describe Watir::Browser do
 
   describe "#wait_while" do
     it "delegates to the Wait module" do
-      expect(Watir::Wait).to receive(:while).with(3, "foo").and_yield
+      expect(Watir::Wait).to receive(:while).with(timeout: 3, message: "foo", object: browser).and_yield
 
       called = false
-      browser.wait_while(3, "foo") { called = true }
+      browser.wait_while(timeout: 3, message: "foo") { called = true }
 
       expect(called).to be true
     end
@@ -88,7 +88,7 @@ describe Watir::Browser do
 
   describe "#wait_until" do
     it "delegates to the Wait module" do
-      expect(Watir::Wait).to receive(:until).with(timeout: 3, message: "foo").and_yield
+      expect(Watir::Wait).to receive(:until).with(timeout: 3, message: "foo", object: browser).and_yield
 
       called = false
       browser.wait_until(timeout: 3, message: "foo") { called = true }

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -88,10 +88,10 @@ describe Watir::Browser do
 
   describe "#wait_until" do
     it "delegates to the Wait module" do
-      expect(Watir::Wait).to receive(:until).with(3, "foo").and_yield
+      expect(Watir::Wait).to receive(:until).with(timeout: 3, message: "foo").and_yield
 
       called = false
-      browser.wait_until(3, "foo") { called = true }
+      browser.wait_until(timeout: 3, message: "foo") { called = true }
 
       expect(called).to be true
     end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -1,140 +1,138 @@
 require 'watirspec_helper'
 
-module Watir
-  describe Element do
+describe Watir::Element do
 
-    describe '#present?' do
-      before do
-        browser.goto(WatirSpec.url_for("wait.html"))
-      end
-
-      it 'returns true if the element exists and is visible' do
-        expect(browser.div(:id, 'foo')).to be_present
-      end
-
-      it 'returns false if the element exists but is not visible' do
-        expect(browser.div(:id, 'bar')).to_not be_present
-      end
-
-      it 'returns false if the element does not exist' do
-        expect(browser.div(:id, 'should-not-exist')).to_not be_present
-      end
-
-      it "returns false if the element is stale" do
-        wd_element = browser.div(id: "foo").wd
-
-        # simulate element going stale during lookup
-        allow(browser.driver).to receive(:find_element).with(:id, 'foo') { wd_element }
-        browser.refresh
-
-        expect(browser.div(:id, 'foo')).to_not be_present
-      end
-
+  describe '#present?' do
+    before do
+      browser.goto(WatirSpec.url_for("wait.html"))
     end
 
-    describe "#enabled?" do
-      before do
-        browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
-      end
-
-      it "returns true if the element is enabled" do
-        expect(browser.element(name: 'new_user_submit')).to be_enabled
-      end
-
-      it "returns false if the element is disabled" do
-        expect(browser.element(name: 'new_user_submit_disabled')).to_not be_enabled
-      end
-
-      it "raises UnknownObjectException if the element doesn't exist" do
-        expect { browser.element(name: "no_such_name").enabled? }.to raise_error(Exception::UnknownObjectException)
-      end
+    it 'returns true if the element exists and is visible' do
+      expect(browser.div(:id, 'foo')).to be_present
     end
 
-    describe "#exists?" do
-      before do
-        browser.goto WatirSpec.url_for('removed_element.html')
-      end
-
-      it "relocates element from a collection when it becomes stale" do
-        watir_element = browser.divs(id: "text").first
-        expect(watir_element).to exist
-
-        browser.refresh
-
-        expect(watir_element).to exist
-      end
-
-      it "returns false when tag name does not match id" do
-        watir_element = browser.span(id: "text")
-        expect(watir_element).to_not exist
-      end
+    it 'returns false if the element exists but is not visible' do
+      expect(browser.div(:id, 'bar')).to_not be_present
     end
 
-    describe "#element_call" do
+    it 'returns false if the element does not exist' do
+      expect(browser.div(:id, 'should-not-exist')).to_not be_present
+    end
 
-      it 'handles exceptions when taking an action on an element that goes stale during execution' do
-        browser.goto WatirSpec.url_for('removed_element.html')
+    it "returns false if the element is stale" do
+      wd_element = browser.div(id: "foo").wd
 
-        watir_element = browser.div(id: "text")
+      # simulate element going stale during lookup
+      allow(browser.driver).to receive(:find_element).with(:id, 'foo') { wd_element }
+      browser.refresh
 
-          # simulate element going stale after assert_exists and before action taken, but not when block retried
-        allow(watir_element).to receive(:text) do
-          watir_element.send(:element_call) do
-            @already_stale ||= false
-            browser.refresh unless @already_stale
-            @already_stale = true
-            watir_element.instance_variable_get('@element').text
-          end
+      expect(browser.div(:id, 'foo')).to_not be_present
+    end
+
+  end
+
+  describe "#enabled?" do
+    before do
+      browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+    end
+
+    it "returns true if the element is enabled" do
+      expect(browser.element(name: 'new_user_submit')).to be_enabled
+    end
+
+    it "returns false if the element is disabled" do
+      expect(browser.element(name: 'new_user_submit_disabled')).to_not be_enabled
+    end
+
+    it "raises UnknownObjectException if the element doesn't exist" do
+      expect { browser.element(name: "no_such_name").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+    end
+  end
+
+  describe "#exists?" do
+    before do
+      browser.goto WatirSpec.url_for('removed_element.html')
+    end
+
+    it "relocates element from a collection when it becomes stale" do
+      watir_element = browser.divs(id: "text").first
+      expect(watir_element).to exist
+
+      browser.refresh
+
+      expect(watir_element).to exist
+    end
+
+    it "returns false when tag name does not match id" do
+      watir_element = browser.span(id: "text")
+      expect(watir_element).to_not exist
+    end
+  end
+
+  describe "#element_call" do
+
+    it 'handles exceptions when taking an action on an element that goes stale during execution' do
+      browser.goto WatirSpec.url_for('removed_element.html')
+
+      watir_element = browser.div(id: "text")
+
+        # simulate element going stale after assert_exists and before action taken, but not when block retried
+      allow(watir_element).to receive(:text) do
+        watir_element.send(:element_call) do
+          @already_stale ||= false
+          browser.refresh unless @already_stale
+          @already_stale = true
+          watir_element.instance_variable_get('@element').text
         end
-
-        expect { watir_element.text }.to_not raise_error
       end
 
+      expect { watir_element.text }.to_not raise_error
     end
 
-    bug "Actions Endpoint Not Yet Implemented", :firefox do
-      describe "#hover" do
-        not_compliant_on :internet_explorer, :safari do
-          it "should hover over the element" do
-            browser.goto WatirSpec.url_for('hover.html')
-            link = browser.a
+  end
 
-            expect(link.style("font-size")).to eq "10px"
-            link.hover
-            expect(link.style("font-size")).to eq "20px"
-          end
+  bug "Actions Endpoint Not Yet Implemented", :firefox do
+    describe "#hover" do
+      not_compliant_on :internet_explorer, :safari do
+        it "should hover over the element" do
+          browser.goto WatirSpec.url_for('hover.html')
+          link = browser.a
+
+          expect(link.style("font-size")).to eq "10px"
+          link.hover
+          expect(link.style("font-size")).to eq "20px"
         end
       end
     end
+  end
 
-    describe "#selector_string" do
-      it "displays selector string for regular element" do
-        browser.goto(WatirSpec.url_for("wait.html"))
-        element = browser.div(:id, 'not_present')
-        error = 'required condition for {:id=>"not_present", :tag_name=>"div"} is not met'
-        expect { element.wait_until_present(timeout: 0) }.to raise_exception(Wait::TimeoutError, error)
-      end
+  describe "#selector_string" do
+    it "displays selector string for regular element" do
+      browser.goto(WatirSpec.url_for("wait.html"))
+      element = browser.div(:id, 'not_present')
+      error = 'required condition for {:id=>"not_present", :tag_name=>"div"} is not met'
+      expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Wait::TimeoutError, error)
+    end
 
-      it "displays selector string for element from colection" do
-        browser.goto(WatirSpec.url_for("wait.html"))
-        element = browser.divs.last
-        error = 'required condition for {:tag_name=>"div", :index=>4} is not met'
-        expect {element.wait_until_present(timeout: 0)}.to raise_exception(Wait::TimeoutError, error)
-      end
+    it "displays selector string for element from colection" do
+      browser.goto(WatirSpec.url_for("wait.html"))
+      element = browser.divs.last
+      error = 'required condition for {:tag_name=>"div", :index=>4} is not met'
+      expect {element.wait_until_present(timeout: 0)}.to raise_exception(Watir::Wait::TimeoutError, error)
+    end
 
-      it "displays selector string for nested element" do
-        browser.goto(WatirSpec.url_for("wait.html"))
-        element = browser.div(index: -1).div(:id, 'foo')
-        error = 'required condition for {:index=>-1, :tag_name=>"div"} --> {:id=>"foo", :tag_name=>"div"} is not met'
-        expect {element.wait_until_present(timeout: 0)}.to raise_exception(Wait::TimeoutError, error)
-      end
+    it "displays selector string for nested element" do
+      browser.goto(WatirSpec.url_for("wait.html"))
+      element = browser.div(index: -1).div(:id, 'foo')
+      error = 'required condition for {:index=>-1, :tag_name=>"div"} --> {:id=>"foo", :tag_name=>"div"} is not met'
+      expect {element.wait_until_present(timeout: 0)}.to raise_exception(Watir::Wait::TimeoutError, error)
+    end
 
-      it "displays selector string for nested element under frame" do
-        browser.goto(WatirSpec.url_for("nested_iframes.html"))
-        element = browser.iframe(id: 'one').iframe(:id, 'three')
-        error = 'unable to locate iframe using {:id=>"one", :tag_name=>"iframe"} --> {:id=>"three", :tag_name=>"iframe"}'
-        expect {element.wait_until_present(timeout: 0)}.to raise_exception(Exception::UnknownFrameException, error)
-      end
+    it "displays selector string for nested element under frame" do
+      browser.goto(WatirSpec.url_for("nested_iframes.html"))
+      element = browser.iframe(id: 'one').iframe(:id, 'three')
+      error = 'unable to locate iframe using {:id=>"one", :tag_name=>"iframe"} --> {:id=>"three", :tag_name=>"iframe"}'
+      expect {element.wait_until_present(timeout: 0)}.to raise_exception(Exception::UnknownFrameException, error)
     end
   end
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -110,23 +110,23 @@ module Watir
     describe "#selector_string" do
       it "displays selector string for regular element" do
         browser.goto(WatirSpec.url_for("wait.html"))
-        delegator = browser.div(:id, 'foo').when_present
-        message = delegator.instance_variable_get('@message')
-        expect(message).to eq 'waiting for {:id=>"foo", :tag_name=>"div"} to become present'
+        element = browser.div(:id, 'not_present')
+        error = 'required condition for {:id=>"not_present", :tag_name=>"div"} is not met'
+        expect { element.wait_until_present(timeout: 0) }.to raise_exception(Wait::TimeoutError, error)
       end
 
       it "displays selector string for element from colection" do
         browser.goto(WatirSpec.url_for("wait.html"))
         element = browser.divs.last
         error = 'required condition for {:tag_name=>"div", :index=>4} is not met'
-        expect {element.wait_until_present(timeout: 0)}.to raise_exception(TimeoutError, error)
+        expect {element.wait_until_present(timeout: 0)}.to raise_exception(Wait::TimeoutError, error)
       end
 
       it "displays selector string for nested element" do
         browser.goto(WatirSpec.url_for("wait.html"))
         element = browser.div(index: -1).div(:id, 'foo')
         error = 'required condition for {:index=>-1, :tag_name=>"div"} --> {:id=>"foo", :tag_name=>"div"} is not met'
-        expect {element.wait_until_present(timeout: 0)}.to raise_exception(TimeoutError, error)
+        expect {element.wait_until_present(timeout: 0)}.to raise_exception(Wait::TimeoutError, error)
       end
 
       it "displays selector string for nested element under frame" do
@@ -134,7 +134,6 @@ module Watir
         element = browser.iframe(id: 'one').iframe(:id, 'three')
         error = 'unable to locate iframe using {:id=>"one", :tag_name=>"iframe"} --> {:id=>"three", :tag_name=>"iframe"}'
         expect {element.wait_until_present(timeout: 0)}.to raise_exception(Exception::UnknownFrameException, error)
-      end
       end
     end
   end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -110,29 +110,29 @@ describe Watir::Element do
     it "displays selector string for regular element" do
       browser.goto(WatirSpec.url_for("wait.html"))
       element = browser.div(:id, 'not_present')
-      error = 'required condition for {:id=>"not_present", :tag_name=>"div"} is not met'
+      error = 'timed out after 0 seconds, waiting for true condition on {:id=>"not_present", :tag_name=>"div"}'
       expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Wait::TimeoutError, error)
     end
 
     it "displays selector string for element from colection" do
       browser.goto(WatirSpec.url_for("wait.html"))
       element = browser.divs.last
-      error = 'required condition for {:tag_name=>"div", :index=>4} is not met'
-      expect {element.wait_until_present(timeout: 0)}.to raise_exception(Watir::Wait::TimeoutError, error)
+      error = 'timed out after 0 seconds, waiting for true condition on {:tag_name=>"div", :index=>4}'
+      expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Wait::TimeoutError, error)
     end
 
     it "displays selector string for nested element" do
       browser.goto(WatirSpec.url_for("wait.html"))
       element = browser.div(index: -1).div(:id, 'foo')
-      error = 'required condition for {:index=>-1, :tag_name=>"div"} --> {:id=>"foo", :tag_name=>"div"} is not met'
-      expect {element.wait_until_present(timeout: 0)}.to raise_exception(Watir::Wait::TimeoutError, error)
+      error = 'timed out after 0 seconds, waiting for true condition on {:index=>-1, :tag_name=>"div"} --> {:id=>"foo", :tag_name=>"div"}'
+      expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Wait::TimeoutError, error)
     end
 
     it "displays selector string for nested element under frame" do
       browser.goto(WatirSpec.url_for("nested_iframes.html"))
       element = browser.iframe(id: 'one').iframe(:id, 'three')
       error = 'unable to locate iframe using {:id=>"one", :tag_name=>"iframe"} --> {:id=>"three", :tag_name=>"iframe"}'
-      expect {element.wait_until_present(timeout: 0)}.to raise_exception(Exception::UnknownFrameException, error)
+      expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Exception::UnknownFrameException, error)
     end
   end
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -1,138 +1,141 @@
 require 'watirspec_helper'
 
-describe Watir::Element do
+module Watir
+  describe Element do
 
-  describe '#present?' do
-    before do
-      browser.goto(WatirSpec.url_for("wait.html"))
-    end
-
-    it 'returns true if the element exists and is visible' do
-      expect(browser.div(:id, 'foo')).to be_present
-    end
-
-    it 'returns false if the element exists but is not visible' do
-      expect(browser.div(:id, 'bar')).to_not be_present
-    end
-
-    it 'returns false if the element does not exist' do
-      expect(browser.div(:id, 'should-not-exist')).to_not be_present
-    end
-
-    it "returns false if the element is stale" do
-      wd_element = browser.div(id: "foo").wd
-
-      # simulate element going stale during lookup
-      allow(browser.driver).to receive(:find_element).with(:id, 'foo') { wd_element }
-      browser.refresh
-
-      expect(browser.div(:id, 'foo')).to_not be_present
-    end
-
-  end
-
-  describe "#enabled?" do
-    before do
-      browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
-    end
-
-    it "returns true if the element is enabled" do
-      expect(browser.element(name: 'new_user_submit')).to be_enabled
-    end
-
-    it "returns false if the element is disabled" do
-      expect(browser.element(name: 'new_user_submit_disabled')).to_not be_enabled
-    end
-
-    it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.element(name: "no_such_name").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
-    end
-  end
-
-  describe "#exists?" do
-    before do
-      browser.goto WatirSpec.url_for('removed_element.html')
-    end
-
-    it "relocates element from a collection when it becomes stale" do
-      watir_element = browser.divs(id: "text").first
-      expect(watir_element).to exist
-
-      browser.refresh
-
-      expect(watir_element).to exist
-    end
-
-    it "returns false when tag name does not match id" do
-      watir_element = browser.span(id: "text")
-      expect(watir_element).to_not exist
-    end
-  end
-
-  describe "#element_call" do
-
-    it 'handles exceptions when taking an action on an element that goes stale during execution' do
-      browser.goto WatirSpec.url_for('removed_element.html')
-
-      watir_element = browser.div(id: "text")
-
-        # simulate element going stale after assert_exists and before action taken, but not when block retried
-      allow(watir_element).to receive(:text) do
-        watir_element.send(:element_call) do
-          @already_stale ||= false
-          browser.refresh unless @already_stale
-          @already_stale = true
-          watir_element.instance_variable_get('@element').text
-        end
+    describe '#present?' do
+      before do
+        browser.goto(WatirSpec.url_for("wait.html"))
       end
 
-      expect { watir_element.text }.to_not raise_error
+      it 'returns true if the element exists and is visible' do
+        expect(browser.div(:id, 'foo')).to be_present
+      end
+
+      it 'returns false if the element exists but is not visible' do
+        expect(browser.div(:id, 'bar')).to_not be_present
+      end
+
+      it 'returns false if the element does not exist' do
+        expect(browser.div(:id, 'should-not-exist')).to_not be_present
+      end
+
+      it "returns false if the element is stale" do
+        wd_element = browser.div(id: "foo").wd
+
+        # simulate element going stale during lookup
+        allow(browser.driver).to receive(:find_element).with(:id, 'foo') { wd_element }
+        browser.refresh
+
+        expect(browser.div(:id, 'foo')).to_not be_present
+      end
+
     end
 
-  end
+    describe "#enabled?" do
+      before do
+        browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+      end
 
-  bug "Actions Endpoint Not Yet Implemented", :firefox do
-    describe "#hover" do
-      not_compliant_on :internet_explorer, :safari do
-        it "should hover over the element" do
-          browser.goto WatirSpec.url_for('hover.html')
-          link = browser.a
+      it "returns true if the element is enabled" do
+        expect(browser.element(name: 'new_user_submit')).to be_enabled
+      end
 
-          expect(link.style("font-size")).to eq "10px"
-          link.hover
-          expect(link.style("font-size")).to eq "20px"
+      it "returns false if the element is disabled" do
+        expect(browser.element(name: 'new_user_submit_disabled')).to_not be_enabled
+      end
+
+      it "raises UnknownObjectException if the element doesn't exist" do
+        expect { browser.element(name: "no_such_name").enabled? }.to raise_error(Exception::UnknownObjectException)
+      end
+    end
+
+    describe "#exists?" do
+      before do
+        browser.goto WatirSpec.url_for('removed_element.html')
+      end
+
+      it "relocates element from a collection when it becomes stale" do
+        watir_element = browser.divs(id: "text").first
+        expect(watir_element).to exist
+
+        browser.refresh
+
+        expect(watir_element).to exist
+      end
+
+      it "returns false when tag name does not match id" do
+        watir_element = browser.span(id: "text")
+        expect(watir_element).to_not exist
+      end
+    end
+
+    describe "#element_call" do
+
+      it 'handles exceptions when taking an action on an element that goes stale during execution' do
+        browser.goto WatirSpec.url_for('removed_element.html')
+
+        watir_element = browser.div(id: "text")
+
+          # simulate element going stale after assert_exists and before action taken, but not when block retried
+        allow(watir_element).to receive(:text) do
+          watir_element.send(:element_call) do
+            @already_stale ||= false
+            browser.refresh unless @already_stale
+            @already_stale = true
+            watir_element.instance_variable_get('@element').text
+          end
+        end
+
+        expect { watir_element.text }.to_not raise_error
+      end
+
+    end
+
+    bug "Actions Endpoint Not Yet Implemented", :firefox do
+      describe "#hover" do
+        not_compliant_on :internet_explorer, :safari do
+          it "should hover over the element" do
+            browser.goto WatirSpec.url_for('hover.html')
+            link = browser.a
+
+            expect(link.style("font-size")).to eq "10px"
+            link.hover
+            expect(link.style("font-size")).to eq "20px"
+          end
         end
       end
     end
-  end
 
-  describe "#selector_string" do
-    it "displays selector string for regular element" do
-      browser.goto(WatirSpec.url_for("wait.html"))
-      delegator = browser.div(:id, 'foo').when_present
-      message = delegator.instance_variable_get('@message')
-      expect(message).to eq 'waiting for {:id=>"foo", :tag_name=>"div"} to become present'
-    end
+    describe "#selector_string" do
+      it "displays selector string for regular element" do
+        browser.goto(WatirSpec.url_for("wait.html"))
+        delegator = browser.div(:id, 'foo').when_present
+        message = delegator.instance_variable_get('@message')
+        expect(message).to eq 'waiting for {:id=>"foo", :tag_name=>"div"} to become present'
+      end
 
-    it "displays selector string for element from colection" do
-      browser.goto(WatirSpec.url_for("wait.html"))
-      delegator = browser.divs.last.when_present
-      message = delegator.instance_variable_get('@message')
-      expect(message).to match /waiting for {:tag_name=>\"div\", :index=>3} to become present/
-    end
+      it "displays selector string for element from colection" do
+        browser.goto(WatirSpec.url_for("wait.html"))
+        element = browser.divs.last
+        error = 'required condition for {:tag_name=>"div", :index=>4} is not met'
+        expect {element.wait_until_present(timeout: 0)}.to raise_exception(TimeoutError, error)
+      end
 
-    it "displays selector string for nested element" do
-      browser.goto(WatirSpec.url_for("wait.html"))
-      delegator = browser.div(index: -1).div(:id, 'foo').when_present
-      message = delegator.instance_variable_get('@message')
-      expect(message).to eq 'waiting for {:index=>-1, :tag_name=>"div"} --> {:id=>"foo", :tag_name=>"div"} to become present'
-    end
+      it "displays selector string for nested element" do
+        browser.goto(WatirSpec.url_for("wait.html"))
+        element = browser.div(index: -1).div(:id, 'foo')
+        error = 'required condition for {:index=>-1, :tag_name=>"div"} --> {:id=>"foo", :tag_name=>"div"} is not met'
+        expect {element.wait_until_present(timeout: 0)}.to raise_exception(TimeoutError, error)
+      end
 
-    it "displays selector string for nested element under frame" do
-      browser.goto(WatirSpec.url_for("nested_iframes.html"))
-      delegator = browser.iframe(id: 'one').iframe(:id, 'three').when_present
-      message = delegator.instance_variable_get('@message')
-      expect(message).to eq 'waiting for {:id=>"one", :tag_name=>"iframe"} --> {:id=>"three", :tag_name=>"iframe"} to become present'
+      it "displays selector string for nested element under frame" do
+        browser.goto(WatirSpec.url_for("nested_iframes.html"))
+        element = browser.iframe(id: 'one').iframe(:id, 'three')
+        error = 'unable to locate iframe using {:id=>"one", :tag_name=>"iframe"} --> {:id=>"three", :tag_name=>"iframe"}'
+        expect {element.wait_until_present(timeout: 0)}.to raise_exception(Exception::UnknownFrameException, error)
+      end
+      end
     end
   end
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -76,11 +76,14 @@ describe Watir::Element do
 
       watir_element = browser.div(id: "text")
 
-        # simulate element going stale after assert_exists and before action taken
+        # simulate element going stale after assert_exists and before action taken, but not when block retried
       allow(watir_element).to receive(:text) do
-        watir_element.send :assert_exists
-        browser.refresh
-        watir_element.send(:element_call) { watir_element.instance_variable_get('@element').text }
+        watir_element.send(:element_call) do
+          @already_stale ||= false
+          browser.refresh unless @already_stale
+          @already_stale = true
+          watir_element.instance_variable_get('@element').text
+        end
       end
 
       expect { watir_element.text }.to_not raise_error

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,3 +26,34 @@ end
 if Selenium::WebDriver::Platform.linux? && ENV['DISPLAY'].nil?
   raise "DISPLAY not set"
 end
+
+TIMING_EXCEPTIONS = { raise_unknown_object_exception: Watir::Exception::UnknownObjectException,
+                      raise_no_matching_window_exception: Watir::Exception::NoMatchingWindowFoundException,
+                      raise_unknown_frame_exception: Watir::Exception::UnknownFrameException,
+                      raise_object_disabled_exception: Watir::Exception::ObjectDisabledException,
+                      raise_object_read_only_exception: Watir::Exception::ObjectReadOnlyException}
+
+TIMING_EXCEPTIONS.each do |matcher, exception|
+  RSpec::Matchers.define matcher do |_expected|
+    match do |actual|
+      original_timeout = Watir.default_timeout
+      Watir.default_timeout = 0
+      begin
+        actual.call
+        false
+      rescue exception
+        true
+      ensure
+        Watir.default_timeout = original_timeout
+      end
+    end
+
+    failure_message do |actual|
+      "expected #{exception} but nothing was raised"
+    end
+
+    def supports_block_expectations?
+      true
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,10 @@ require 'rspec'
 
 SELENIUM_SELECTORS = %i(class class_name css id tag_name xpath)
 
+if ENV['RELAXED_LOCATE'] == "false"
+  Watir.relaxed_locate = false
+end
+
 if ENV['TRAVIS']
   ENV['DISPLAY'] = ":99.0"
 

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -51,7 +51,9 @@ describe "Browser::AfterHooks" do
 
     it "runs after_hooks after Browser#refresh" do
       browser.goto WatirSpec.url_for("font.html")
-      @page_after_hook = Proc.new { @yield = browser.title == "The font element" }
+      @page_after_hook = Proc.new do
+        @yield = browser.title == "The font element"
+      end
       browser.after_hooks.add @page_after_hook
       browser.refresh
       expect(@yield).to be true
@@ -60,11 +62,10 @@ describe "Browser::AfterHooks" do
     it "runs after_hooks after Element#click" do
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
       @page_after_hook = Proc.new do
-        Watir::Wait.while { browser.title.empty? }
-        @yield = browser.title == "Non-control elements"
+        @yield = browser.title == "Forms with input elements"
       end
       browser.after_hooks.add @page_after_hook
-      browser.link(index: 1).click
+      browser.link(index: 2).click
       expect(@yield).to be true
     end
 

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -62,7 +62,8 @@ describe "Browser::AfterHooks" do
     it "runs after_hooks after Element#click" do
       browser.goto(WatirSpec.url_for("non_control_elements.html"))
       @page_after_hook = Proc.new do
-        @yield = browser.title == "Forms with input elements"
+        browser.wait_until { |b| b.title == "Forms with input elements" }
+        @yield = true
       end
       browser.after_hooks.add @page_after_hook
       browser.link(index: 2).click

--- a/spec/watirspec/alert_spec.rb
+++ b/spec/watirspec/alert_spec.rb
@@ -26,7 +26,7 @@ describe 'Alert API' do
 
           it 'returns true if alert is present' do
             browser.button(id: 'alert').click
-            browser.wait_until(10) { browser.alert.exists? }
+            browser.wait_until(timeout: 10) { browser.alert.exists? }
           end
         end
 

--- a/spec/watirspec/alert_spec.rb
+++ b/spec/watirspec/alert_spec.rb
@@ -52,14 +52,14 @@ describe 'Alert API' do
           describe 'when_present' do
             it 'waits until alert is present and goes on' do
               browser.button(id: 'timeout-alert').click
-              browser.alert.ok
+              browser.alert.when_present.ok
 
               expect(browser.alert).to_not exist
             end
 
             it 'raises error if alert is not present after timeout' do
               expect {
-                browser.alert.ok
+                browser.alert.when_present.ok
               }.to raise_error(Watir::Wait::TimeoutError)
             end
           end

--- a/spec/watirspec/alert_spec.rb
+++ b/spec/watirspec/alert_spec.rb
@@ -49,17 +49,17 @@ describe 'Alert API' do
         end
 
         not_compliant_on :relaxed_locate do
-          describe 'when_present' do
+          describe 'wait_until_present' do
             it 'waits until alert is present and goes on' do
               browser.button(id: 'timeout-alert').click
-              browser.alert.when_present.ok
+              browser.alert.wait_until_present.ok
 
               expect(browser.alert).to_not exist
             end
 
             it 'raises error if alert is not present after timeout' do
               expect {
-                browser.alert.when_present.ok
+                browser.alert.wait_until_present.ok
               }.to raise_error(Watir::Wait::TimeoutError)
             end
           end

--- a/spec/watirspec/alert_spec.rb
+++ b/spec/watirspec/alert_spec.rb
@@ -42,24 +42,26 @@ describe 'Alert API' do
           describe '#close' do
             it 'closes alert' do
               browser.button(id: 'alert').click
-              browser.alert.when_present.close
+              browser.alert.close
               expect(browser.alert).to_not exist
             end
           end
         end
 
-        describe 'when_present' do
-          it 'waits until alert is present and goes on' do
-            browser.button(id: 'timeout-alert').click
-            browser.alert.when_present.ok
+        not_compliant_on :relaxed_locate do
+          describe 'when_present' do
+            it 'waits until alert is present and goes on' do
+              browser.button(id: 'timeout-alert').click
+              browser.alert.ok
 
-            expect(browser.alert).to_not exist
-          end
+              expect(browser.alert).to_not exist
+            end
 
-          it 'raises error if alert is not present after timeout' do
-            expect {
-              browser.alert.when_present(0.1).ok
-            }.to raise_error(Watir::Wait::TimeoutError)
+            it 'raises error if alert is not present after timeout' do
+              expect {
+                browser.alert.ok
+              }.to raise_error(Watir::Wait::TimeoutError)
+            end
           end
         end
       end
@@ -76,7 +78,7 @@ describe 'Alert API' do
         describe '#close' do
           it 'cancels confirm' do
             browser.button(id: 'confirm').click
-            browser.alert.when_present.close
+            browser.alert.close
             expect(browser.button(id: 'confirm').value).to eq "false"
           end
         end

--- a/spec/watirspec/browser_spec.rb
+++ b/spec/watirspec/browser_spec.rb
@@ -285,7 +285,7 @@ describe "Browser" do
 
   it "raises UnknownObjectException when trying to access DOM elements on plain/text-page" do
     browser.goto(WatirSpec.url_for("plain_text"))
-    expect { browser.div(id: 'foo').id }.to raise_error(Watir::Exception::UnknownObjectException)
+    expect { browser.div(id: 'foo').id }.to raise_unknown_object_exception
   end
 
 end

--- a/spec/watirspec/elements/area_spec.rb
+++ b/spec/watirspec/elements/area_spec.rb
@@ -61,8 +61,8 @@ describe "Area" do
     end
 
     it "raises UnknownObjectException if the area doesn't exist" do
-      expect { browser.area(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.area(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.area(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.area(index: 1337).id }.to raise_unknown_object_exception
     end
 
   end

--- a/spec/watirspec/elements/button_spec.rb
+++ b/spec/watirspec/elements/button_spec.rb
@@ -104,7 +104,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      expect { browser.button(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -116,7 +116,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      expect { browser.button(name: "no_such_name").name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").name }.to raise_unknown_object_exception
     end
   end
 
@@ -127,7 +127,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      expect { browser.button(name: "no_such_name").src }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").src }.to raise_unknown_object_exception
     end
   end
 
@@ -149,7 +149,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the button does not exist" do
-      expect { browser.button(name: "no_such_name").style }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").style }.to raise_unknown_object_exception
     end
   end
 
@@ -171,7 +171,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      expect { browser.button(name: "no_such_name").type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").type }.to raise_unknown_object_exception
     end
   end
 
@@ -183,7 +183,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      expect { browser.button(name: "no_such_name").value }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").value }.to raise_unknown_object_exception
     end
   end
 
@@ -196,7 +196,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.button(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(id: "no_such_id").text }.to raise_unknown_object_exception
     end
   end
 
@@ -224,7 +224,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if the button doesn't exist" do
-      expect { browser.button(name: "no_such_name").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").enabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -238,7 +238,7 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException if button does not exist" do
-      expect { browser.button(name: "no_such_name").disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(name: "no_such_name").disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -257,12 +257,12 @@ describe "Button" do
     end
 
     it "raises UnknownObjectException when clicking a button that doesn't exist" do
-      expect { browser.button(value: "no_such_value").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.button(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.button(value: "no_such_value").click }.to raise_unknown_object_exception
+      expect { browser.button(id: "no_such_id").click }.to raise_unknown_object_exception
     end
 
     it "raises ObjectDisabledException when clicking a disabled button" do
-      expect { browser.button(value: "Disabled").click }.to raise_error(Watir::Exception::ObjectDisabledException)
+      expect { browser.button(value: "Disabled").click }.to raise_object_disabled_exception
     end
   end
 

--- a/spec/watirspec/elements/checkbox_spec.rb
+++ b/spec/watirspec/elements/checkbox_spec.rb
@@ -86,7 +86,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(id: "no_such_id").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -100,7 +100,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -114,7 +114,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -128,7 +128,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -138,7 +138,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -148,7 +148,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).value}.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).value}.to raise_unknown_object_exception
     end
   end
 
@@ -177,8 +177,8 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      expect { browser.checkbox(id: "no_such_id").enabled?  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").enabled?  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(id: "no_such_id").enabled?  }.to raise_unknown_object_exception
+      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").enabled?  }.to raise_unknown_object_exception
     end
   end
 
@@ -192,7 +192,7 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(index: 1337).disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -201,8 +201,8 @@ describe "CheckBox" do
   describe "#clear" do
     it "raises ObjectDisabledException if the checkbox is disabled" do
       expect(browser.checkbox(id: "new_user_interests_dentistry")).to_not be_set
-      expect { browser.checkbox(id: "new_user_interests_dentistry").clear }.to raise_error(Watir::Exception::ObjectDisabledException)
-      expect { browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']").clear }.to raise_error(Watir::Exception::ObjectDisabledException)
+      expect { browser.checkbox(id: "new_user_interests_dentistry").clear }.to raise_object_disabled_exception
+      expect { browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']").clear }.to raise_object_disabled_exception
     end
 
     it "clears the checkbox button if it is set" do
@@ -216,8 +216,8 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      expect { browser.checkbox(name: "no_such_id").clear }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").clear  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(name: "no_such_id").clear }.to raise_unknown_object_exception
+      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").clear  }.to raise_unknown_object_exception
     end
   end
 
@@ -241,13 +241,13 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      expect { browser.checkbox(name: "no_such_name").set  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.checkbox(xpath: "//input[@name='no_such_name']").set  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(name: "no_such_name").set  }.to raise_unknown_object_exception
+      expect { browser.checkbox(xpath: "//input[@name='no_such_name']").set  }.to raise_unknown_object_exception
     end
 
     it "raises ObjectDisabledException if the checkbox is disabled" do
-      expect { browser.checkbox(id: "new_user_interests_dentistry").set  }.to raise_error(Watir::Exception::ObjectDisabledException)
-      expect { browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']").set  }.to raise_error(Watir::Exception::ObjectDisabledException )
+      expect { browser.checkbox(id: "new_user_interests_dentistry").set  }.to raise_object_disabled_exception
+      expect { browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']").set  }.to raise_object_disabled_exception
     end
   end
 
@@ -271,8 +271,8 @@ describe "CheckBox" do
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do
-      expect { browser.checkbox(id: "no_such_id").set?  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").set?  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.checkbox(id: "no_such_id").set?  }.to raise_unknown_object_exception
+      expect { browser.checkbox(xpath: "//input[@id='no_such_id']").set?  }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/dd_spec.rb
+++ b/spec/watirspec/elements/dd_spec.rb
@@ -43,10 +43,10 @@ describe "Dd" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dd(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(xpath: "//dd[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dd(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.dd(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.dd(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.dd(xpath: "//dd[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -60,9 +60,9 @@ describe "Dd" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.dd(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dd(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dd(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.dd(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dd(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dd(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -82,10 +82,10 @@ describe "Dd" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dd(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(xpath: "//dd[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dd(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.dd(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.dd(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.dd(xpath: "//dd[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -108,10 +108,10 @@ describe "Dd" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dd(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dd(xpath: "//dd[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dd(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.dd(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.dd(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.dd(xpath: "//dd[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/del_spec.rb
+++ b/spec/watirspec/elements/del_spec.rb
@@ -54,7 +54,7 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -68,8 +68,8 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.del(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.del(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,8 +83,8 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.del(xpath: "//del[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.del(xpath: "//del[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -98,8 +98,8 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.del(:xpath , "//del[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.del(:xpath , "//del[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -121,8 +121,8 @@ describe "Del" do
     end
 
     it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.del(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.del(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.del(title: "no_such_title").click }.to raise_unknown_object_exception
     end
   end
 end

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -59,10 +59,10 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(xpath: "//div[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.div(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.div(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.div(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.div(xpath: "//div[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -76,9 +76,9 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.div(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.div(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.div(index: 1337).id }.to raise_unknown_object_exception
     end
 
     it "should take all conditions into account when locating by id" do
@@ -99,7 +99,7 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.div(id: "no_such_id").style }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.div(id: "no_such_id").style }.to raise_unknown_object_exception
     end
   end
 
@@ -119,10 +119,10 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(xpath: "//div[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.div(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.div(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.div(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.div(xpath: "//div[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -144,10 +144,10 @@ describe "Div" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.div(xpath: "//div[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.div(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.div(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.div(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.div(xpath: "//div[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/dl_spec.rb
+++ b/spec/watirspec/elements/dl_spec.rb
@@ -43,10 +43,10 @@ describe "Dl" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dl(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(xpath: "//dl[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dl(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.dl(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.dl(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.dl(xpath: "//dl[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -60,9 +60,9 @@ describe "Dl" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.dl(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dl(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dl(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.dl(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dl(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dl(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -82,10 +82,10 @@ describe "Dl" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dl(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(xpath: "//dl[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dl(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.dl(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.dl(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.dl(xpath: "//dl[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -108,10 +108,10 @@ describe "Dl" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dl(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dl(xpath: "//dl[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dl(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.dl(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.dl(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.dl(xpath: "//dl[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/dt_spec.rb
+++ b/spec/watirspec/elements/dt_spec.rb
@@ -43,10 +43,10 @@ describe "Dt" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dt(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(xpath: "//dt[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dt(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.dt(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.dt(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.dt(xpath: "//dt[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -60,9 +60,9 @@ describe "Dt" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.dt(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dt(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.dt(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.dt(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dt(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.dt(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -82,10 +82,10 @@ describe "Dt" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dt(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(xpath: "//dt[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dt(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.dt(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.dt(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.dt(xpath: "//dt[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -108,10 +108,10 @@ describe "Dt" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.dt(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.dt(xpath: "//dt[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.dt(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.dt(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.dt(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.dt(xpath: "//dt[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -13,7 +13,7 @@ describe "Element" do
     end
 
     it "raises UnknownObjectException with a sane error message when given a hash of :how => 'what' arguments (non-existing object)" do
-      expect { browser.text_field(index: 100, name: "foo").id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 100, name: "foo").id }.to raise_unknown_object_exception
     end
 
     it "raises ArgumentError if given the wrong number of arguments" do
@@ -198,7 +198,7 @@ describe "Element" do
     end
 
     it "raises UnknownObjectException exception if the element does not exist" do
-      expect {browser.text_field(id: "no_such_id").visible?}.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.text_field(id: "no_such_id").visible?}.to raise_unknown_object_exception
     end
 
     it "raises UnknownObjectException exception if the element is stale" do
@@ -208,7 +208,7 @@ describe "Element" do
       allow(browser.driver).to receive(:find_element).with(:id, 'new_user_email') { wd_element }
       browser.refresh
 
-      expect { browser.text_field(id: 'new_user_email').visible? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: 'new_user_email').visible? }.to raise_unknown_object_exception
     end
 
     it "returns true if the element has style='visibility: visible' even if parent has style='visibility: hidden'" do

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -108,7 +108,7 @@ describe "Element" do
     end
 
     it "finds several elements from an element's subtree" do
-      expect(browser.fieldset.elements(xpath: ".//label").length).to eq 20
+      expect(browser.fieldset.elements(xpath: ".//label").length).to eq 21
     end
   end
 

--- a/spec/watirspec/elements/em_spec.rb
+++ b/spec/watirspec/elements/em_spec.rb
@@ -39,10 +39,10 @@ describe "Em" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.em(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(title: "no_such_title").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(xpath: "//em[@id='no_such_id']").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.em(id: "no_such_id").class_name }.to raise_unknown_object_exception
+      expect { browser.em(title: "no_such_title").class_name }.to raise_unknown_object_exception
+      expect { browser.em(index: 1337).class_name }.to raise_unknown_object_exception
+      expect { browser.em(xpath: "//em[@id='no_such_id']").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -52,9 +52,9 @@ describe "Em" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect {browser.em(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.em(title: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect {browser.em(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect {browser.em(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.em(title: "no_such_id").id }.to raise_unknown_object_exception
+      expect {browser.em(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -70,10 +70,10 @@ describe "Em" do
     end
 
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.em(id: "no_such_id").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(title: "no_such_title").text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(xpath: "//em[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.em(id: "no_such_id").text }.to raise_unknown_object_exception
+      expect { browser.em(title: "no_such_title").text }.to raise_unknown_object_exception
+      expect { browser.em(index: 1337).text }.to raise_unknown_object_exception
+      expect { browser.em(xpath: "//em[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -90,10 +90,10 @@ describe "Em" do
   # Manipulation methods
   describe "#click" do
     it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.em(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.em(xpath: "//em[@id='no_such_id']").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.em(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.em(title: "no_such_title").click }.to raise_unknown_object_exception
+      expect { browser.em(index: 1337).click }.to raise_unknown_object_exception
+      expect { browser.em(xpath: "//em[@id='no_such_id']").click }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/filefield_spec.rb
+++ b/spec/watirspec/elements/filefield_spec.rb
@@ -54,7 +54,7 @@ describe "FileField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.file_field(index: 1337).class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -64,7 +64,7 @@ describe "FileField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.file_field(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -74,7 +74,7 @@ describe "FileField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.file_field(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -90,7 +90,7 @@ describe "FileField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.file_field(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/frame_spec.rb
+++ b/spec/watirspec/elements/frame_spec.rb
@@ -72,19 +72,19 @@ describe "Frame" do
   end
 
   it "raises UnknownFrameException when accessing elements inside non-existing frame" do
-    expect { browser.frame(name: "no_such_name").p(index: 0).id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.frame(name: "no_such_name").p(index: 0).id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownFrameException when accessing a non-existing frame" do
-    expect { browser.frame(name: "no_such_name").id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.frame(name: "no_such_name").id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownFrameException when accessing a non-existing subframe" do
-    expect { browser.frame(name: "frame1").frame(name: "no_such_name").id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.frame(name: "frame1").frame(name: "no_such_name").id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownObjectException when accessing a non-existing element inside an existing frame" do
-    expect { browser.frame(index: 0).p(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+    expect { browser.frame(index: 0).p(index: 1337).id }.to raise_unknown_object_exception
   end
 
   it "raises NoMethodError when trying to access attributes it doesn't have" do

--- a/spec/watirspec/elements/hidden_spec.rb
+++ b/spec/watirspec/elements/hidden_spec.rb
@@ -56,7 +56,7 @@ describe "Hidden" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.hidden(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.hidden(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -66,7 +66,7 @@ describe "Hidden" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.hidden(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.hidden(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -76,7 +76,7 @@ describe "Hidden" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.hidden(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.hidden(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -86,7 +86,7 @@ describe "Hidden" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.hidden(index: 1337).value }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.hidden(index: 1337).value }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/hn_spec.rb
+++ b/spec/watirspec/elements/hn_spec.rb
@@ -51,7 +51,7 @@ describe ["H1", "H2", "H3", "H4", "H5", "H6"] do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.h2(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.h2(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -65,8 +65,8 @@ describe ["H1", "H2", "H3", "H4", "H5", "H6"] do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.h1(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.h1(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.h1(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.h1(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -80,8 +80,8 @@ describe ["H1", "H2", "H3", "H4", "H5", "H6"] do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.h1(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.h1(:xpath , "//h1[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.h1(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.h1(:xpath , "//h1[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -122,19 +122,19 @@ describe "IFrame" do
   end
 
   it "raises UnknownFrameException when accessing elements inside non-existing iframe" do
-    expect { browser.iframe(name: "no_such_name").p(index: 0).id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.iframe(name: "no_such_name").p(index: 0).id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownFrameException when accessing a non-existing iframe" do
-    expect { browser.iframe(name: "no_such_name").id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.iframe(name: "no_such_name").id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownFrameException when accessing a non-existing subframe" do
-    expect { browser.iframe(name: "iframe1").iframe(name: "no_such_name").id }.to raise_error(Watir::Exception::UnknownFrameException)
+    expect { browser.iframe(name: "iframe1").iframe(name: "no_such_name").id }.to raise_unknown_frame_exception
   end
 
   it "raises UnknownObjectException when accessing a non-existing element inside an existing iframe" do
-    expect { browser.iframe(index: 0).p(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+    expect { browser.iframe(index: 0).p(index: 1337).id }.to raise_unknown_object_exception
   end
 
   it "raises NoMethodError when trying to access attributes it doesn't have" do

--- a/spec/watirspec/elements/image_spec.rb
+++ b/spec/watirspec/elements/image_spec.rb
@@ -54,7 +54,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).alt }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).alt }.to raise_unknown_object_exception
     end
   end
 
@@ -68,7 +68,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -82,7 +82,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).src }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).src }.to raise_unknown_object_exception
     end
   end
 
@@ -96,7 +96,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -112,10 +112,10 @@ describe "Image" do
   # Manipulation methods
   describe "#click" do
     it "raises UnknownObjectException when the image doesn't exist" do
-      expect { browser.image(id: 'missing_attribute').click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(class: 'missing_attribute').click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(src: 'missing_attribute').click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.image(alt: 'missing_attribute').click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(id: 'missing_attribute').click }.to raise_unknown_object_exception
+      expect { browser.image(class: 'missing_attribute').click }.to raise_unknown_object_exception
+      expect { browser.image(src: 'missing_attribute').click }.to raise_unknown_object_exception
+      expect { browser.image(alt: 'missing_attribute').click }.to raise_unknown_object_exception
     end
   end
 
@@ -125,7 +125,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).height }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).height }.to raise_unknown_object_exception
     end
   end
 
@@ -135,7 +135,7 @@ describe "Image" do
     end
 
     it "raises UnknownObjectException if the image doesn't exist" do
-      expect { browser.image(index: 1337).width }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.image(index: 1337).width }.to raise_unknown_object_exception
     end
   end
 
@@ -153,10 +153,10 @@ describe "Image" do
       end
 
       it "raises UnknownObjectException if the image doesn't exist" do
-        expect { browser.image(id: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-        expect { browser.image(src: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-        expect { browser.image(alt: 'no_such_image').loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
-        expect { browser.image(index: 1337).loaded? }.to raise_error(Watir::Exception::UnknownObjectException)
+        expect { browser.image(id: 'no_such_image').loaded? }.to raise_unknown_object_exception
+        expect { browser.image(src: 'no_such_image').loaded? }.to raise_unknown_object_exception
+        expect { browser.image(alt: 'no_such_image').loaded? }.to raise_unknown_object_exception
+        expect { browser.image(index: 1337).loaded? }.to raise_unknown_object_exception
       end
     end
   end

--- a/spec/watirspec/elements/ins_spec.rb
+++ b/spec/watirspec/elements/ins_spec.rb
@@ -54,7 +54,7 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -68,8 +68,8 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ins(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.ins(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,8 +83,8 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ins(xpath: "//ins[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.ins(xpath: "//ins[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -98,8 +98,8 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ins(:xpath , "//ins[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.ins(:xpath , "//ins[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -121,8 +121,8 @@ describe "Ins" do
     end
 
     it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ins(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ins(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.ins(title: "no_such_title").click }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/label_spec.rb
+++ b/spec/watirspec/elements/label_spec.rb
@@ -55,7 +55,7 @@ describe "Label" do
     end
 
     it "raises UnknownObjectException if the label doesn't exist" do
-      expect { browser.label(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.label(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -65,7 +65,7 @@ describe "Label" do
     end
 
     it "raises UnknownObjectException if the label doesn't exist" do
-      expect { browser.label(index: 1337).for }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.label(index: 1337).for }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/labels_spec.rb
+++ b/spec/watirspec/elements/labels_spec.rb
@@ -14,7 +14,7 @@ describe "Labels" do
 
   describe "#length" do
     it "returns the number of labels" do
-      expect(browser.labels.length).to eq 38
+      expect(browser.labels.length).to eq 39
     end
   end
 

--- a/spec/watirspec/elements/li_spec.rb
+++ b/spec/watirspec/elements/li_spec.rb
@@ -54,7 +54,7 @@ describe "Li" do
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.li(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -68,8 +68,8 @@ describe "Li" do
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.li(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.li(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.li(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,8 +83,8 @@ describe "Li" do
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.li(xpath: "//li[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.li(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.li(xpath: "//li[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -98,8 +98,8 @@ describe "Li" do
     end
 
     it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.li(:xpath , "//li[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.li(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.li(:xpath , "//li[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -64,7 +64,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -78,7 +78,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).href }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).href }.to raise_unknown_object_exception
     end
   end
 
@@ -98,7 +98,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -112,7 +112,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).text }.to raise_unknown_object_exception
     end
   end
 
@@ -126,7 +126,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -159,7 +159,7 @@ describe "Link" do
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.link(index: 1337).click }.to raise_unknown_object_exception
     end
 
     it "clicks a link with no text content but an img child" do

--- a/spec/watirspec/elements/map_spec.rb
+++ b/spec/watirspec/elements/map_spec.rb
@@ -50,8 +50,8 @@ describe "Map" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.map(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.map(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.map(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.map(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -65,8 +65,8 @@ describe "Map" do
     end
 
     it "raises UnknownObjectException if the map doesn't exist" do
-      expect { browser.map(id: "no_such_id").name }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.map(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.map(id: "no_such_id").name }.to raise_unknown_object_exception
+      expect { browser.map(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/ol_spec.rb
+++ b/spec/watirspec/elements/ol_spec.rb
@@ -61,7 +61,7 @@ describe "Ol" do
     end
 
     it "raises UnknownObjectException if the ol doesn't exist" do
-      expect { browser.ol(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ol(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -75,8 +75,8 @@ describe "Ol" do
     end
 
     it "raises UnknownObjectException if the ol doesn't exist" do
-      expect { browser.ol(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ol(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ol(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.ol(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/option_spec.rb
+++ b/spec/watirspec/elements/option_spec.rb
@@ -113,13 +113,13 @@ describe "Option" do
     end
 
     it "raises UnknownObjectException if the option does not exist (page context)" do
-      expect { browser.option(text: "no_such_text").select }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.option(text: /missing/).select }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.option(text: "no_such_text").select }.to raise_unknown_object_exception
+      expect { browser.option(text: /missing/).select }.to raise_unknown_object_exception
     end
 
     it "raises UnknownObjectException if the option does not exist (select_list context)" do
-      expect { browser.select_list(name: "new_user_country").option(text: "no_such_text").select }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.select_list(name: "new_user_country").option(text: /missing/).select }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: "new_user_country").option(text: "no_such_text").select }.to raise_unknown_object_exception
+      expect { browser.select_list(name: "new_user_country").option(text: /missing/).select }.to raise_unknown_object_exception
     end
 
     it "raises MissingWayOfFindingObjectException when given a bad 'how' (page context)" do

--- a/spec/watirspec/elements/p_spec.rb
+++ b/spec/watirspec/elements/p_spec.rb
@@ -54,7 +54,7 @@ describe "P" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.p(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -68,8 +68,8 @@ describe "P" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.p(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.p(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.p(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,8 +83,8 @@ describe "P" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.p(xpath: "//p[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.p(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.p(xpath: "//p[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -98,8 +98,8 @@ describe "P" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.p(:xpath , "//p[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.p(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.p(:xpath , "//p[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/pre_spec.rb
+++ b/spec/watirspec/elements/pre_spec.rb
@@ -54,7 +54,7 @@ describe "Pre" do
     end
 
     it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.pre(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.pre(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -68,8 +68,8 @@ describe "Pre" do
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      expect { browser.pre(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.pre(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.pre(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.pre(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,8 +83,8 @@ describe "Pre" do
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      expect { browser.pre(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.pre(xpath: "//pre[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.pre(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.pre(xpath: "//pre[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -98,8 +98,8 @@ describe "Pre" do
     end
 
     it "raises UnknownObjectException if the pre doesn't exist" do
-      expect { browser.pre(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.pre(:xpath , "//pre[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.pre(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.pre(:xpath , "//pre[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/radio_spec.rb
+++ b/spec/watirspec/elements/radio_spec.rb
@@ -84,7 +84,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(id: "no_such_id").class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(id: "no_such_id").class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -98,7 +98,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -112,7 +112,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -126,7 +126,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -136,7 +136,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -146,7 +146,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).value}.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).value}.to raise_unknown_object_exception
     end
   end
 
@@ -174,8 +174,8 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      expect { browser.radio(id: "no_such_id").enabled?  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.radio(xpath: "//input[@id='no_such_id']").enabled?  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(id: "no_such_id").enabled?  }.to raise_unknown_object_exception
+      expect { browser.radio(xpath: "//input[@id='no_such_id']").enabled?  }.to raise_unknown_object_exception
     end
   end
 
@@ -189,7 +189,7 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(index: 1337).disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -226,13 +226,13 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      expect { browser.radio(name: "no_such_name").set  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.radio(xpath: "//input[@name='no_such_name']").set  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(name: "no_such_name").set  }.to raise_unknown_object_exception
+      expect { browser.radio(xpath: "//input[@name='no_such_name']").set  }.to raise_unknown_object_exception
     end
 
     it "raises ObjectDisabledException if the radio is disabled" do
-      expect { browser.radio(id: "new_user_newsletter_nah").set  }.to raise_error(Watir::Exception::ObjectDisabledException)
-      expect { browser.radio(xpath: "//input[@id='new_user_newsletter_nah']").set  }.to raise_error(Watir::Exception::ObjectDisabledException )
+      expect { browser.radio(id: "new_user_newsletter_nah").set  }.to raise_object_disabled_exception
+      expect { browser.radio(xpath: "//input[@id='new_user_newsletter_nah']").set  }.to raise_object_disabled_exception
     end
   end
 
@@ -255,8 +255,8 @@ describe "Radio" do
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      expect { browser.radio(id: "no_such_id").set?  }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.radio(xpath: "//input[@id='no_such_id']").set?  }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.radio(id: "no_such_id").set?  }.to raise_unknown_object_exception
+      expect { browser.radio(xpath: "//input[@id='no_such_id']").set?  }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -54,7 +54,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'no_such_name').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -64,7 +64,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -74,7 +74,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -85,7 +85,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).multiple? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).multiple? }.to raise_unknown_object_exception
     end
   end
 
@@ -99,7 +99,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).value }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).value }.to raise_unknown_object_exception
     end
   end
 
@@ -123,7 +123,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select_list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'no_such_name').enabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -137,7 +137,7 @@ describe "SelectList" do
     end
 
     it "should raise UnknownObjectException when the select list does not exist" do
-      expect { browser.select_list(index: 1337).disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -159,7 +159,7 @@ describe "SelectList" do
 
   describe "#selected_options" do
     it "should raise UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').selected_options }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'no_such_name').selected_options }.to raise_unknown_object_exception
     end
 
     it "gets the currently selected item(s)" do
@@ -185,7 +185,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').clear }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'no_such_name').clear }.to raise_unknown_object_exception
     end
 
     not_compliant_on :safari do
@@ -243,7 +243,7 @@ describe "SelectList" do
     end
 
     it "raises UnknownObjectException if the option doesn't exist" do
-      expect { browser.select_list(name: 'new_user_country').selected?('missing_option') }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.select_list(name: 'new_user_country').selected?('missing_option') }.to raise_unknown_object_exception
     end
   end
 
@@ -346,7 +346,7 @@ describe "SelectList" do
     end
 
     it "raises ObjectDisabledException if the option is disabled" do
-      expect { browser.select_list(name: "new_user_languages").select("Russian") }.to raise_error(Watir::Exception::ObjectDisabledException)
+      expect { browser.select_list(name: "new_user_languages").select("Russian") }.to raise_object_disabled_exception
     end
 
     it "raises a TypeError if argument is not a String, Regexp or Numeric" do

--- a/spec/watirspec/elements/span_spec.rb
+++ b/spec/watirspec/elements/span_spec.rb
@@ -54,7 +54,7 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -68,8 +68,8 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.span(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.span(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -83,8 +83,8 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: 'no_such_id').title }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.span(xpath: "//span[@id='no_such_id']").title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: 'no_such_id').title }.to raise_unknown_object_exception
+      expect { browser.span(xpath: "//span[@id='no_such_id']").title }.to raise_unknown_object_exception
     end
   end
 
@@ -98,8 +98,8 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.span(:xpath , "//span[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.span(:xpath , "//span[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 
@@ -121,8 +121,8 @@ describe "Span" do
     end
 
     it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: "no_such_id").click }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.span(title: "no_such_title").click }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.span(id: "no_such_id").click }.to raise_unknown_object_exception
+      expect { browser.span(title: "no_such_title").click }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/strong_spec.rb
+++ b/spec/watirspec/elements/strong_spec.rb
@@ -54,7 +54,7 @@ describe "Strong" do
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.strong(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.strong(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -64,8 +64,8 @@ describe "Strong" do
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.strong(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.strong(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.strong(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.strong(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -75,8 +75,8 @@ describe "Strong" do
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.strong(id: 'no_such_id').text }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.strong(:xpath , "//strong[@id='no_such_id']").text }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.strong(id: 'no_such_id').text }.to raise_unknown_object_exception
+      expect { browser.strong(:xpath , "//strong[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/text_field_spec.rb
+++ b/spec/watirspec/elements/text_field_spec.rb
@@ -87,7 +87,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 
@@ -97,7 +97,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).name }.to raise_unknown_object_exception
     end
   end
 
@@ -107,7 +107,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).title }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).title }.to raise_unknown_object_exception
     end
   end
 
@@ -125,7 +125,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).type }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -137,7 +137,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).value }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).value }.to raise_unknown_object_exception
     end
   end
 
@@ -164,7 +164,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: "no_such_id").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: "no_such_id").enabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -178,7 +178,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(index: 1337).disabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -195,7 +195,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: 'no_such_id').readonly? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: 'no_such_id').readonly? }.to raise_unknown_object_exception
     end
   end
 
@@ -212,15 +212,15 @@ describe "TextField" do
     end
 
     it "raises ObjectReadOnlyException if the object is read only" do
-      expect { browser.text_field(id: "new_user_code").append("Append This") }.to raise_error(Watir::Exception::ObjectReadOnlyException)
+      expect { browser.text_field(id: "new_user_code").append("Append This") }.to raise_object_read_only_exception
     end
 
     it "raises ObjectDisabledException if the object is disabled" do
-      expect { browser.text_field(name: "new_user_species").append("Append This") }.to raise_error(Watir::Exception::ObjectDisabledException)
+      expect { browser.text_field(name: "new_user_species").append("Append This") }.to raise_object_disabled_exception
     end
 
     it "raises UnknownObjectException if the object doesn't exist" do
-      expect { browser.text_field(name: "no_such_name").append("Append This") }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(name: "no_such_name").append("Append This") }.to raise_unknown_object_exception
     end
   end
 
@@ -233,12 +233,12 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: "no_such_id").clear }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: "no_such_id").clear }.to raise_unknown_object_exception
     end
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1200366", :firefox do
       it "raises ObjectReadOnlyException if the object is read only" do
-        expect { browser.text_field(id: "new_user_code").clear }.to raise_error(Watir::Exception::ObjectReadOnlyException)
+        expect { browser.text_field(id: "new_user_code").clear }.to raise_object_read_only_exception
       end
     end
   end
@@ -260,7 +260,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(name: "no_such_name").value = 'yo' }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(name: "no_such_name").value = 'yo' }.to raise_unknown_object_exception
     end
   end
 
@@ -296,7 +296,7 @@ describe "TextField" do
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.text_field(id: "no_such_id").set('secret') }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.text_field(id: "no_such_id").set('secret') }.to raise_unknown_object_exception
     end
   end
 end

--- a/spec/watirspec/elements/text_fields_spec.rb
+++ b/spec/watirspec/elements/text_fields_spec.rb
@@ -14,7 +14,7 @@ describe "TextFields" do
 
   describe "#length" do
     it "returns the number of text fields" do
-      expect(browser.text_fields.length).to eq 18
+      expect(browser.text_fields.length).to eq 19
     end
   end
 

--- a/spec/watirspec/elements/ul_spec.rb
+++ b/spec/watirspec/elements/ul_spec.rb
@@ -50,7 +50,7 @@ describe "Ul" do
     end
 
     it "raises UnknownObjectException if the ul doesn't exist" do
-      expect { browser.ul(id: 'no_such_id').class_name }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ul(id: 'no_such_id').class_name }.to raise_unknown_object_exception
     end
   end
 
@@ -64,8 +64,8 @@ describe "Ul" do
     end
 
     it "raises UnknownObjectException if the ul doesn't exist" do
-      expect { browser.ul(id: "no_such_id").id }.to raise_error(Watir::Exception::UnknownObjectException)
-      expect { browser.ul(index: 1337).id }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.ul(id: "no_such_id").id }.to raise_unknown_object_exception
+      expect { browser.ul(index: 1337).id }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -43,6 +43,8 @@
             <input type="text" name="new_user_species" id="new_user_species" value="Homo sapiens sapiens" disabled="disabled" /> <br />
             <label for="new_user_code">Personal code</label>
             <input type="text" title="Your personal code" name="new_user_code" id="new_user_code" value="HE2FF8" readonly="readonly" /> <br  />
+            <label for="good_luck">Good Luck</label>
+            <input type="text" title="Good Luck" name="good_luck" id="good_luck" disabled="disabled" readonly="readonly" /> <br  />
             <input type="col" id="unknown_text_field" /> <br />
             <label for="new_user_languages">Languages</label>
             <select name="new_user_languages" id="new_user_languages" multiple="multiple" onchange="WatirSpec.addMessage('changed language');">

--- a/spec/watirspec/html/wait.html
+++ b/spec/watirspec/html/wait.html
@@ -38,6 +38,8 @@
         show and enable btn
       </a>
     </div>
-    <div id="also_hidden" style="display:block;"></div>
+    <div id="also_hidden" style="display:none;">
+      <div id="hidden_child">Nothing to see here</div>
+    </div>
   </body>
 </html>

--- a/spec/watirspec/html/wait.html
+++ b/spec/watirspec/html/wait.html
@@ -3,9 +3,28 @@
   <head>
     <title>wait test</title>
     <script type="text/javascript" charset="utf-8">
+
+      function setTimeoutAddDisplay(id, current_id, timeout) {
+          setTimeoutAdd(id, "none", id, current_id, timeout);
+          setTimeoutDisplay(id, "block", timeout*2)
+      }
+
       function setTimeoutDisplay(id, display, timeout) {
           setTimeout(function() {
               document.getElementById(id).style.display = display;
+          }, timeout);
+      }
+
+      function setTimeoutAdd(id, display, text, existing_id, timeout) {
+          var newDiv = document.createElement("div");
+          newDiv.setAttribute("id", id);
+          newDiv.style.display = display;
+          newDiv.appendChild(document.createTextNode(text));
+
+          var currentDiv = document.getElementById(existing_id);
+
+          setTimeout(function() {
+              document.body.insertBefore(newDiv, currentDiv);
           }, timeout);
       }
 
@@ -30,6 +49,7 @@
     <a id="show_bar" href="#" onclick="setTimeoutDisplay('bar', 'block', 500);">show bar</a>
     <a id="hide_foo" href="#" onclick="setTimeoutDisplay('foo', 'none', 500);">hide foo</a>
     <a id="remove_foo" href="#" onclick="setTimeoutRemove('foo', 1000);">remove foo</a>
+    <a id="add_foobar" href="#" onclick="setTimeoutAddDisplay('foobar', 'bar', 1000);">add foobar</a>
     <div id="buttons">
       <button id="btn" type="button" onclick="setDisabled('btn', true, 0)" disabled>Click To Disable!</button>
       <a id="enable_btn" href="#" onclick="setDisabled('btn', false, 500);">enable btn</a>

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -1,0 +1,206 @@
+require "watirspec_helper"
+
+module Watir
+  describe '#relaxed_locate?' do
+    not_compliant_on :not_relaxed_locate do
+      context 'when true' do
+        before :each do
+          browser.goto(WatirSpec.url_for("wait.html"))
+        end
+
+        context 'when acting on an element that is never present' do
+          it 'raises exception after timing out' do
+            begin
+              time_out = 2
+              Watir.default_timeout = time_out
+              element = browser.link(id: 'not_there')
+              start_time = ::Time.now
+              expect { element.click }.to raise_exception(Exception::UnknownObjectException)
+              expect(::Time.now - start_time).to be > time_out
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+        end
+
+        context 'when acting on an element that is already present' do
+          it 'does not wait' do
+            start_time = ::Time.now
+            expect { browser.link.click }.to_not raise_exception
+            expect(::Time.now - start_time).to be < 1
+          end
+        end
+
+        context 'when acting on an element that eventually becomes present' do
+          it 'waits to take action' do
+            start_time = ::Time.now
+            browser.a(id: 'show_bar').click
+            expect { browser.div(id: 'bar').click }.to_not raise_exception
+            expect(::Time.now - start_time).to be < Watir.default_timeout
+          end
+        end
+
+        context 'when evaluating order of failure precedence' do
+          it 'fails first for parent not existing' do
+            begin
+              Watir.default_timeout = 0
+              selector = "{:id=>\"no_parent\", :tag_name=>\"div\"}"
+              element = browser.div(id: 'no_parent').div(id: 'no_child')
+              error = Watir::Exception::UnknownObjectException
+              message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
+              expect { element.click }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for child not existing if parent exists' do
+            begin
+              Watir.default_timeout = 0
+              selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"no_child\", :tag_name=>\"div\"}"
+              element = browser.div(id: 'buttons').div(id: 'no_child')
+              error = Watir::Exception::UnknownObjectException
+              message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
+              expect { element.click }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for parent not present if child exists' do
+            begin
+              Watir.default_timeout = 0.5
+              selector = "{:id=>\"also_hidden\", :tag_name=>\"div\"}"
+              element = browser.div(id: 'also_hidden').div(id: 'hidden_child')
+              error = Watir::Exception::UnknownObjectException
+              message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+              expect { element.click }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for child not present if parent is present' do
+            begin
+              Watir.default_timeout = 0.5
+              selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"btn2\", :tag_name=>\"button\"}"
+              element = browser.div(id: 'buttons').button(id: 'btn2')
+              error = Watir::Exception::UnknownObjectException
+              message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+              expect { element.click }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for element not enabled if present' do
+            browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+            begin
+              Watir.default_timeout = 0.5
+              selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"good_luck\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
+              element = browser.form(id: 'new_user').text_field(id: 'good_luck')
+              error = Watir::Exception::ObjectDisabledException
+              message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be enabled"
+              expect { element.set('foo') }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+
+          it 'fails for element being readonly if enabled' do
+            browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+            begin
+              Watir.default_timeout = 0.5
+              selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"new_user_code\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
+              element = browser.form(id: 'new_user').text_field(id: 'new_user_code')
+              error = Watir::Exception::ObjectReadOnlyException
+              message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to not be readonly"
+              expect { element.set('foo') }.to raise_exception(error, message)
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+        end
+
+        it 'gives warning when rescuing for flow control' do
+          begin
+            Watir.default_timeout = 1
+            element = browser.link(id: 'not_there')
+            message = "This test has slept for the duration of the default timeout. If your test is passing, consider using Element#exists? instead of rescuing this error\n"
+            expect do
+              begin
+                element.click
+              rescue Exception::UnknownObjectException
+              end
+            end.to output(message).to_stderr
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'ensures all checks happen once even if time has expired' do
+          begin
+            Watir.default_timeout = -1
+            expect { browser.link.click }.to_not raise_exception
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'ensures that the same timeout is used for all of the calls' do
+          begin
+            Watir.default_timeout = 1
+            start_time = ::Time.now
+            browser.a(id: 'show_bar').click
+            expect { browser.div(id: 'bar').div(id: 'not_there').click }.to raise_exception
+            finish_time = ::Time.now - start_time
+            expect(finish_time).to be > Watir.default_timeout
+            expect(finish_time).to be < 2 * Watir.default_timeout
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+      end
+    end
+
+    not_compliant_on :relaxed_locate do
+      context 'when false' do
+        before :each do
+          browser.goto(WatirSpec.url_for("wait.html"))
+        end
+
+        context 'when acting on an element that is never present' do
+          it 'raises exception immediately' do
+            begin
+              time_out = 2
+              Watir.default_timeout = time_out
+              element = browser.link(id: 'not_there')
+              start_time = ::Time.now
+              expect { element.click }.to raise_exception(Exception::UnknownObjectException)
+              expect(::Time.now - start_time).to be < 1
+            ensure
+              Watir.default_timeout = 30
+            end
+          end
+        end
+
+        context 'when acting on an element that eventually becomes present' do
+          it 'raises exception immediately' do
+            start_time = ::Time.now
+            browser.a(id: 'show_bar').click
+            expect { browser.div(id: 'bar').click }.to raise_exception(Selenium::WebDriver::Error::ElementNotVisibleError)
+            expect(::Time.now - start_time).to be < 1
+          end
+        end
+
+        it 'receives a warning for using #when_present' do
+          message = /#when_present would likely be unnecessary if Watir#relaxed_locate\? were set to true/
+          browser.a(id: 'show_bar').click
+          expect do
+            browser.div(id: 'bar').when_present.click
+          end.to output(message).to_stderr
+        end
+      end
+    end
+  end
+end

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -24,18 +24,28 @@ describe 'Watir#relaxed_locate?' do
 
       context 'when acting on an element that is already present' do
         it 'does not wait' do
-          start_time = ::Time.now
-          expect { browser.link.click }.to_not raise_exception
-          expect(::Time.now - start_time).to be < 1
+          begin
+            Watir.default_timeout = 2
+            start_time = ::Time.now
+            expect { browser.link.click }.to_not raise_exception
+            expect(::Time.now - start_time).to be < 2
+          ensure
+            Watir.default_timeout = 30
+          end
         end
       end
 
       context 'when acting on an element that eventually becomes present' do
-        it 'waits to take action' do
-          start_time = ::Time.now
-          browser.a(id: 'show_bar').click
-          expect { browser.div(id: 'bar').click }.to_not raise_exception
-          expect(::Time.now - start_time).to be < Watir.default_timeout
+        it 'waits until present and then takes action' do
+          begin
+            Watir.default_timeout = 3
+            start_time = ::Time.now
+            browser.a(id: 'show_bar').click
+            expect { browser.div(id: 'bar').click }.to_not raise_exception
+            expect(::Time.now - start_time).to be < 3
+          ensure
+            Watir.default_timeout = 30
+          end
         end
       end
 

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -126,7 +126,9 @@ module Watir
           begin
             Watir.default_timeout = 1
             element = browser.link(id: 'not_there')
-            message = "This test has slept for the duration of the default timeout. If your test is passing, consider using Element#exists? instead of rescuing this error\n"
+            message = "This code has slept for the duration of the default timeout "
+            message << "waiting for an Element to exist. If the test is still passing, "
+            message << "consider using Element#exists? instead of rescuing UnknownObjectException\n"
             expect do
               begin
                 element.click
@@ -149,7 +151,7 @@ module Watir
 
         it 'ensures that the same timeout is used for all of the calls' do
           begin
-            Watir.default_timeout = 1
+            Watir.default_timeout = 2
             start_time = ::Time.now
             browser.a(id: 'show_bar').click
             expect { browser.div(id: 'bar').div(id: 'not_there').click }.to raise_exception
@@ -194,7 +196,7 @@ module Watir
         end
 
         it 'receives a warning for using #when_present' do
-          message = /#when_present would likely be unnecessary if Watir#relaxed_locate\? were set to true/
+          message = /#when_present has been deprecated and is unlikely to be needed; replace this with #wait_until_present if a wait is still needed/
           browser.a(id: 'show_bar').click
           expect do
             browser.div(id: 'bar').when_present.click

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -1,205 +1,203 @@
 require "watirspec_helper"
 
-module Watir
-  describe '#relaxed_locate?' do
-    not_compliant_on :not_relaxed_locate do
-      context 'when true' do
-        before :each do
-          browser.goto(WatirSpec.url_for("wait.html"))
-        end
+describe 'Watir#relaxed_locate?' do
+  not_compliant_on :not_relaxed_locate do
+    context 'when true' do
+      before :each do
+        browser.goto(WatirSpec.url_for("wait.html"))
+      end
 
-        context 'when acting on an element that is never present' do
-          it 'raises exception after timing out' do
-            begin
-              time_out = 2
-              Watir.default_timeout = time_out
-              element = browser.link(id: 'not_there')
-              start_time = ::Time.now
-              expect { element.click }.to raise_exception(Exception::UnknownObjectException)
-              expect(::Time.now - start_time).to be > time_out
-            ensure
-              Watir.default_timeout = 30
-            end
-          end
-        end
-
-        context 'when acting on an element that is already present' do
-          it 'does not wait' do
-            start_time = ::Time.now
-            expect { browser.link.click }.to_not raise_exception
-            expect(::Time.now - start_time).to be < 1
-          end
-        end
-
-        context 'when acting on an element that eventually becomes present' do
-          it 'waits to take action' do
-            start_time = ::Time.now
-            browser.a(id: 'show_bar').click
-            expect { browser.div(id: 'bar').click }.to_not raise_exception
-            expect(::Time.now - start_time).to be < Watir.default_timeout
-          end
-        end
-
-        context 'when evaluating order of failure precedence' do
-          it 'fails first for parent not existing' do
-            begin
-              Watir.default_timeout = 0
-              selector = "{:id=>\"no_parent\", :tag_name=>\"div\"}"
-              element = browser.div(id: 'no_parent').div(id: 'no_child')
-              error = Watir::Exception::UnknownObjectException
-              message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
-              expect { element.click }.to raise_exception(error, message)
-            ensure
-              Watir.default_timeout = 30
-            end
-          end
-
-          it 'fails for child not existing if parent exists' do
-            begin
-              Watir.default_timeout = 0
-              selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"no_child\", :tag_name=>\"div\"}"
-              element = browser.div(id: 'buttons').div(id: 'no_child')
-              error = Watir::Exception::UnknownObjectException
-              message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
-              expect { element.click }.to raise_exception(error, message)
-            ensure
-              Watir.default_timeout = 30
-            end
-          end
-
-          it 'fails for parent not present if child exists' do
-            begin
-              Watir.default_timeout = 0.5
-              selector = "{:id=>\"also_hidden\", :tag_name=>\"div\"}"
-              element = browser.div(id: 'also_hidden').div(id: 'hidden_child')
-              error = Watir::Exception::UnknownObjectException
-              message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
-              expect { element.click }.to raise_exception(error, message)
-            ensure
-              Watir.default_timeout = 30
-            end
-          end
-
-          it 'fails for child not present if parent is present' do
-            begin
-              Watir.default_timeout = 0.5
-              selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"btn2\", :tag_name=>\"button\"}"
-              element = browser.div(id: 'buttons').button(id: 'btn2')
-              error = Watir::Exception::UnknownObjectException
-              message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
-              expect { element.click }.to raise_exception(error, message)
-            ensure
-              Watir.default_timeout = 30
-            end
-          end
-
-          it 'fails for element not enabled if present' do
-            browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
-            begin
-              Watir.default_timeout = 0.5
-              selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"good_luck\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
-              element = browser.form(id: 'new_user').text_field(id: 'good_luck')
-              error = Watir::Exception::ObjectDisabledException
-              message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be enabled"
-              expect { element.set('foo') }.to raise_exception(error, message)
-            ensure
-              Watir.default_timeout = 30
-            end
-          end
-
-          it 'fails for element being readonly if enabled' do
-            browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
-            begin
-              Watir.default_timeout = 0.5
-              selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"new_user_code\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
-              element = browser.form(id: 'new_user').text_field(id: 'new_user_code')
-              error = Watir::Exception::ObjectReadOnlyException
-              message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to not be readonly"
-              expect { element.set('foo') }.to raise_exception(error, message)
-            ensure
-              Watir.default_timeout = 30
-            end
-          end
-        end
-
-        it 'gives warning when rescuing for flow control' do
+      context 'when acting on an element that is never present' do
+        it 'raises exception after timing out' do
           begin
-            Watir.default_timeout = 1
+            time_out = 2
+            Watir.default_timeout = time_out
             element = browser.link(id: 'not_there')
-            message = "This code has slept for the duration of the default timeout "
-            message << "waiting for an Element to exist. If the test is still passing, "
-            message << "consider using Element#exists? instead of rescuing UnknownObjectException\n"
-            expect do
-              begin
-                element.click
-              rescue Exception::UnknownObjectException
-              end
-            end.to output(message).to_stderr
-          ensure
-            Watir.default_timeout = 30
-          end
-        end
-
-        it 'ensures all checks happen once even if time has expired' do
-          begin
-            Watir.default_timeout = -1
-            expect { browser.link.click }.to_not raise_exception
-          ensure
-            Watir.default_timeout = 30
-          end
-        end
-
-        it 'ensures that the same timeout is used for all of the calls' do
-          begin
-            Watir.default_timeout = 1.1
-            browser.a(id: 'add_foobar').click
-            # Element created after 1 second, and displays after 2 seconds
-            # Click will only raise this exception if the timer is not reset between #wait_for_exists and #wait_for_present
-            expect { browser.div(id: 'foobar').click }.to raise_exception Watir::Exception::UnknownObjectException
+            start_time = ::Time.now
+            expect { element.click }.to raise_exception(Watir::Exception::UnknownObjectException)
+            expect(::Time.now - start_time).to be > time_out
           ensure
             Watir.default_timeout = 30
           end
         end
       end
-    end
 
-    not_compliant_on :relaxed_locate do
-      context 'when false' do
-        before :each do
-          browser.goto(WatirSpec.url_for("wait.html"))
+      context 'when acting on an element that is already present' do
+        it 'does not wait' do
+          start_time = ::Time.now
+          expect { browser.link.click }.to_not raise_exception
+          expect(::Time.now - start_time).to be < 1
         end
+      end
 
-        context 'when acting on an element that is never present' do
-          it 'raises exception immediately' do
-            begin
-              time_out = 2
-              Watir.default_timeout = time_out
-              element = browser.link(id: 'not_there')
-              start_time = ::Time.now
-              expect { element.click }.to raise_exception(Exception::UnknownObjectException)
-              expect(::Time.now - start_time).to be < 1
-            ensure
-              Watir.default_timeout = 30
-            end
-          end
-        end
-
-        context 'when acting on an element that eventually becomes present' do
-          it 'raises exception immediately' do
-            start_time = ::Time.now
-            browser.a(id: 'show_bar').click
-            expect { browser.div(id: 'bar').click }.to raise_exception(Selenium::WebDriver::Error::ElementNotVisibleError)
-            expect(::Time.now - start_time).to be < 1
-          end
-        end
-
-        it 'receives a warning for using #when_present' do
-          message = /#when_present has been deprecated and is unlikely to be needed; replace this with #wait_until_present if a wait is still needed/
+      context 'when acting on an element that eventually becomes present' do
+        it 'waits to take action' do
+          start_time = ::Time.now
           browser.a(id: 'show_bar').click
-          expect do
-            browser.div(id: 'bar').when_present.click
-          end.to output(message).to_stderr
+          expect { browser.div(id: 'bar').click }.to_not raise_exception
+          expect(::Time.now - start_time).to be < Watir.default_timeout
         end
+      end
+
+      context 'when evaluating order of failure precedence' do
+        it 'fails first for parent not existing' do
+          begin
+            Watir.default_timeout = 0
+            selector = "{:id=>\"no_parent\", :tag_name=>\"div\"}"
+            element = browser.div(id: 'no_parent').div(id: 'no_child')
+            error = Watir::Exception::UnknownObjectException
+            message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
+            expect { element.click }.to raise_exception(error, message)
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'fails for child not existing if parent exists' do
+          begin
+            Watir.default_timeout = 0
+            selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"no_child\", :tag_name=>\"div\"}"
+            element = browser.div(id: 'buttons').div(id: 'no_child')
+            error = Watir::Exception::UnknownObjectException
+            message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
+            expect { element.click }.to raise_exception(error, message)
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'fails for parent not present if child exists' do
+          begin
+            Watir.default_timeout = 0.5
+            selector = "{:id=>\"also_hidden\", :tag_name=>\"div\"}"
+            element = browser.div(id: 'also_hidden').div(id: 'hidden_child')
+            error = Watir::Exception::UnknownObjectException
+            message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+            expect { element.click }.to raise_exception(error, message)
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'fails for child not present if parent is present' do
+          begin
+            Watir.default_timeout = 0.5
+            selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"btn2\", :tag_name=>\"button\"}"
+            element = browser.div(id: 'buttons').button(id: 'btn2')
+            error = Watir::Exception::UnknownObjectException
+            message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+            expect { element.click }.to raise_exception(error, message)
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'fails for element not enabled if present' do
+          browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+          begin
+            Watir.default_timeout = 0.5
+            selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"good_luck\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
+            element = browser.form(id: 'new_user').text_field(id: 'good_luck')
+            error = Watir::Exception::ObjectDisabledException
+            message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be enabled"
+            expect { element.set('foo') }.to raise_exception(error, message)
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+
+        it 'fails for element being readonly if enabled' do
+          browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+          begin
+            Watir.default_timeout = 0.5
+            selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"new_user_code\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
+            element = browser.form(id: 'new_user').text_field(id: 'new_user_code')
+            error = Watir::Exception::ObjectReadOnlyException
+            message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to not be readonly"
+            expect { element.set('foo') }.to raise_exception(error, message)
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+      end
+
+      it 'gives warning when rescuing for flow control' do
+        begin
+          Watir.default_timeout = 1
+          element = browser.link(id: 'not_there')
+          message = "This code has slept for the duration of the default timeout "
+          message << "waiting for an Element to exist. If the test is still passing, "
+          message << "consider using Element#exists? instead of rescuing UnknownObjectException\n"
+          expect do
+            begin
+              element.click
+            rescue Watir::Exception::UnknownObjectException
+            end
+          end.to output(message).to_stderr
+        ensure
+          Watir.default_timeout = 30
+        end
+      end
+
+      it 'ensures all checks happen once even if time has expired' do
+        begin
+          Watir.default_timeout = -1
+          expect { browser.link.click }.to_not raise_exception
+        ensure
+          Watir.default_timeout = 30
+        end
+      end
+
+      it 'ensures that the same timeout is used for all of the calls' do
+        begin
+          Watir.default_timeout = 1.1
+          browser.a(id: 'add_foobar').click
+          # Element created after 1 second, and displays after 2 seconds
+          # Click will only raise this exception if the timer is not reset between #wait_for_exists and #wait_for_present
+          expect { browser.div(id: 'foobar').click }.to raise_exception Watir::Exception::UnknownObjectException
+        ensure
+          Watir.default_timeout = 30
+        end
+      end
+    end
+  end
+
+  not_compliant_on :relaxed_locate do
+    context 'when false' do
+      before :each do
+        browser.goto(WatirSpec.url_for("wait.html"))
+      end
+
+      context 'when acting on an element that is never present' do
+        it 'raises exception immediately' do
+          begin
+            time_out = 2
+            Watir.default_timeout = time_out
+            element = browser.link(id: 'not_there')
+            start_time = ::Time.now
+            expect { element.click }.to raise_exception(Watir::Exception::UnknownObjectException)
+            expect(::Time.now - start_time).to be < 1
+          ensure
+            Watir.default_timeout = 30
+          end
+        end
+      end
+
+      context 'when acting on an element that eventually becomes present' do
+        it 'raises exception immediately' do
+          start_time = ::Time.now
+          browser.a(id: 'show_bar').click
+          expect { browser.div(id: 'bar').click }.to raise_exception(Selenium::WebDriver::Error::ElementNotVisibleError)
+          expect(::Time.now - start_time).to be < 1
+        end
+      end
+
+      it 'receives a warning for using #when_present' do
+        message = /#when_present has been deprecated and is unlikely to be needed; replace this with #wait_until_present if a wait is still needed/
+        browser.a(id: 'show_bar').click
+        expect do
+          browser.div(id: 'bar').when_present.click
+        end.to output(message).to_stderr
       end
     end
   end

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -151,13 +151,11 @@ module Watir
 
         it 'ensures that the same timeout is used for all of the calls' do
           begin
-            Watir.default_timeout = 2
-            start_time = ::Time.now
-            browser.a(id: 'show_bar').click
-            expect { browser.div(id: 'bar').div(id: 'not_there').click }.to raise_exception
-            finish_time = ::Time.now - start_time
-            expect(finish_time).to be > Watir.default_timeout
-            expect(finish_time).to be < 2 * Watir.default_timeout
+            Watir.default_timeout = 1.1
+            browser.a(id: 'add_foobar').click
+            # Element created after 1 second, and displays after 2 seconds
+            # Click will only raise this exception if the timer is not reset between #wait_for_exists and #wait_for_present
+            expect { browser.div(id: 'foobar').click }.to raise_exception Watir::Exception::UnknownObjectException
           ensure
             Watir.default_timeout = 30
           end

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -1,283 +1,358 @@
 require "watirspec_helper"
 
 not_compliant_on :safari do
-  describe Watir::Wait do
-    describe "#until" do
-      it "returns result of block if truthy" do
-        result = 'catter'
-        expect(Watir::Wait.until(0.5) { result }).to be result
+  module Watir
+    describe Wait do
+      describe "#until" do
+        it "waits until the block returns true" do
+          Wait.until(timeout: 0.5) { @result = true }
+          expect(@result).to be true
+        end
+
+        it "executes block if timeout is zero" do
+          Wait.until(timeout: 0) { @result = true }
+          expect(@result).to be true
+        end
+
+        it "times out" do
+          expect { Wait.until(timeout: 0.5) { false } }.to raise_error(Wait::TimeoutError)
+        end
+
+        it "times out with a custom message" do
+          expect {
+            Wait.until(timeout: 0.5, message: "oops") { false }
+          }.to raise_error(Wait::TimeoutError, "timed out after 0.5 seconds, oops")
+        end
+
+        it "uses timer for waiting" do
+          timer = Wait.timer
+          expect(timer).to receive(:wait).with(0.5).and_call_original
+          Wait.until(timeout: 0.5) { true }
+        end
+
+        it "ordered pairs are deprecated" do
+          message = /Instead of passing arguments into Wait#until method, use keywords/
+          expect { Wait.until(0) { true } }.to output(message).to_stderr
+        end
       end
 
-      it "waits until the block returns true" do
-        expect(Watir::Wait.until(0.5) { true }).to be true
+      describe "#while" do
+        it "waits while the block returns true" do
+          expect(Wait.while(timeout: 0.5) { false }).to be_nil
+        end
+
+        it "executes block if timeout is zero" do
+          expect(Wait.while(timeout: 0) { false }).to be_nil
+        end
+
+        it "times out" do
+          expect { Wait.while(timeout: 0.5) { true } }.to raise_error(Wait::TimeoutError)
+        end
+
+        it "times out with a custom message" do
+          expect {
+            Wait.while(timeout: 0.5, message: "oops") { true }
+          }.to raise_error(Wait::TimeoutError, "timed out after 0.5 seconds, oops")
+        end
+
+        it "uses timer for waiting" do
+          timer = Wait.timer
+          expect(timer).to receive(:wait).with(0.5).and_call_original
+          Wait.while(timeout: 0.5) { false }
+        end
+
+        it "ordered pairs are deprecated" do
+          message = /Instead of passing arguments into Wait#while method, use keywords/
+          expect { Wait.while(0) { false } }.to output(message).to_stderr
+        end
       end
 
-      it "executes block if timeout is zero" do
-        expect(Watir::Wait.until(0) { true }).to be true
+      describe "#timer" do
+        it "returns default timer" do
+          expect(Wait.timer).to be_a(Wait::Timer)
+        end
       end
 
-      it "times out" do
-        expect {Watir::Wait.until(0.5) { false }}.to raise_error(Watir::Wait::TimeoutError)
-      end
+      describe "#timer=" do
+        after { Wait.timer = nil }
 
-      it "times out with a custom message" do
-        expect {
-          Watir::Wait.until(0.5, "oops") { false }
-        }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
-      end
-
-      it "uses timer for waiting" do
-        timer = Watir::Wait.timer
-        expect(timer).to receive(:wait).with(0.5).and_call_original
-        Watir::Wait.until(0.5) { true }
+        it "changes default timer" do
+          timer = Class.new
+          Wait.timer = timer
+          expect(Wait.timer).to eq(timer)
+        end
       end
     end
 
-    describe "#while" do
-      it "waits while the block returns true" do
-        expect(Watir::Wait.while(0.5) { false }).to be_nil
+    describe Element do
+      before do
+        browser.goto WatirSpec.url_for("wait.html")
       end
 
-      it "executes block if timeout is zero" do
-        expect(Watir::Wait.while(0) { false }).to be_nil
-      end
-
-      it "times out" do
-        expect {Watir::Wait.while(0.5) { true }}.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      it "times out with a custom message" do
-        expect {
-          Watir::Wait.while(0.5, "oops") { true }
-        }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
-      end
-
-      it "uses timer for waiting" do
-        timer = Watir::Wait.timer
-        expect(timer).to receive(:wait).with(0.5).and_call_original
-        Watir::Wait.while(0.5) { false }
-      end
-    end
-
-    describe "#timer" do
-      it "returns default timer" do
-        expect(Watir::Wait.timer).to be_a(Watir::Wait::Timer)
-      end
-    end
-
-    describe "#timer=" do
-      after { Watir::Wait.timer = nil }
-
-      it "changes default timer" do
-        timer = Class.new
-        Watir::Wait.timer = timer
-        expect(Watir::Wait.timer).to eq(timer)
-      end
-    end
-  end
-
-  describe Watir::Element do
-    before do
-      browser.goto WatirSpec.url_for("wait.html")
-    end
-
-    not_compliant_on :relaxed_locate do
       describe "#when_present" do
-        it "yields when the element becomes present" do
-          called = false
+        context 'warnings' do
+          it 'received for using #when_present' do
+            message = /when_present has been deprecated and is unlikely to be needed; use #wait_until_present if a wait is still needed/
+            browser.a(id: 'show_bar').click
+            expect do
+              browser.div(id: 'bar').when_present.click
+            end.to output(message).to_stderr
+          end
 
-          browser.a(id: 'show_bar').click
-          browser.div(id: 'bar').when_present(2) { called = true }
-
-          expect(called).to be true
+          it 'received for passing block to #when_present' do
+            message = /do not pass a block to take actions after a wait/
+            browser.a(id: 'show_bar').click
+            expect do
+              browser.div(id: 'bar').when_present {}
+            end.to output(message).to_stderr
+          end
         end
 
-        it "invokes subsequent method calls when the element becomes present" do
-          browser.a(id: 'show_bar').click
+        not_compliant_on :relaxed_locate do
+          context 'deprecated' do
+            it "invokes subsequent method calls when the element becomes present" do
+              browser.a(id: 'show_bar').click
 
-          bar = browser.div(id: 'bar')
-          bar.when_present(2).click
-          expect(bar.text).to eq "changed"
-        end
+              bar = browser.div(id: 'bar')
+              bar.when_present(2).click
+              expect(bar.text).to eq "changed"
+            end
 
-        it "times out when given a block" do
-          expect { browser.div(id: 'bar').when_present(1) {}}.to raise_error(Watir::Wait::TimeoutError)
-        end
+            it "times out when given a block" do
+              expect { browser.div(id: 'bar').when_present(1) {} }.to raise_error(Wait::TimeoutError)
+            end
 
-        it "times out when not given a block" do
-          expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Watir::Wait::TimeoutError,
-            /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
-          )
-        end
+            it "times out when not given a block" do
+              message = /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
+              expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Wait::TimeoutError, message)
+            end
 
-        it "responds to Element methods" do
-          decorator = browser.div.when_present
+            it "responds to Element methods" do
+              decorator = browser.div.when_present
 
-          expect(decorator).to respond_to(:exist?)
-          expect(decorator).to respond_to(:present?)
-          expect(decorator).to respond_to(:click)
-        end
+              expect(decorator).to respond_to(:exist?)
+              expect(decorator).to respond_to(:present?)
+              expect(decorator).to respond_to(:click)
+            end
 
-        it "delegates present? to element" do
-          Object.class_eval do
-            def present?
-              false
+            it "delegates present? to element" do
+              Object.class_eval do
+                def present?
+                  false
+                end
+              end
+              element = browser.a(id: "show_bar").when_present(1)
+              expect(element).to be_present
+            end
+
+            it "processes before calling present?" do
+              browser.a(id: 'show_bar').click
+              expect(browser.div(id: 'bar').when_present.present?).to be true
             end
           end
-          element = browser.a(id: "show_bar").when_present(1)
-          expect(element).to be_present
         end
 
-        it "processes before calling present?" do
-          browser.a(id: 'show_bar').click
-          expect(browser.div(id: 'bar').when_present.present?).to be true
+        not_compliant_on :relaxed_locate do
+          describe "#when_enabled" do
+            it "yields when the element becomes enabled" do
+              called = false
+
+              browser.a(id: 'enable_btn').click
+              browser.button(id: 'btn').when_enabled(2) { called = true }
+
+              expect(called).to be true
+            end
+
+            it "invokes subsequent method calls when the element becomes enabled" do
+              browser.a(id: 'enable_btn').click
+
+              btn = browser.button(id: 'btn')
+              btn.when_enabled(2).click
+              Wait.while { btn.enabled? }
+              expect(btn.disabled?).to be true
+            end
+
+            it "times out when given a block" do
+              expect { browser.button(id: 'btn').when_enabled(1) {} }.to raise_error(Wait::TimeoutError)
+            end
+
+            it "times out when not given a block" do
+              message = /^timed out after 1 seconds, waiting for (\{:id=>"btn", :tag_name=>"button"\}|\{:tag_name=>"button", :id=>"btn"\}) to become enabled$/
+              expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Wait::TimeoutError, message)
+            end
+
+            it "times out when not given a block" do
+              message = /timed out after 1 seconds, waiting for {:id=>"btn", :tag_name=>"button"} to become enabled$/
+              expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Wait::TimeoutError, message)
+            end
+
+            it "responds to Element methods" do
+              decorator = browser.button.when_enabled
+
+              expect(decorator).to respond_to(:exist?)
+              expect(decorator).to respond_to(:present?)
+              expect(decorator).to respond_to(:click)
+            end
+
+            it "can be chained with #when_present" do
+              browser.a(id: 'show_and_enable_btn').click
+              browser.button(id: 'btn2').when_present(5).when_enabled(5).click
+
+              expect(browser.button(id: 'btn2')).to exist
+              expect(browser.button(id: 'btn2')).to be_enabled
+            end
+          end
+        end
+
+        describe "#wait_until_present" do
+          it "it waits until the element appears" do
+            browser.a(id: 'show_bar').click
+            expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
+          end
+
+          it "times out if the element doesn't appear" do
+            message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\})$/
+            expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(Wait::TimeoutError, message)
+          end
+
+          it "ordered pairs are deprecated" do
+            browser.a(id: 'show_bar').click
+            message = /Instead of passing arguments into #wait_until_present method, use keywords/
+            expect { browser.div(id: 'bar').wait_until_present(5) }.to output(message).to_stderr
+          end
+        end
+
+        describe "#wait_while_present" do
+          it "waits until the element disappears" do
+            browser.a(id: 'hide_foo').click
+            expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to_not raise_exception
+          end
+
+          it "times out if the element doesn't disappear" do
+            message = /^timed out after 1 seconds, waiting for false condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
+            expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(Wait::TimeoutError, message)
+          end
+
+          it "ordered pairs are deprecated" do
+            browser.a(id: 'hide_foo').click
+            message = /Instead of passing arguments into #wait_while_present method, use keywords/
+            expect { browser.div(id: 'foo').wait_while_present(5) }.to output(message).to_stderr
+          end
+        end
+
+        describe "#wait_until_stale" do
+          it "waits until the element disappears" do
+            stale_element = browser.div(id: 'foo')
+            stale_element.exists?
+            browser.refresh
+            expect { stale_element.wait_until_stale(timeout: 1) }.to_not raise_exception
+          end
+
+          it "times out if the element doesn't go stale" do
+            message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
+            element = browser.div(id: 'foo')
+            element.exists?
+            expect { element.wait_until_stale(timeout: 1) }.to raise_error(Wait::TimeoutError, message)
+          end
+        end
+
+        describe "#wait_until" do
+          it "returns element for additional actions" do
+            element = browser.div(id: 'foo')
+            expect(element.wait_until(&:exist?)).to eq element
+          end
+
+          it "accepts self in block" do
+            element = browser.div(id: 'bar')
+            browser.a(id: 'show_bar').click
+            expect { element.wait_until { |el| el.text == 'bar' } }.to_not raise_exception
+          end
+
+          it "accepts any values in block" do
+            element = browser.div(id: 'bar')
+            expect { element.wait_until { true } }.to_not raise_exception
+          end
+
+          it "accepts just a timeout parameter" do
+            element = browser.div(id: 'bar')
+            expect { element.wait_until(timeout: 0) { true } }.to_not raise_exception
+          end
+
+          it "accepts just a message parameter" do
+            element = browser.div(id: 'bar')
+            expect { element.wait_until(message: 'no') { true } }.to_not raise_exception
+          end
+        end
+
+        describe "#wait_while" do
+          it "returns element for additional actions" do
+            element = browser.div(id: 'foo')
+            browser.a(id: 'hide_foo').click
+            expect(element.wait_while(&:present?)).to eq element
+          end
+
+          it "accepts self in block" do
+            element = browser.div(id: 'foo')
+            browser.a(id: 'hide_foo').click
+            expect { element.wait_while { |el| el.text == 'foo' } }.to_not raise_exception
+          end
+
+          it "accepts any values in block" do
+            element = browser.div(id: 'foo')
+            expect { element.wait_while { false } }.to_not raise_exception
+          end
+
+          it "accepts just a timeout parameter" do
+            element = browser.div(id: 'foo')
+            expect { element.wait_while(timeout: 0) { false } }.to_not raise_exception
+          end
+
+          it "accepts just a message parameter" do
+            element = browser.div(id: 'foo')
+            expect { element.wait_while(message: 'no') { false } }.to_not raise_exception
+          end
         end
       end
     end
 
-    not_compliant_on :relaxed_locate do
-      describe "#when_enabled" do
-        it "yields when the element becomes enabled" do
-          called = false
+    describe Watir do
+      describe "#default_timeout" do
+        before do
+          Watir.default_timeout = 1
 
-          browser.a(id: 'enable_btn').click
-          browser.button(id: 'btn').when_enabled(2) { called = true }
-
-          expect(called).to be true
+          browser.goto WatirSpec.url_for("wait.html")
         end
 
-        it "invokes subsequent method calls when the element becomes enabled" do
-          browser.a(id: 'enable_btn').click
-
-          btn = browser.button(id: 'btn')
-          btn.when_enabled(2).click
-          Watir::Wait.while { btn.enabled? }
-          expect(btn.disabled?).to be true
+        after do
+          # Reset the default timeout
+          Watir.default_timeout = 30
         end
 
-        it "times out when given a block" do
-          expect { browser.button(id: 'btn').when_enabled(1) {}}.to raise_error(Watir::Wait::TimeoutError)
+        context "when no timeout is specified" do
+          it "is used by Wait#until" do
+            expect {
+              Wait.until { false }
+            }.to raise_error(Wait::TimeoutError)
+          end
+
+          it "is used by Wait#while" do
+            expect {
+              Wait.while { true }
+            }.to raise_error(Wait::TimeoutError)
+          end
+
+          it "is used by Element#wait_until_present" do
+            expect {
+              browser.div(id: 'bar').wait_until_present
+            }.to raise_error(Wait::TimeoutError)
+          end
+
+          it "is used by Element#wait_while_present" do
+            expect {
+              browser.div(id: 'foo').wait_while_present
+            }.to raise_error(Wait::TimeoutError)
+          end
         end
-
-        it "times out when not given a block" do
-          expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Watir::Wait::TimeoutError,
-            /^timed out after 1 seconds, waiting for (\{:id=>"btn", :tag_name=>"button"\}|\{:tag_name=>"button", :id=>"btn"\}) to become enabled$/
-          )
-        end
-
-        it "times out when not given a block" do
-          expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Watir::Wait::TimeoutError,
-            /timed out after 1 seconds, waiting for {:id=>"btn", :tag_name=>"button"} to become enabled$/
-          )
-        end
-
-        it "responds to Element methods" do
-          decorator = browser.button.when_enabled
-
-          expect(decorator).to respond_to(:exist?)
-          expect(decorator).to respond_to(:present?)
-          expect(decorator).to respond_to(:click)
-        end
-
-        it "can be chained with #when_present" do
-          browser.a(id: 'show_and_enable_btn').click
-          browser.button(id: 'btn2').when_present(5).when_enabled(5).click
-
-          expect(browser.button(id: 'btn2')).to exist
-          expect(browser.button(id: 'btn2')).to be_enabled
-        end
-      end
-    end
-
-    describe "#wait_until_present" do
-      it "it waits until the element appears" do
-        browser.a(id: 'show_bar').click
-        expect { browser.div(id: 'bar').wait_until_present(5) }.to_not raise_exception
-      end
-
-      it "times out if the element doesn't appear" do
-        expect { browser.div(id: 'bar').wait_until_present(1) }.to raise_error(Watir::Wait::TimeoutError,
-          /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
-        )
-      end
-
-    end
-
-    describe "#wait_while_present" do
-      it "waits until the element disappears" do
-        browser.a(id: 'hide_foo').click
-        expect { browser.div(id: 'foo').wait_while_present(1) }.to_not raise_exception
-      end
-
-      it "times out if the element doesn't disappear" do
-        expect { browser.div(id: 'foo').wait_while_present(1) }.to raise_error(Watir::Wait::TimeoutError,
-          /^timed out after 1 seconds, waiting for (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\}) to disappear$/
-        )
-      end
-    end
-
-    describe "#wait_until_stale" do
-      it "waits until the element disappears" do
-        stale_element = browser.div(id: 'foo')
-        stale_element.exists?
-        browser.refresh
-        expect { stale_element.wait_until_stale(1) }.to_not raise_exception
-      end
-
-      it "times out if the element doesn't go stale" do
-
-        element = browser.div(id: 'foo')
-        element.exists?
-        expect { element.wait_until_stale(1) }.to raise_error(Watir::Wait::TimeoutError,
-                                                              /^timed out after 1 seconds, waiting for (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\}) to become stale$/
-        )
-      end
-    end
-  end
-
-  describe "Watir.default_timeout" do
-    before do
-      Watir.default_timeout = 1
-
-      browser.goto WatirSpec.url_for("wait.html")
-    end
-
-    after do
-      # Reset the default timeout
-      Watir.default_timeout = 30
-    end
-
-    context "when no timeout is specified" do
-      it "is used by Watir::Wait#until" do
-        expect {
-          Watir::Wait.until { false }
-        }.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      it "is used by Watir::Wait#while" do
-        expect {
-          Watir::Wait.while { true }
-        }.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      not_compliant_on :relaxed_locate do
-        it "is used by Element#when_present" do
-          expect {
-            browser.div(id: 'bar').when_present.click
-          }.to raise_error(Watir::Wait::TimeoutError)
-        end
-      end
-
-      it "is used by Element#wait_until_present" do
-        expect {
-          browser.div(id: 'bar').wait_until_present
-        }.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      it "is used by Element#wait_while_present" do
-        expect {
-          browser.div(id: 'foo').wait_while_present
-        }.to raise_error(Watir::Wait::TimeoutError)
       end
     end
   end

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -1,304 +1,302 @@
 require "watirspec_helper"
 
 not_compliant_on :safari do
-  module Watir
-    describe Wait do
-      describe "#until" do
-        it "waits until the block returns true" do
-          Wait.until(timeout: 0.5) { @result = true }
-          expect(@result).to be true
-        end
-
-        it "executes block if timeout is zero" do
-          Wait.until(timeout: 0) { @result = true }
-          expect(@result).to be true
-        end
-
-        it "times out" do
-          expect { Wait.until(timeout: 0.5) { false } }.to raise_error(Wait::TimeoutError)
-        end
-
-        it "times out with a custom message" do
-          expect {
-            Wait.until(timeout: 0.5, message: "oops") { false }
-          }.to raise_error(Wait::TimeoutError, "timed out after 0.5 seconds, oops")
-        end
-
-        it "uses timer for waiting" do
-          timer = Wait.timer
-          expect(timer).to receive(:wait).with(0.5).and_call_original
-          Wait.until(timeout: 0.5) { true }
-        end
-
-        it "ordered pairs are deprecated" do
-          message = /Instead of passing arguments into Wait#until method, use keywords/
-          expect { Wait.until(0) { true } }.to output(message).to_stderr
-        end
+  describe Watir::Wait do
+    describe "#until" do
+      it "waits until the block returns true" do
+        Watir::Wait.until(timeout: 0.5) { @result = true }
+        expect(@result).to be true
       end
 
-      describe "#while" do
-        it "waits while the block returns true" do
-          expect(Wait.while(timeout: 0.5) { false }).to be_nil
-        end
-
-        it "executes block if timeout is zero" do
-          expect(Wait.while(timeout: 0) { false }).to be_nil
-        end
-
-        it "times out" do
-          expect { Wait.while(timeout: 0.5) { true } }.to raise_error(Wait::TimeoutError)
-        end
-
-        it "times out with a custom message" do
-          expect {
-            Wait.while(timeout: 0.5, message: "oops") { true }
-          }.to raise_error(Wait::TimeoutError, "timed out after 0.5 seconds, oops")
-        end
-
-        it "uses timer for waiting" do
-          timer = Wait.timer
-          expect(timer).to receive(:wait).with(0.5).and_call_original
-          Wait.while(timeout: 0.5) { false }
-        end
-
-        it "ordered pairs are deprecated" do
-          message = /Instead of passing arguments into Wait#while method, use keywords/
-          expect { Wait.while(0) { false } }.to output(message).to_stderr
-        end
+      it "executes block if timeout is zero" do
+        Watir::Wait.until(timeout: 0) { @result = true }
+        expect(@result).to be true
       end
 
-      describe "#timer" do
-        it "returns default timer" do
-          expect(Wait.timer).to be_a(Wait::Timer)
-        end
+      it "times out" do
+        expect { Watir::Wait.until(timeout: 0.5) { false } }.to raise_error(Watir::Wait::TimeoutError)
       end
 
-      describe "#timer=" do
-        after { Wait.timer = nil }
+      it "times out with a custom message" do
+        expect {
+          Watir::Wait.until(timeout: 0.5, message: "oops") { false }
+        }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
+      end
 
-        it "changes default timer" do
-          timer = Class.new
-          Wait.timer = timer
-          expect(Wait.timer).to eq(timer)
+      it "uses timer for waiting" do
+        timer = Watir::Wait.timer
+        expect(timer).to receive(:wait).with(0.5).and_call_original
+        Watir::Wait.until(timeout: 0.5) { true }
+      end
+
+      it "ordered pairs are deprecated" do
+        message = /Instead of passing arguments into Wait#until method, use keywords/
+        expect { Watir::Wait.until(0) { true } }.to output(message).to_stderr
+      end
+    end
+
+    describe "#while" do
+      it "waits while the block returns true" do
+        expect(Watir::Wait.while(timeout: 0.5) { false }).to be_nil
+      end
+
+      it "executes block if timeout is zero" do
+        expect(Watir::Wait.while(timeout: 0) { false }).to be_nil
+      end
+
+      it "times out" do
+        expect { Watir::Wait.while(timeout: 0.5) { true } }.to raise_error(Watir::Wait::TimeoutError)
+      end
+
+      it "times out with a custom message" do
+        expect {
+          Watir::Wait.while(timeout: 0.5, message: "oops") { true }
+        }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
+      end
+
+      it "uses timer for waiting" do
+        timer = Watir::Wait.timer
+        expect(timer).to receive(:wait).with(0.5).and_call_original
+        Watir::Wait.while(timeout: 0.5) { false }
+      end
+
+      it "ordered pairs are deprecated" do
+        message = /Instead of passing arguments into Wait#while method, use keywords/
+        expect { Watir::Wait.while(0) { false } }.to output(message).to_stderr
+      end
+    end
+
+    describe "#timer" do
+      it "returns default timer" do
+        expect(Watir::Wait.timer).to be_a(Watir::Wait::Timer)
+      end
+    end
+
+    describe "#timer=" do
+      after { Watir::Wait.timer = nil }
+
+      it "changes default timer" do
+        timer = Class.new
+        Watir::Wait.timer = timer
+        expect(Watir::Wait.timer).to eq(timer)
+      end
+    end
+  end
+
+  describe Watir::Element do
+    before do
+      browser.goto WatirSpec.url_for("wait.html")
+    end
+
+    # TODO: This is deprecated; remove in future version
+    not_compliant_on :relaxed_locate do
+      describe "#when_present" do
+        it "invokes subsequent method calls when the element becomes present" do
+          browser.a(id: 'show_bar').click
+
+          bar = browser.div(id: 'bar')
+          bar.when_present(2).click
+          expect(bar.text).to eq "changed"
+        end
+
+        it "times out when given a block" do
+          expect { browser.div(id: 'bar').when_present(1) {} }.to raise_error(Watir::Wait::TimeoutError)
+        end
+
+        it "times out when not given a block" do
+          message = /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
+          expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Watir::Wait::TimeoutError, message)
+        end
+
+        it "responds to Element methods" do
+          decorator = browser.div.when_present
+
+          expect(decorator).to respond_to(:exist?)
+          expect(decorator).to respond_to(:present?)
+          expect(decorator).to respond_to(:click)
+        end
+
+        it "delegates present? to element" do
+          Object.class_eval do
+            def present?
+              false
+            end
+          end
+          element = browser.a(id: "show_bar").when_present(1)
+          expect(element).to be_present
+        end
+
+        it "processes before calling present?" do
+          browser.a(id: 'show_bar').click
+          expect(browser.div(id: 'bar').when_present.present?).to be true
         end
       end
     end
 
-    describe Element do
+    not_compliant_on :relaxed_locate do
+      describe "#wait_until &:enabled?" do
+        it "invokes subsequent method calls when the element becomes enabled" do
+          browser.a(id: 'enable_btn').click
+
+          btn = browser.button(id: 'btn')
+          btn.wait_until(timeout: 2, &:enabled?).click
+          Watir::Wait.while { btn.enabled? }
+          expect(btn.disabled?).to be true
+        end
+
+        it "times out" do
+          message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"btn", :tag_name=>"button"\}|\{:tag_name=>"button", :id=>"btn"\})$/
+          expect { browser.button(id: 'btn').wait_until(timeout: 1, &:enabled?).click }.to raise_error(Watir::Wait::TimeoutError, message)
+        end
+
+        it "responds to Element methods" do
+          element = browser.button.wait_until { true }
+
+          expect(element).to respond_to(:exist?)
+          expect(element).to respond_to(:present?)
+          expect(element).to respond_to(:click)
+        end
+
+        it "can be chained with #wait_until &:present?" do
+          browser.a(id: 'show_and_enable_btn').click
+          browser.button(id: 'btn2').wait_until(&:present?).wait_until(&:enabled?).click
+
+          expect(browser.button(id: 'btn2')).to exist
+          expect(browser.button(id: 'btn2')).to be_enabled
+        end
+      end
+    end
+
+    describe "#wait_until_present" do
+      it "it waits until the element appears" do
+        browser.a(id: 'show_bar').click
+        expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
+      end
+
+      it "times out if the element doesn't appear" do
+        message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\})$/
+        expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
+      end
+
+      it "ordered pairs are deprecated" do
+        browser.a(id: 'show_bar').click
+        message = /Instead of passing arguments into #wait_until_present method, use keywords/
+        expect { browser.div(id: 'bar').wait_until_present(5) }.to output(message).to_stderr
+      end
+    end
+
+    describe "#wait_while_present" do
+      it "waits until the element disappears" do
+        browser.a(id: 'hide_foo').click
+        expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to_not raise_exception
+      end
+
+      it "times out if the element doesn't disappear" do
+        message = /^timed out after 1 seconds, waiting for false condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
+        expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
+      end
+
+      it "ordered pairs are deprecated" do
+        browser.a(id: 'hide_foo').click
+        message = /Instead of passing arguments into #wait_while_present method, use keywords/
+        expect { browser.div(id: 'foo').wait_while_present(5) }.to output(message).to_stderr
+      end
+    end
+
+    describe "#wait_until" do
+      it "returns element for additional actions" do
+        element = browser.div(id: 'foo')
+        expect(element.wait_until(&:exist?)).to eq element
+      end
+
+      it "accepts self in block" do
+        element = browser.div(id: 'bar')
+        browser.a(id: 'show_bar').click
+        expect { element.wait_until { |el| el.text == 'bar' } }.to_not raise_exception
+      end
+
+      it "accepts any values in block" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until { true } }.to_not raise_exception
+      end
+
+      it "accepts just a timeout parameter" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until(timeout: 0) { true } }.to_not raise_exception
+      end
+
+      it "accepts just a message parameter" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until(message: 'no') { true } }.to_not raise_exception
+      end
+    end
+
+    describe "#wait_while" do
+      it "returns element for additional actions" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect(element.wait_while(&:present?)).to eq element
+      end
+
+      it "accepts self in block" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect { element.wait_while { |el| el.text == 'foo' } }.to_not raise_exception
+      end
+
+      it "accepts any values in block" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while { false } }.to_not raise_exception
+      end
+
+      it "accepts just a timeout parameter" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while(timeout: 0) { false } }.to_not raise_exception
+      end
+
+      it "accepts just a message parameter" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while(message: 'no') { false } }.to_not raise_exception
+      end
+    end
+  end
+
+  describe Watir do
+    describe "#default_timeout" do
       before do
+        Watir.default_timeout = 1
+
         browser.goto WatirSpec.url_for("wait.html")
       end
 
-      # TODO: This is deprecated; remove in future version
-      not_compliant_on :relaxed_locate do
-        describe "#when_present" do
-          it "invokes subsequent method calls when the element becomes present" do
-            browser.a(id: 'show_bar').click
-
-            bar = browser.div(id: 'bar')
-            bar.when_present(2).click
-            expect(bar.text).to eq "changed"
-          end
-
-          it "times out when given a block" do
-            expect { browser.div(id: 'bar').when_present(1) {} }.to raise_error(Wait::TimeoutError)
-          end
-
-          it "times out when not given a block" do
-            message = /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
-            expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Wait::TimeoutError, message)
-          end
-
-          it "responds to Element methods" do
-            decorator = browser.div.when_present
-
-            expect(decorator).to respond_to(:exist?)
-            expect(decorator).to respond_to(:present?)
-            expect(decorator).to respond_to(:click)
-          end
-
-          it "delegates present? to element" do
-            Object.class_eval do
-              def present?
-                false
-              end
-            end
-            element = browser.a(id: "show_bar").when_present(1)
-            expect(element).to be_present
-          end
-
-          it "processes before calling present?" do
-            browser.a(id: 'show_bar').click
-            expect(browser.div(id: 'bar').when_present.present?).to be true
-          end
-        end
+      after do
+        # Reset the default timeout
+        Watir.default_timeout = 30
       end
 
-      not_compliant_on :relaxed_locate do
-        describe "#wait_until &:enabled?" do
-          it "invokes subsequent method calls when the element becomes enabled" do
-            browser.a(id: 'enable_btn').click
-
-            btn = browser.button(id: 'btn')
-            btn.wait_until(timeout: 2, &:enabled?).click
-            Wait.while { btn.enabled? }
-            expect(btn.disabled?).to be true
-          end
-
-          it "times out" do
-            message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"btn", :tag_name=>"button"\}|\{:tag_name=>"button", :id=>"btn"\})$/
-            expect { browser.button(id: 'btn').wait_until(timeout: 1, &:enabled?).click }.to raise_error(Wait::TimeoutError, message)
-          end
-
-          it "responds to Element methods" do
-            element = browser.button.wait_until { true }
-
-            expect(element).to respond_to(:exist?)
-            expect(element).to respond_to(:present?)
-            expect(element).to respond_to(:click)
-          end
-
-          it "can be chained with #wait_until &:present?" do
-            browser.a(id: 'show_and_enable_btn').click
-            browser.button(id: 'btn2').wait_until(&:present?).wait_until(&:enabled?).click
-
-            expect(browser.button(id: 'btn2')).to exist
-            expect(browser.button(id: 'btn2')).to be_enabled
-          end
-        end
-      end
-
-      describe "#wait_until_present" do
-        it "it waits until the element appears" do
-          browser.a(id: 'show_bar').click
-          expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
+      context "when no timeout is specified" do
+        it "is used by Wait#until" do
+          expect {
+            Watir::Wait.until { false }
+          }.to raise_error(Watir::Wait::TimeoutError)
         end
 
-        it "times out if the element doesn't appear" do
-          message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\})$/
-          expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(Wait::TimeoutError, message)
+        it "is used by Wait#while" do
+          expect {
+            Watir::Wait.while { true }
+          }.to raise_error(Watir::Wait::TimeoutError)
         end
 
-        it "ordered pairs are deprecated" do
-          browser.a(id: 'show_bar').click
-          message = /Instead of passing arguments into #wait_until_present method, use keywords/
-          expect { browser.div(id: 'bar').wait_until_present(5) }.to output(message).to_stderr
-        end
-      end
-
-      describe "#wait_while_present" do
-        it "waits until the element disappears" do
-          browser.a(id: 'hide_foo').click
-          expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to_not raise_exception
+        it "is used by Element#wait_until_present" do
+          expect {
+            browser.div(id: 'bar').wait_until_present
+          }.to raise_error(Watir::Wait::TimeoutError)
         end
 
-        it "times out if the element doesn't disappear" do
-          message = /^timed out after 1 seconds, waiting for false condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
-          expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(Wait::TimeoutError, message)
-        end
-
-        it "ordered pairs are deprecated" do
-          browser.a(id: 'hide_foo').click
-          message = /Instead of passing arguments into #wait_while_present method, use keywords/
-          expect { browser.div(id: 'foo').wait_while_present(5) }.to output(message).to_stderr
-        end
-      end
-
-      describe "#wait_until" do
-        it "returns element for additional actions" do
-          element = browser.div(id: 'foo')
-          expect(element.wait_until(&:exist?)).to eq element
-        end
-
-        it "accepts self in block" do
-          element = browser.div(id: 'bar')
-          browser.a(id: 'show_bar').click
-          expect { element.wait_until { |el| el.text == 'bar' } }.to_not raise_exception
-        end
-
-        it "accepts any values in block" do
-          element = browser.div(id: 'bar')
-          expect { element.wait_until { true } }.to_not raise_exception
-        end
-
-        it "accepts just a timeout parameter" do
-          element = browser.div(id: 'bar')
-          expect { element.wait_until(timeout: 0) { true } }.to_not raise_exception
-        end
-
-        it "accepts just a message parameter" do
-          element = browser.div(id: 'bar')
-          expect { element.wait_until(message: 'no') { true } }.to_not raise_exception
-        end
-      end
-
-      describe "#wait_while" do
-        it "returns element for additional actions" do
-          element = browser.div(id: 'foo')
-          browser.a(id: 'hide_foo').click
-          expect(element.wait_while(&:present?)).to eq element
-        end
-
-        it "accepts self in block" do
-          element = browser.div(id: 'foo')
-          browser.a(id: 'hide_foo').click
-          expect { element.wait_while { |el| el.text == 'foo' } }.to_not raise_exception
-        end
-
-        it "accepts any values in block" do
-          element = browser.div(id: 'foo')
-          expect { element.wait_while { false } }.to_not raise_exception
-        end
-
-        it "accepts just a timeout parameter" do
-          element = browser.div(id: 'foo')
-          expect { element.wait_while(timeout: 0) { false } }.to_not raise_exception
-        end
-
-        it "accepts just a message parameter" do
-          element = browser.div(id: 'foo')
-          expect { element.wait_while(message: 'no') { false } }.to_not raise_exception
-        end
-      end
-    end
-
-    describe Watir do
-      describe "#default_timeout" do
-        before do
-          Watir.default_timeout = 1
-
-          browser.goto WatirSpec.url_for("wait.html")
-        end
-
-        after do
-          # Reset the default timeout
-          Watir.default_timeout = 30
-        end
-
-        context "when no timeout is specified" do
-          it "is used by Wait#until" do
-            expect {
-              Wait.until { false }
-            }.to raise_error(Wait::TimeoutError)
-          end
-
-          it "is used by Wait#while" do
-            expect {
-              Wait.while { true }
-            }.to raise_error(Wait::TimeoutError)
-          end
-
-          it "is used by Element#wait_until_present" do
-            expect {
-              browser.div(id: 'bar').wait_until_present
-            }.to raise_error(Wait::TimeoutError)
-          end
-
-          it "is used by Element#wait_while_present" do
-            expect {
-              browser.div(id: 'foo').wait_while_present
-            }.to raise_error(Wait::TimeoutError)
-          end
+        it "is used by Element#wait_while_present" do
+          expect {
+            browser.div(id: 'foo').wait_while_present
+          }.to raise_error(Watir::Wait::TimeoutError)
         end
       end
     end

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -92,18 +92,10 @@ not_compliant_on :safari do
       describe "#when_present" do
         context 'warnings' do
           it 'received for using #when_present' do
-            message = /when_present has been deprecated and is unlikely to be needed; use #wait_until_present if a wait is still needed/
+            message = /when_present has been deprecated and is unlikely to be needed; replace this with #wait_until_present if a wait is still needed/
             browser.a(id: 'show_bar').click
             expect do
               browser.div(id: 'bar').when_present.click
-            end.to output(message).to_stderr
-          end
-
-          it 'received for passing block to #when_present' do
-            message = /do not pass a block to take actions after a wait/
-            browser.a(id: 'show_bar').click
-            expect do
-              browser.div(id: 'bar').when_present {}
             end.to output(message).to_stderr
           end
         end
@@ -237,22 +229,6 @@ not_compliant_on :safari do
             browser.a(id: 'hide_foo').click
             message = /Instead of passing arguments into #wait_while_present method, use keywords/
             expect { browser.div(id: 'foo').wait_while_present(5) }.to output(message).to_stderr
-          end
-        end
-
-        describe "#wait_until_stale" do
-          it "waits until the element disappears" do
-            stale_element = browser.div(id: 'foo')
-            stale_element.exists?
-            browser.refresh
-            expect { stale_element.wait_until_stale(timeout: 1) }.to_not raise_exception
-          end
-
-          it "times out if the element doesn't go stale" do
-            message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
-            element = browser.div(id: 'foo')
-            element.exists?
-            expect { element.wait_until_stale(timeout: 1) }.to raise_error(Wait::TimeoutError, message)
           end
         end
 

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -81,108 +81,111 @@ not_compliant_on :safari do
       browser.goto WatirSpec.url_for("wait.html")
     end
 
-    describe "#when_present" do
-      it "yields when the element becomes present" do
-        called = false
+    not_compliant_on :relaxed_locate do
+      describe "#when_present" do
+        it "yields when the element becomes present" do
+          called = false
 
-        browser.a(id: 'show_bar').click
-        browser.div(id: 'bar').when_present(2) { called = true }
+          browser.a(id: 'show_bar').click
+          browser.div(id: 'bar').when_present(2) { called = true }
 
-        expect(called).to be true
-      end
-
-      it "invokes subsequent method calls when the element becomes present" do
-        browser.a(id: 'show_bar').click
-
-        bar = browser.div(id: 'bar')
-        bar.when_present(2).click
-        expect(bar.text).to eq "changed"
-      end
-
-      it "times out when given a block" do
-        expect { browser.div(id: 'bar').when_present(1) {}}.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      it "times out when not given a block" do
-        expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Watir::Wait::TimeoutError,
-          /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
-        )
-      end
-
-      it "responds to Element methods" do
-        decorator = browser.div.when_present
-
-        expect(decorator).to respond_to(:exist?)
-        expect(decorator).to respond_to(:present?)
-        expect(decorator).to respond_to(:click)
-      end
-
-      it "delegates present? to element" do
-        Object.class_eval do
-          def present?
-            false
-          end
+          expect(called).to be true
         end
-        element = browser.a(id: "show_bar").when_present(1)
-        expect(element).to be_present
-      end
 
-      it "processes before calling present?" do
-        browser.a(id: 'show_bar').click
-        expect(browser.div(id: 'bar').when_present.present?).to be true
-      end
+        it "invokes subsequent method calls when the element becomes present" do
+          browser.a(id: 'show_bar').click
 
+          bar = browser.div(id: 'bar')
+          bar.when_present(2).click
+          expect(bar.text).to eq "changed"
+        end
+
+        it "times out when given a block" do
+          expect { browser.div(id: 'bar').when_present(1) {}}.to raise_error(Watir::Wait::TimeoutError)
+        end
+
+        it "times out when not given a block" do
+          expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Watir::Wait::TimeoutError,
+            /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
+          )
+        end
+
+        it "responds to Element methods" do
+          decorator = browser.div.when_present
+
+          expect(decorator).to respond_to(:exist?)
+          expect(decorator).to respond_to(:present?)
+          expect(decorator).to respond_to(:click)
+        end
+
+        it "delegates present? to element" do
+          Object.class_eval do
+            def present?
+              false
+            end
+          end
+          element = browser.a(id: "show_bar").when_present(1)
+          expect(element).to be_present
+        end
+
+        it "processes before calling present?" do
+          browser.a(id: 'show_bar').click
+          expect(browser.div(id: 'bar').when_present.present?).to be true
+        end
+      end
     end
 
-    describe "#when_enabled" do
-      it "yields when the element becomes enabled" do
-        called = false
+    not_compliant_on :relaxed_locate do
+      describe "#when_enabled" do
+        it "yields when the element becomes enabled" do
+          called = false
 
-        browser.a(id: 'enable_btn').click
-        browser.button(id: 'btn').when_enabled(2) { called = true }
+          browser.a(id: 'enable_btn').click
+          browser.button(id: 'btn').when_enabled(2) { called = true }
 
-        expect(called).to be true
-      end
+          expect(called).to be true
+        end
 
-      it "invokes subsequent method calls when the element becomes enabled" do
-        browser.a(id: 'enable_btn').click
+        it "invokes subsequent method calls when the element becomes enabled" do
+          browser.a(id: 'enable_btn').click
 
-        btn = browser.button(id: 'btn')
-        btn.when_enabled(2).click
-        Watir::Wait.while { btn.enabled? }
-        expect(btn.disabled?).to be true
-      end
+          btn = browser.button(id: 'btn')
+          btn.when_enabled(2).click
+          Watir::Wait.while { btn.enabled? }
+          expect(btn.disabled?).to be true
+        end
 
-      it "times out when given a block" do
-        expect { browser.button(id: 'btn').when_enabled(1) {}}.to raise_error(Watir::Wait::TimeoutError)
-      end
+        it "times out when given a block" do
+          expect { browser.button(id: 'btn').when_enabled(1) {}}.to raise_error(Watir::Wait::TimeoutError)
+        end
 
-      it "times out when not given a block" do
-        expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Watir::Wait::TimeoutError,
-          /^timed out after 1 seconds, waiting for (\{:id=>"btn", :tag_name=>"button"\}|\{:tag_name=>"button", :id=>"btn"\}) to become enabled$/
-        )
-      end
+        it "times out when not given a block" do
+          expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Watir::Wait::TimeoutError,
+            /^timed out after 1 seconds, waiting for (\{:id=>"btn", :tag_name=>"button"\}|\{:tag_name=>"button", :id=>"btn"\}) to become enabled$/
+          )
+        end
 
-      it "times out when not given a block" do
-        expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Watir::Wait::TimeoutError,
-          /timed out after 1 seconds, waiting for {:id=>"btn", :tag_name=>"button"} to become enabled$/
-        )
-      end
+        it "times out when not given a block" do
+          expect { browser.button(id: 'btn').when_enabled(1).click }.to raise_error(Watir::Wait::TimeoutError,
+            /timed out after 1 seconds, waiting for {:id=>"btn", :tag_name=>"button"} to become enabled$/
+          )
+        end
 
-      it "responds to Element methods" do
-        decorator = browser.button.when_enabled
+        it "responds to Element methods" do
+          decorator = browser.button.when_enabled
 
-        expect(decorator).to respond_to(:exist?)
-        expect(decorator).to respond_to(:present?)
-        expect(decorator).to respond_to(:click)
-      end
+          expect(decorator).to respond_to(:exist?)
+          expect(decorator).to respond_to(:present?)
+          expect(decorator).to respond_to(:click)
+        end
 
-      it "can be chained with #when_present" do
-        browser.a(id: 'show_and_enable_btn').click
-        browser.button(id: 'btn2').when_present(5).when_enabled(5).click
+        it "can be chained with #when_present" do
+          browser.a(id: 'show_and_enable_btn').click
+          browser.button(id: 'btn2').when_present(5).when_enabled(5).click
 
-        expect(browser.button(id: 'btn2')).to exist
-        expect(browser.button(id: 'btn2')).to be_enabled
+          expect(browser.button(id: 'btn2')).to exist
+          expect(browser.button(id: 'btn2')).to be_enabled
+        end
       end
     end
 
@@ -257,10 +260,12 @@ not_compliant_on :safari do
         }.to raise_error(Watir::Wait::TimeoutError)
       end
 
-      it "is used by Element#when_present" do
-        expect {
-          browser.div(id: 'bar').when_present.click
-        }.to raise_error(Watir::Wait::TimeoutError)
+      not_compliant_on :relaxed_locate do
+        it "is used by Element#when_present" do
+          expect {
+            browser.div(id: 'bar').when_present.click
+          }.to raise_error(Watir::Wait::TimeoutError)
+        end
       end
 
       it "is used by Element#wait_until_present" do

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -366,17 +366,19 @@ not_compliant_on :safari do
         end
       end
 
-      it "should resize the window" do
-        initial_size = browser.window.size
-        browser.window.resize_to(
-          initial_size.width - 20,
-          initial_size.height - 20
-        )
+      bug "https://github.com/SeleniumHQ/selenium/issues/2856", %i(remote firefox) do
+        it "should resize the window" do
+          initial_size = browser.window.size
+          browser.window.resize_to(
+            initial_size.width - 20,
+            initial_size.height - 20
+          )
 
-        new_size = browser.window.size
+          new_size = browser.window.size
 
-        expect(new_size.width).to eq initial_size.width - 20
-        expect(new_size.height).to eq initial_size.height - 20
+          expect(new_size.width).to eq initial_size.width - 20
+          expect(new_size.height).to eq initial_size.height - 20
+        end
       end
 
       not_compliant_on :firefox do
@@ -397,19 +399,21 @@ not_compliant_on :safari do
       end
 
       compliant_on :window_manager do
-        it "should maximize the window" do
-          initial_size = browser.window.size
-          browser.window.resize_to(
-              initial_size.width,
-              initial_size.height - 20
-          )
+        bug "https://github.com/SeleniumHQ/selenium/issues/2856", %i(remote firefox) do
+          it "should maximize the window" do
+            initial_size = browser.window.size
+            browser.window.resize_to(
+                initial_size.width,
+                initial_size.height - 20
+            )
 
-          browser.window.maximize
-          browser.wait_until { browser.window.size != initial_size }
+            browser.window.maximize
+            browser.wait_until { browser.window.size != initial_size }
 
-          new_size = browser.window.size
-          expect(new_size.width).to be >= initial_size.width
-          expect(new_size.height).to be > (initial_size.height - 20)
+            new_size = browser.window.size
+            expect(new_size.width).to be >= initial_size.width
+            expect(new_size.height).to be > (initial_size.height - 20)
+          end
         end
       end
     end

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -81,15 +81,15 @@ not_compliant_on :safari do
       end
 
       it "raises a NoMatchingWindowFoundException error if no window matches the selector" do
-        expect { browser.window(title: "noop").use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+        expect { browser.window(title: "noop").use }.to raise_no_matching_window_exception
       end
 
       it "raises a NoMatchingWindowFoundException error if there's no window at the given index" do
-        expect { browser.window(index: 100).use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+        expect { browser.window(index: 100).use }.to raise_no_matching_window_exception
       end
 
       it "raises NoMatchingWindowFoundException error when attempting to use a window with an incorrect handle" do
-        expect { browser.window(handle: 'bar').use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+        expect { browser.window(handle: 'bar').use }.to raise_no_matching_window_exception
       end
     end
   end
@@ -263,7 +263,7 @@ not_compliant_on :safari do
             original_window = browser.window
             browser.window(index: 1).use
             original_window.close
-            expect { original_window.use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+            expect { original_window.use }.to raise_no_matching_window_exception
           end
 
           bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
@@ -271,7 +271,7 @@ not_compliant_on :safari do
               browser.window(title: "closeable window").use
               browser.a(id: "close").click
               Watir::Wait.until { browser.windows.size == 1 }
-              expect { browser.window.use }.to raise_error(Watir::Exception::NoMatchingWindowFoundException)
+              expect { browser.window.use }.to raise_no_matching_window_exception
             end
           end
         end

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -186,21 +186,23 @@ not_compliant_on :safari do
         end
       end
 
-      describe "#when_present" do
-        it "waits until the window is present" do
-          # TODO: improve this spec.
-          did_yield = false
-          browser.window(title: "closeable window").when_present do
-            did_yield = true
+      not_compliant_on :relaxed_locate do
+        describe "#when_present" do
+          it "waits until the window is present" do
+            # TODO: improve this spec.
+            did_yield = false
+            browser.window(title: "closeable window").when_present do
+              did_yield = true
+            end
+
+            expect(did_yield).to be true
           end
 
-          expect(did_yield).to be true
-        end
-
-        it "times out waiting for a non-present window" do
-          expect {
-            browser.window(title: "noop").wait_until_present(0.5)
-          }.to raise_error(Watir::Wait::TimeoutError)
+          it "times out waiting for a non-present window" do
+            expect {
+              browser.window(title: "noop").wait_until_present(0.5)
+            }.to raise_error(Watir::Wait::TimeoutError)
+          end
         end
       end
     end

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -187,20 +187,10 @@ not_compliant_on :safari do
       end
 
       not_compliant_on :relaxed_locate do
-        describe "#when_present" do
-          it "waits until the window is present" do
-            # TODO: improve this spec.
-            did_yield = false
-            browser.window(title: "closeable window").when_present do
-              did_yield = true
-            end
-
-            expect(did_yield).to be true
-          end
-
+        describe "#wait_until &:present?" do
           it "times out waiting for a non-present window" do
             expect {
-              browser.window(title: "noop").wait_until_present(0.5)
+              browser.window(title: "noop").wait_until(timeout: 0.5, &:present?)
             }.to raise_error(Watir::Wait::TimeoutError)
           end
         end

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -121,6 +121,8 @@ class ImplementationConfig
 
     matching_guards << matching_browser
     matching_guards << [matching_browser, Selenium::WebDriver::Platform.os]
+    matching_guards << :relaxed_locate if Watir.relaxed_locate?
+    matching_guards << :not_relaxed_locate unless Watir.relaxed_locate?
 
     if !Selenium::WebDriver::Platform.linux? || ENV['DESKTOP_SESSION']
       # some specs (i.e. Window#maximize) needs a window manager on linux

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -32,5 +32,5 @@ It facilitates the writing of automated tests by mimicing the behavior of a user
   s.add_development_dependency 'activesupport', '~> 3.0' # for pluralization during code generation
   s.add_development_dependency 'pry'
   s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'yard-doctest', '>= 0.1.7'
+  s.add_development_dependency 'yard-doctest', '>= 0.1.8'
 end


### PR DESCRIPTION
After my previous PRs and several discussions, this is my overall proposal. I added [a bunch of tests](https://github.com/watir/watirspec/pull/87)
1. This waits for a set of preconditions (as specified by each method) to be true before failing when taking an action on an element
2. There is a single toggle to make (almost) everything backward compatible
   1. The only non-backward compatible concern is tests that take actions on elements, rescue the `TimeoutError` and use that for flow control
   2. I've added a warning message for people to indicate that might be what is going on
3. There are performance short cuts for everything now, very few extra calls to get this to work
4. It creates and clears a Wait::Timer instance for every `#element_call` to avoid repeating the same timeout value (@jkotests' concern)
5. It ensures that wait actions are always taken at least once (acting like asserts instead of waits), regardless of the time remaining on the overall timer.
6. It deprecates when_\* decorators. 
   1. Because this is a huge change, I'm not removing them, just putting warnings everywhere
   2. There should be minimal need for `when_present` or `when_enabled` with the new code
   3. Any need that does exist can be replaced with the new `wait_until` methods
   4. This gets rid of the unnecessary metaprogramming
   5. Having a Delegator that is defined independently of the future meta-programmed action isn't necessary
   6. Accepting a block that only executes code after taking the action in the method is not good form
7. It improves error messages further 
   1. It gives status on whether element is located but not visible or enabled, etc
   2. It only returns the `selector_string` of the parent if it is the parent method that is actually failing
8. Deprecates ordered parameters of `timeout` and `message` in favor of keywords 
   1. This is nice if you want to pass in a message, but not the timeout value
   2. It also provides context for the number that is getting passed in `timeout: 5`, etc
9. Implement generic `wait_until` and `wait_while` in the manner @p0deje suggested
   1. These return `self` so that actions can be chained after
   2. These do lose some of the extra error messaging, but several people pointed out to me that the stack trace will make the call exceedingly clear what the call was
10. There was some discussion of the `#wait_until` vs `#wait_while` vs `#wait_until_not` options... I'm leaning against including a `#wait_until_not` method. If `#wait_while` seems clunky, it seems like it would be easier to put the negation in the block `wait_until { !condition }` 

**Examples of new wait calls**
Element#wait_until(&:present?).text
Element#wait_until(timeout: 5, &:present?).text
Element#wait_until(message: “Sorry”, &:present?)
Element#wait_until { |el| el.text == ‘foo’ }
Element#wait_until { element.text == ‘foo’ }
