### PR TITLE
implement keyword support

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -12,6 +12,8 @@ module Watir
     include EventuallyPresent
     include Waitable
 
+    attr_accessor :keyword
+
     #
     # temporarily add :id and :class_name manually since they're no longer specified in the HTML spec.
     #
@@ -49,11 +51,16 @@ module Watir
     alias_method :exist?, :exists?
 
     def inspect
+      string = "#<#{self.class}: "
+      string << "keyword: #{keyword} " if keyword
+      string << "located: #{!!@element}; "
       if @selector.empty?
-        '#<%s:0x%x located=%s selector=%s>' % [self.class, hash*2, !!@element, '{element: (selenium element)}']
+        string << '{element: (selenium element)}'
       else
-        '#<%s:0x%x located=%s selector=%s>' % [self.class, hash*2, !!@element, selector_string]
+        string << selector_string
       end
+      string << '>'
+      string
     end
 
     #
@@ -505,7 +512,7 @@ module Watir
           warn message
         end
         raise unknown_exception, "timed out after #{Watir.default_timeout} seconds, "\
-                                         "waiting for #{selector_string} to be located"
+                                         "waiting for #{inspect} to be located"
       end
     end
 
@@ -534,7 +541,7 @@ module Watir
       begin
         wait_until(&:enabled?)
       rescue Watir::Wait::TimeoutError
-        message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector_string} to be enabled"
+        message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{inspect} to be enabled"
         raise ObjectDisabledException, message
       end
     end
@@ -546,7 +553,7 @@ module Watir
       begin
         wait_until { !respond_to?(:readonly?) || !readonly? }
       rescue Watir::Wait::TimeoutError
-        message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector_string} to not be readonly"
+        message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{inspect} to not be readonly"
         raise ObjectReadOnlyException, message
       end
     end
@@ -567,7 +574,7 @@ module Watir
 
     def assert_element_found
       unless @element
-        raise unknown_exception, "unable to locate element, using #{selector_string}"
+        raise unknown_exception, "unable to locate element: #{inspect}"
       end
     end
 
@@ -625,7 +632,7 @@ module Watir
 
     def assert_enabled
       unless element_call { @element.enabled? }
-        raise ObjectDisabledException, "object is disabled #{selector_string}"
+        raise ObjectDisabledException, "object is disabled #{inspect}"
       end
     end
 
@@ -633,7 +640,7 @@ module Watir
       assert_enabled
 
       if respond_to?(:readonly?) && readonly?
-        raise ObjectReadOnlyException, "object is read only #{selector_string}"
+        raise ObjectReadOnlyException, "object is read only #{inspect}"
       end
     end
 

--- a/lib/watir/wait.rb
+++ b/lib/watir/wait.rb
@@ -121,7 +121,7 @@ module Watir
         timeout = deprecated_timeout
         message = deprecated_message
       end
-      message ||= "waiting for true condition on #{selector_string}"
+      message ||= "waiting for true condition on #{inspect}"
       Wait.until(timeout: timeout, message: message, interval: interval, object: self, &blk)
 
       self
@@ -147,7 +147,7 @@ module Watir
         timeout = deprecated_timeout
         message = deprecated_message
       end
-      message ||= "waiting for false condition on #{selector_string}"
+      message ||= "waiting for false condition on #{inspect}"
       Wait.while(timeout: timeout, message: message, interval: interval, object: self, &blk)
 
       self

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -76,7 +76,7 @@ describe Watir::Element do
 
       watir_element = browser.div(id: "text")
 
-        # simulate element going stale after assert_exists and before action taken, but not when block retried
+      # simulate element going stale after assert_exists and before action taken, but not when block retried
       allow(watir_element).to receive(:text) do
         watir_element.send(:element_call) do
           @already_stale ||= false
@@ -106,33 +106,54 @@ describe Watir::Element do
     end
   end
 
-  describe "#selector_string" do
-    it "displays selector string for regular element" do
-      browser.goto(WatirSpec.url_for("wait.html"))
+  describe "#inspect" do
+    before(:each) { browser.goto(WatirSpec.url_for("nested_iframes.html")) }
+
+    it "does displays specified element type" do
+      expect(browser.div.inspect).to include('Watir::Div')
+    end
+
+    it "does not display element type if not specified" do
+      element = browser.element(index: 4)
+      expect(element.inspect).to include('Watir::HTMLElement')
+    end
+
+    it "displays keyword if specified" do
+      element = browser.h3
+      element.keyword = 'foo'
+      expect(element.inspect).to include('keyword: foo')
+    end
+
+    it "does not display keyword if not specified" do
+      element = browser.h3
+      expect(element.inspect).to_not include('keyword')
+    end
+
+    it "locate is false when not located" do
       element = browser.div(:id, 'not_present')
-      error = 'timed out after 0 seconds, waiting for true condition on {:id=>"not_present", :tag_name=>"div"}'
-      expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Wait::TimeoutError, error)
+      expect(element.inspect).to include('located: false')
+    end
+
+    it "locate is true when located" do
+      element = browser.h3
+      element.exists?
+      expect(element.inspect).to include('located: true')
     end
 
     it "displays selector string for element from colection" do
