### PR TITLE
use javascript to get selected options

### DIFF
--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -112,7 +112,7 @@ module Watir
     #
 
     def selected_options
-      options.select { |e| e.selected? }
+      browser.execute_script("return arguments[0].selectedOptions;", self)
     end
 
     private


### PR DESCRIPTION
This PR is based on [this Stack Overflow question](http://stackoverflow.com/questions/42724129/watir-web-driver-taking-too-long-to-get-the-selected-item-from-drop-down), and @jkotests's response.

The reason to use Selenium calls instead of a javascript call is typically because Selenium attempts to evaluate the visibility of an option. In the case of obtaining selected options, I don't think it is possible for it to be hidden. As such I think using javascript here for performance reasons is a reasonable alternative.

@p0deje what do you think?

