### PR TITLE
Initial support for AppVeyor CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Watir Powered By Selenium!
 
 [![Gem Version](https://badge.fury.io/rb/watir.svg)](http://badge.fury.io/rb/watir)
-[![Build Status](https://travis-ci.org/watir/watir.svg?branch=master)](https://travis-ci.org/watir/watir)
+[![Travis Status](https://travis-ci.org/watir/watir.svg?branch=master)](https://travis-ci.org/watir/watir)
+[![AppVeyor status](https://ci.appveyor.com/api/projects/status/9vbb7pp5p4uyoott/branch/master?svg=true)](https://ci.appveyor.com/project/p0deje/watir)
 [![Code Climate](https://codeclimate.com/github/watir/watir.svg)](https://codeclimate.com/github/watir/watir)
 [![Dependency Status](https://gemnasium.com/watir/watir.svg)](https://gemnasium.com/watir/watir)
 [![Coverage Status](https://coveralls.io/repos/watir/watir/badge.svg?branch=master)](https://coveralls.io/r/watir/watir)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+version: "#{build}"
+build: off
+clone_depth: 100
+install:
+  - set PATH=C:\Ruby23\bin;%PATH%
+  - bundle install
+  - support/appveyor.cmd
+test_script:
+  - bundle exec rake %RAKE_TASK%
+environment:
+  matrix:
+    - RAKE_TASK: spec:chrome
+    - RAKE_TASK: spec:firefox

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -152,9 +152,9 @@ module Watir
     # Returns browser name.
     #
     # @example
-    #   browser = Watir::Browser.new :phantomjs
+    #   browser = Watir::Browser.new :chrome
     #   browser.name
-    #   #=> :phantomjs
+    #   #=> :chrome
     #
     # @return [Symbol]
     #

--- a/support/appveyor.cmd
+++ b/support/appveyor.cmd
@@ -1,0 +1,9 @@
+if "%RAKE_TASK%"=="spec:firefox" (
+  choco install -y curl
+  choco install -y 7zip.commandline
+  curl -L -O --insecure https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-win32.zip
+  7za e geckodriver-v0.11.1-win32.zip
+  move geckodriver.exe C:\Tools\WebDriver
+
+  geckodriver.exe --version
+)


### PR DESCRIPTION
This PR adds AppVeyor as part of our CI which is a Windows machine.

Currently, the following tests are implemented:
- Chrome
- Firefox + geckodriver

Shortly we can add support for IE11 which is pre-installed in VM and PhantomJS (if we want to).

The tests are currently only run on Ruby 2.3. I don't see much point in testing different Ruby versions (like on Travis) mainly because in AppVeyor the builds are not run in parallel so the bigger matrix we have, the longer we'll have to wait.

Doctests are failing (seems to be running out of ephemeral ports) and IE11 needs some stabilization. In any case, I think it's good for a start.
