### PR TITLE
To subtype

### DIFF
--- a/lib/watir/adjacent.rb
+++ b/lib/watir/adjacent.rb
@@ -1,5 +1,3 @@
-require "active_support/inflector"
-
 module Watir
   module Adjacent
 
@@ -73,19 +71,6 @@ module Watir
     alias_method :next_siblings, :following_siblings
 
     #
-    # Returns collection of all sibling elements of current element.
-    #
-    # @example
-    #   browser.text_field(name: "new_user_first_name").following_siblings.size
-    #   #=> 52
-    #
-
-    def siblings(opt = {})
-      raise ArgumentError, "#siblings can not take an index value" if opt[:index]
-      preceding_siblings(opt) + following_siblings(opt)
-    end
-
-    #
     # Returns element of direct child of current element.
     #
     # @example
@@ -122,10 +107,14 @@ module Watir
         raise ArgumentError, "unsupported locators: #{opt.inspect} for ##{caller} method"
       end
 
-      xpath = "./#{direction}#{tag_name || '*'}"
-      tag_name ||= 'element'
-      return self.send(tag_name.to_s.pluralize, {xpath: xpath}) unless index
-      self.send(tag_name, {xpath: "#{xpath}[#{index + 1}]"})
+      klass = self.send(tag_name).class if tag_name
+      if index
+        klass ||= HTMLElement
+        klass.new(self, xpath: "./#{direction}#{tag_name || '*'}[#{index + 1}]")
+      else
+        klass = tag_name ? Object.const_get("#{klass}Collection") : HTMLElementCollection
+        klass.new(self, xpath: "./#{direction}#{tag_name || '*'}")
+      end
     end
 
   end # Adjacent

--- a/lib/watir/adjacent.rb
+++ b/lib/watir/adjacent.rb
@@ -107,12 +107,11 @@ module Watir
         raise ArgumentError, "unsupported locators: #{opt.inspect} for ##{caller} method"
       end
 
-      klass = self.send(tag_name).class if tag_name
       if index
-        klass ||= HTMLElement
+        klass = tag_name ? self.send(tag_name).class : HTMLElement
         klass.new(self, xpath: "./#{direction}#{tag_name || '*'}[#{index + 1}]")
       else
-        klass = tag_name ? Object.const_get("#{klass}Collection") : HTMLElementCollection
+        klass = tag_name ? Object.const_get("#{self.send(tag_name).class}Collection") : HTMLElementCollection
         klass.new(self, xpath: "./#{direction}#{tag_name || '*'}")
       end
     end

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -110,20 +110,6 @@ module Watir
     #   #=> 8
     #
 
-    def +(other)
-      case
-      when to_a.empty?
-        other
-      when other.to_a.empty?
-        self
-      when to_a.class != other.to_a.class
-        raise  Watir::Exception::Error, "Unable to combine collection of #{to_a.class} and #{other.to_a.class}"
-      else
-        @to_a = to_a + other.to_a
-        self
-      end
-    end
-
     private
 
     def elements

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -81,7 +81,8 @@ module Watir
 
     def to_a
       @to_a ||= elements.map.with_index do |e, idx|
-        element_class.new(@query_scope, @selector.merge(element: e, index: idx))
+        element = element_class.new(@query_scope, @selector.merge(element: e, index: idx))
+        element_class == Watir::HTMLElement ? element.to_subtype : element
       end
     end
 

--- a/spec/watirspec/adjacent_spec.rb
+++ b/spec/watirspec/adjacent_spec.rb
@@ -119,18 +119,6 @@ describe "Adjacent Elements" do
     end
   end
 
-  describe "#siblings" do
-    it "gets collection of siblings of an element" do
-      expect(browser.div(id: "first_sibling").siblings.size).to eq 4
-    end
-
-    it "gets collection of siblings of an element by tag" do
-      siblings = browser.div(id: "first_sibling").siblings(tag_name: :div)
-      expect(siblings.size).to eq 2
-      expect(siblings.all? { |sib| sib.is_a? Watir::Div }).to eq true
-    end
-  end
-
   describe "#child" do
     it "gets immediate child of an element by default" do
       expect(browser.div(id: "parent").child.id).to eq 'first_sibling'

--- a/spec/watirspec/elements/collections_spec.rb
+++ b/spec/watirspec/elements/collections_spec.rb
@@ -2,15 +2,26 @@ require "watirspec_helper"
 
 describe "Collections" do
 
-  before :each do
-    browser.goto(WatirSpec.url_for("collections.html"))
-  end
-
   it "returns inner elements of parent element having different html tag" do
+    browser.goto(WatirSpec.url_for("collections.html"))
     expect(browser.span(id: "a_span").divs.size).to eq 2
   end
 
   it "returns inner elements of parent element having same html tag" do
+    browser.goto(WatirSpec.url_for("collections.html"))
     expect(browser.span(id: "a_span").spans.size).to eq 2
+  end
+
+  it "returns correct subtype of elements" do
+    browser.goto(WatirSpec.url_for("collections.html"))
+    collection = browser.span(id: "a_span").spans.to_a
+    expect(collection.all? { |el| el.is_a? Watir::Span}).to eq true
+  end
+
+  it "can contain more than one type of element" do
+    browser.goto(WatirSpec.url_for("nested_elements.html"))
+    collection = browser.div(id: "parent").children
+    expect(collection.any? { |el| el.is_a? Watir::Span}).to eq true
+    expect(collection.any? { |el| el.is_a? Watir::Div}).to eq true
   end
 end


### PR DESCRIPTION
Removes support for `#siblings` since combining HTMLCollections seems like more trouble than it is worth. Doing it "correctly" would mean figuring out how to handle multiple selector signatures, etc, and if users really want it they can iterate over both the previous & next collections themselves.

Also uses `Element#to_subtype` to objects in `ElementCollection` in lieu of #521 