### PR TITLE
allow interval to be set in wait methods

### DIFF
--- a/lib/watir/wait.rb
+++ b/lib/watir/wait.rb
@@ -35,14 +35,14 @@ module Watir
       # @raise [TimeoutError] if timeout is exceeded
       #
 
-      def until(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, object: nil)
+      def until(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: nil, object: nil)
         if deprecated_message || deprecated_timeout
           warn "Instead of passing arguments into Wait#until method, use keywords"
           timeout = deprecated_timeout
           message = deprecated_message
         end
         timeout ||= Watir.default_timeout
-        run_with_timer(timeout) do
+        run_with_timer(timeout, interval) do
           result = yield(object)
           return result if result
         end
@@ -61,14 +61,14 @@ module Watir
       # @raise [TimeoutError] if timeout is exceeded
       #
 
-      def while(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, object: nil)
+      def while(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: nil, object: nil)
         if deprecated_message || deprecated_timeout
           warn "Instead of passing arguments into Wait#while method, use keywords"
           timeout = deprecated_timeout
           message = deprecated_message
         end
         timeout ||= Watir.default_timeout
-        run_with_timer(timeout) { return unless yield(object) }
+        run_with_timer(timeout, interval) { return unless yield(object) }
         raise TimeoutError, message_for(timeout, message)
       end
 
@@ -81,13 +81,13 @@ module Watir
         err
       end
 
-      def run_with_timer(timeout, &block)
+      def run_with_timer(timeout, interval, &block)
         if timeout.zero?
           block.call
         else
           timer.wait(timeout) do
             block.call
-            sleep INTERVAL
+            sleep interval || INTERVAL
           end
         end
       end
@@ -115,14 +115,14 @@ module Watir
     # @param [String] message error message for when times out
     #
 
-    def wait_until(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, &blk)
+    def wait_until(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: interval, &blk)
       if deprecated_message || deprecated_timeout
         warn "Instead of passing arguments into #wait_until, use keywords"
         timeout = deprecated_timeout
         message = deprecated_message
       end
       message ||= "waiting for true condition on #{selector_string}"
-      Wait.until(timeout: timeout, message: message, object: self, &blk)
+      Wait.until(timeout: timeout, message: message, interval: interval, object: self, &blk)
 
       self
     end
@@ -141,14 +141,14 @@ module Watir
     # @param [String] message error message for when times out
     #
 
-    def wait_while(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, &blk)
+    def wait_while(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: interval, &blk)
       if deprecated_message || deprecated_timeout
         warn "Instead of passing arguments into #wait_while method, use keywords"
         timeout = deprecated_timeout
         message = deprecated_message
       end
       message ||= "waiting for false condition on #{selector_string}"
-      Wait.while(timeout: timeout, message: message, object: self, &blk)
+      Wait.while(timeout: timeout, message: message, interval: interval, object: self, &blk)
 
       self
     end
@@ -165,12 +165,12 @@ module Watir
     # @see Watir::Element#present?
     #
 
-    def wait_until_present(deprecated_timeout = nil, timeout: nil)
+    def wait_until_present(deprecated_timeout = nil, timeout: nil, interval: nil)
       if deprecated_timeout
         warn "Instead of passing arguments into #wait_until_present method, use keywords"
         timeout = deprecated_timeout
       end
-      wait_until(timeout: timeout, &:present?)
+      wait_until(timeout: timeout, interval: interval, &:present?)
     end
 
     #

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -77,10 +77,10 @@ describe Watir::Browser do
 
   describe "#wait_while" do
     it "delegates to the Wait module" do
-      expect(Watir::Wait).to receive(:while).with(timeout: 3, message: "foo", object: browser).and_yield
+      expect(Watir::Wait).to receive(:while).with(timeout: 3, message: "foo", interval: 0.2, object: browser).and_yield
 
       called = false
-      browser.wait_while(timeout: 3, message: "foo") { called = true }
+      browser.wait_while(timeout: 3, message: "foo", interval: 0.2) { called = true }
 
       expect(called).to be true
     end
@@ -88,10 +88,10 @@ describe Watir::Browser do
 
   describe "#wait_until" do
     it "delegates to the Wait module" do
-      expect(Watir::Wait).to receive(:until).with(timeout: 3, message: "foo", object: browser).and_yield
+      expect(Watir::Wait).to receive(:until).with(timeout: 3, message: "foo", interval: 0.2, object: browser).and_yield
 
       called = false
-      browser.wait_until(timeout: 3, message: "foo") { called = true }
+      browser.wait_until(timeout: 3, message: "foo", interval: 0.2) { called = true }
 
       expect(called).to be true
     end

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -23,6 +23,17 @@ not_compliant_on :safari do
         }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
       end
 
+      it "uses provided interval" do
+        begin
+          Watir::Wait.until(timeout: 0.4, interval: 0.2) do
+            @result = @result.nil? ? 1 : @result + 1
+            false
+          end
+        rescue Watir::Wait::TimeoutError
+        end
+        expect(@result).to eq 2
+      end
+
       it "uses timer for waiting" do
         timer = Watir::Wait.timer
         expect(timer).to receive(:wait).with(0.5).and_call_original
@@ -52,6 +63,17 @@ not_compliant_on :safari do
         expect {
           Watir::Wait.while(timeout: 0.5, message: "oops") { true }
         }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
+      end
+
+      it "uses provided interval" do
+        begin
+          Watir::Wait.while(timeout: 0.4, interval: 0.2) do
+            @result = @result.nil? ? 1 : @result + 1
+            true
+          end
+        rescue Watir::Wait::TimeoutError
+        end
+        expect(@result).to eq 2
       end
 
       it "uses timer for waiting" do
@@ -178,6 +200,16 @@ not_compliant_on :safari do
         expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
       end
 
+      it "uses provided interval" do
+        element = browser.div(id: 'bar')
+        expect(element).to receive(:present?).twice
+
+        begin
+          element.wait_until_present(timeout: 0.4, interval: 0.2)
+        rescue Watir::Wait::TimeoutError
+        end
+      end
+
       it "ordered pairs are deprecated" do
         browser.a(id: 'show_bar').click
         message = /Instead of passing arguments into #wait_until_present method, use keywords/
@@ -194,6 +226,16 @@ not_compliant_on :safari do
       it "times out if the element doesn't disappear" do
         message = /^timed out after 1 seconds, waiting for false condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
         expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
+      end
+
+      it "uses provided interval" do
+        element = browser.div(id: 'foo')
+        expect(element).to receive(:present?).twice
+
+        begin
+          element.wait_until_present(timeout: 0.4, interval: 0.2)
+        rescue Watir::Wait::TimeoutError
+        end
       end
 
       it "ordered pairs are deprecated" do
@@ -229,6 +271,11 @@ not_compliant_on :safari do
         element = browser.div(id: 'bar')
         expect { element.wait_until(message: 'no') { true } }.to_not raise_exception
       end
+
+      it "accepts just an interval parameter" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until(interval: 0.1) { true } }.to_not raise_exception
+      end
     end
 
     describe "#wait_while" do
@@ -257,6 +304,11 @@ not_compliant_on :safari do
       it "accepts just a message parameter" do
         element = browser.div(id: 'foo')
         expect { element.wait_while(message: 'no') { false } }.to_not raise_exception
+      end
+
+      it "accepts just an interval parameter" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while(interval: 0.1) { false } }.to_not raise_exception
       end
     end
   end


### PR DESCRIPTION
A feature Selenium has had that's been missing in Watir. 0.1 second pings for 30 seconds is a lot of pings. Would also be up for changing these defaults, or allowing the defaults to be configurable.

@p0deje what do you think?