-      browser.goto(WatirSpec.url_for("wait.html"))
-      element = browser.divs.last
-      error = 'timed out after 0 seconds, waiting for true condition on {:tag_name=>"div", :index=>5}'
-      expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Wait::TimeoutError, error)
+      elements = browser.frames
+      expect(elements.last.inspect).to include '{:tag_name=>"frame", :index=>-1}'
     end
 
     it "displays selector string for nested element" do
       browser.goto(WatirSpec.url_for("wait.html"))
-      element = browser.div(index: -1).div(:id, 'foo')
-      error = 'timed out after 0 seconds, waiting for true condition on {:index=>-1, :tag_name=>"div"} --> {:id=>"foo", :tag_name=>"div"}'
-      expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Wait::TimeoutError, error)
+      element = browser.div(index: 1).div(id: 'div2')
+      expect(element.inspect).to include '{:index=>1, :tag_name=>"div"} --> {:id=>"div2", :tag_name=>"div"}'
     end
 
     it "displays selector string for nested element under frame" do
-      browser.goto(WatirSpec.url_for("nested_iframes.html"))
-      element = browser.iframe(id: 'one').iframe(:id, 'three')
-      error = 'unable to locate iframe using {:id=>"one", :tag_name=>"iframe"} --> {:id=>"three", :tag_name=>"iframe"}'
-      expect { element.wait_until_present(timeout: 0) }.to raise_exception(Watir::Exception::UnknownFrameException, error)
+      element = browser.iframe(id: 'one').iframe(id: 'three')
+      expect(element.inspect).to include '{:id=>"one", :tag_name=>"iframe"} --> {:id=>"three", :tag_name=>"iframe"}'
     end
   end
 end

--- a/spec/watirspec/html/nested_iframes.html
+++ b/spec/watirspec/html/nested_iframes.html
@@ -6,4 +6,8 @@
   <h3>Top Layer</h3>
   <iframe id="one" src="nested_frame_1.html"></iframe>
   <iframe id="two" src="nested_iframe_2.html"></iframe>
+
+  <div id="div1">
+    <div id="div2"></div>
+  </div>
 </html>

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -54,10 +54,10 @@ describe 'Watir#relaxed_locate?' do
         it 'fails first for parent not existing' do
           begin
             Watir.default_timeout = 0
-            selector = "{:id=>\"no_parent\", :tag_name=>\"div\"}"
+            inspected = '#<Watir::Div: located: false; {:id=>"no_parent", :tag_name=>"div"}>'
             element = browser.div(id: 'no_parent').div(id: 'no_child')
             error = Watir::Exception::UnknownObjectException
-            message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
+            message = "timed out after #{Watir.default_timeout} seconds, waiting for #{inspected} to be located"
             expect { element.click }.to raise_exception(error, message)
           ensure
             Watir.default_timeout = 30
@@ -67,10 +67,10 @@ describe 'Watir#relaxed_locate?' do
         it 'fails for child not existing if parent exists' do
           begin
             Watir.default_timeout = 0
-            selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"no_child\", :tag_name=>\"div\"}"
+            inspected = '#<Watir::Div: located: false; {:id=>"buttons", :tag_name=>"div"} --> {:id=>"no_child", :tag_name=>"div"}>'
             element = browser.div(id: 'buttons').div(id: 'no_child')
             error = Watir::Exception::UnknownObjectException
-            message = "timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be located"
+            message = "timed out after #{Watir.default_timeout} seconds, waiting for #{inspected} to be located"
             expect { element.click }.to raise_exception(error, message)
           ensure
             Watir.default_timeout = 30
@@ -80,10 +80,10 @@ describe 'Watir#relaxed_locate?' do
         it 'fails for parent not present if child exists' do
           begin
             Watir.default_timeout = 0.5
-            selector = "{:id=>\"also_hidden\", :tag_name=>\"div\"}"
+            inspected = '#<Watir::Div: located: true; {:id=>"also_hidden", :tag_name=>"div"}>'
             element = browser.div(id: 'also_hidden').div(id: 'hidden_child')
             error = Watir::Exception::UnknownObjectException
-            message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+            message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{inspected}"
             allow($stderr).to receive(:write).twice
             expect { element.click }.to raise_exception(error, message)
           ensure
@@ -94,10 +94,10 @@ describe 'Watir#relaxed_locate?' do
         it 'fails for child not present if parent is present' do
           begin
             Watir.default_timeout = 0.5
-            selector = "{:id=>\"buttons\", :tag_name=>\"div\"} --> {:id=>\"btn2\", :tag_name=>\"button\"}"
+            inspected = '#<Watir::Button: located: true; {:id=>"buttons", :tag_name=>"div"} --> {:id=>"btn2", :tag_name=>"button"}>'
             element = browser.div(id: 'buttons').button(id: 'btn2')
             error = Watir::Exception::UnknownObjectException
