### PR TITLE
clean up the stdout

### DIFF
--- a/lib/watir/wait.rb
+++ b/lib/watir/wait.rb
@@ -115,7 +115,7 @@ module Watir
     # @param [String] message error message for when times out
     #
 
-    def wait_until(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: interval, &blk)
+    def wait_until(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: nil, &blk)
       if deprecated_message || deprecated_timeout
         warn "Instead of passing arguments into #wait_until, use keywords"
         timeout = deprecated_timeout
@@ -141,7 +141,7 @@ module Watir
     # @param [String] message error message for when times out
     #
 
-    def wait_while(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: interval, &blk)
+    def wait_while(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: nil, &blk)
       if deprecated_message || deprecated_timeout
         warn "Instead of passing arguments into #wait_while method, use keywords"
         timeout = deprecated_timeout

--- a/lib/watirspec.rb
+++ b/lib/watirspec.rb
@@ -72,15 +72,12 @@ module WatirSpec
       info = []
       info << instance.class.name
 
-      if instance.respond_to?(:driver) && instance.driver.class.name == "Selenium::WebDriver::Driver"
-        info << "(webdriver)"
-        caps = instance.driver.capabilities
+      caps = instance.driver.capabilities
 
-        info << "#{caps.browser_name}"
-        info << "#{caps.version}"
-      end
+      info << "#{caps.browser_name}"
+      info << "#{caps.version}"
 
-      $stderr.puts "running watirspec against #{info.join ' '} using args #{WatirSpec.implementation.browser_args.inspect}"
+      $stderr.puts "running watirspec against #{info.join ' '} using:\n#{WatirSpec.implementation.inspect_args}"
     rescue
       # ignored
     end

--- a/lib/watirspec/guards.rb
+++ b/lib/watirspec/guards.rb
@@ -19,7 +19,9 @@ module WatirSpec
         else
           puts
           gs.each do |guard|
-            puts "\t#{guard[:name].to_s.ljust(20)}: #{guard[:data].inspect}"
+            guard[:data][:file] = guard[:data][:file][/\/spec\/(.*):/, 1]
+            guard_name = "#{guard[:name]}:".ljust(15)
+            puts " #{guard_name} #{guard[:data].inspect}"
           end
         end
       end

--- a/lib/watirspec/implementation.rb
+++ b/lib/watirspec/implementation.rb
@@ -29,5 +29,13 @@ module WatirSpec
       result
     end
 
+    def inspect_args
+      caps = browser_args.last.delete(:desired_capabilities).send(:capabilities)
+      string = "driver: #{browser_args.first}\n"
+      browser_args.last.each { |arg| string << "#{arg.inspect}\n" }
+      string << "capabilities:\n"
+      caps.each { |k, v| string << "\t#{k}: #{v}\n"}
+      string
+    end
   end # Implementation
 end # WatirSpec

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -14,6 +14,7 @@ describe 'Watir#relaxed_locate?' do
             Watir.default_timeout = time_out
             element = browser.link(id: 'not_there')
             start_time = ::Time.now
+            allow($stderr).to receive(:write).twice
             expect { element.click }.to raise_exception(Watir::Exception::UnknownObjectException)
             expect(::Time.now - start_time).to be > time_out
           ensure
@@ -83,6 +84,7 @@ describe 'Watir#relaxed_locate?' do
             element = browser.div(id: 'also_hidden').div(id: 'hidden_child')
             error = Watir::Exception::UnknownObjectException
             message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+            allow($stderr).to receive(:write).twice
             expect { element.click }.to raise_exception(error, message)
           ensure
             Watir.default_timeout = 30
@@ -96,6 +98,7 @@ describe 'Watir#relaxed_locate?' do
             element = browser.div(id: 'buttons').button(id: 'btn2')
             error = Watir::Exception::UnknownObjectException
             message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+            allow($stderr).to receive(:write).twice
             expect { element.click }.to raise_exception(error, message)
           ensure
             Watir.default_timeout = 30
@@ -162,6 +165,7 @@ describe 'Watir#relaxed_locate?' do
         begin
           Watir.default_timeout = 1.1
           browser.a(id: 'add_foobar').click
+          allow($stderr).to receive(:write).twice
           # Element created after 1 second, and displays after 2 seconds
           # Click will only raise this exception if the timer is not reset between #wait_for_exists and #wait_for_present
           expect { browser.div(id: 'foobar').click }.to raise_exception Watir::Exception::UnknownObjectException


### PR DESCRIPTION
fixes the circular reference warning, formats the browser argument output in the beginning, stubs out the expected warnings (which will fail if the warning does not get thrown) and shortens the guard output at the end.

Also removes a `webdriver` conditional, which I don't think is needed any longer.