-            message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{selector}"
+            message = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for true condition on #{inspected}"
             allow($stderr).to receive(:write).twice
             expect { element.click }.to raise_exception(error, message)
           ensure
@@ -109,10 +109,10 @@ describe 'Watir#relaxed_locate?' do
           browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
           begin
             Watir.default_timeout = 0.5
-            selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"good_luck\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
+            inspected = '#<Watir::TextField: located: true; {:id=>"new_user", :tag_name=>"form"} --> {:id=>"good_luck", :tag_name=>"input or textarea", :type=>"(any text type)"}>'
             element = browser.form(id: 'new_user').text_field(id: 'good_luck')
             error = Watir::Exception::ObjectDisabledException
-            message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to be enabled"
+            message = "element present, but timed out after #{Watir.default_timeout} seconds, waiting for #{inspected} to be enabled"
             expect { element.set('foo') }.to raise_exception(error, message)
           ensure
             Watir.default_timeout = 30
@@ -123,10 +123,10 @@ describe 'Watir#relaxed_locate?' do
           browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
           begin
             Watir.default_timeout = 0.5
-            selector = "{:id=>\"new_user\", :tag_name=>\"form\"} --> {:id=>\"new_user_code\", :tag_name=>\"input or textarea\", :type=>\"(any text type)\"}"
+            inspected = '#<Watir::TextField: located: true; {:id=>"new_user", :tag_name=>"form"} --> {:id=>"new_user_code", :tag_name=>"input or textarea", :type=>"(any text type)"}>'
             element = browser.form(id: 'new_user').text_field(id: 'new_user_code')
             error = Watir::Exception::ObjectReadOnlyException
-            message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{selector} to not be readonly"
+            message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, waiting for #{inspected} to not be readonly"
             expect { element.set('foo') }.to raise_exception(error, message)
           ensure
             Watir.default_timeout = 30

--- a/spec/watirspec/support/raise_exception_matchers.rb
+++ b/spec/watirspec/support/raise_exception_matchers.rb
@@ -9,14 +9,15 @@ if defined?(RSpec)
   }.freeze
 
   TIMING_EXCEPTIONS.each do |matcher, exception|
-    RSpec::Matchers.define matcher do |_expected|
+    RSpec::Matchers.define matcher do |message|
       match do |actual|
         original_timeout = Watir.default_timeout
         Watir.default_timeout = 0
         begin
           actual.call
           false
-        rescue exception
+        rescue exception => ex
+          raise exception, "expected '#{message}' to be included in: '#{ex.message}'" unless message.nil? || ex.message.include?(message)
           true
         ensure
           Watir.default_timeout = original_timeout

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -167,8 +167,11 @@ not_compliant_on :safari do
         end
 
         it "times out" do
-          message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"btn", :tag_name=>"button"\}|\{:tag_name=>"button", :id=>"btn"\})$/
-          expect { browser.button(id: 'btn').wait_until(timeout: 1, &:enabled?).click }.to raise_error(Watir::Wait::TimeoutError, message)
+          error = Watir::Wait::TimeoutError
+          inspected = '#<Watir::Button: located: false; {:id=>"btn", :tag_name=>"button"}>'
+          message = "timed out after 1 seconds, waiting for true condition on #{inspected}"
+          element = browser.button(id: 'btn')
+          expect { element.wait_until(timeout: 1, &:enabled?).click }.to raise_error(error, message)
         end
 
         it "responds to Element methods" do
@@ -196,8 +199,11 @@ not_compliant_on :safari do
       end
 
       it "times out if the element doesn't appear" do
-        message = /^timed out after 1 seconds, waiting for true condition on (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\})$/
-        expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
+        inspected = '#<Watir::Div: located: false; {:id=>"bar", :tag_name=>"div"}>'
+        error = Watir::Wait::TimeoutError
+        message = "timed out after 1 seconds, waiting for true condition on #{inspected}"
+
+        expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(error, message)
       end
 
       it "uses provided interval" do
@@ -237,8 +243,10 @@ not_compliant_on :safari do
       end
 
       it "times out if the element doesn't disappear" do
-        message = /^timed out after 1 seconds, waiting for false condition on (\{:id=>"foo", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"foo"\})$/
-        expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(Watir::Wait::TimeoutError, message)
+        error = Watir::Wait::TimeoutError
+        inspected = '#<Watir::Div: located: false; {:id=>"foo", :tag_name=>"div"}>'
+        message = "timed out after 1 seconds, waiting for false condition on #{inspected}"
+        expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(error, message)
       end
 
       it "uses provided interval" do


### PR DESCRIPTION
Being able to set a keyword value for an element is especially useful for page object implementations. Rather than trying to match the selector output to a defined method, the user can now just look up the name of the element assigned. It would need to be implemented in the Page Object gems, but this provides the necessary hook for that.

Also, I changed the error messages to use `#selector_string` when really they should be using `#inspect` like was there before. `#selector_string` is still recursive, but `#inspect` includes information about "located", "class name" and the new "keyword." (I removed the memory information; that is still available with `Element#to_s`if anyone cares about it).

