### PR TITLE
support for map of text of elements in ElementCollection

### DIFF
--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -74,6 +74,28 @@ module Watir
     end
 
     #
+    # List of block calls on each element in this collection
+    #
+    # @param [Block]
+    # @return [Proc]
+    #
+
+    def map &block
+      raise ArgumentError, "#map requires a block as an argument" unless block_given?
+      to_a.map { |a| block.call(a) }
+    end
+
+    #
+    # List of text values of each element in this collection
+    #
+    # @return [String]
+    #
+
+    def text
+      map(&:text)
+    end
+
+    #
     # This collection as an Array.
     #
     # @return [Array<Watir::Element>]

--- a/spec/watirspec/elements/elements_spec.rb
+++ b/spec/watirspec/elements/elements_spec.rb
@@ -33,4 +33,12 @@ describe "Elements" do
     end
   end
 
+  describe "#text" do
+    it "returns an array of text for each item in the collection" do
+      array = ['Denmark', 'Norway', 'Sweden', 'United Kingdom', 'USA', 'Germany']
+      opts = browser.select(id: 'new_user_country').options
+      expect(opts.text).to eq array
+    end
+  end
+
 end


### PR DESCRIPTION
Prompted by this: https://stackoverflow.com/questions/44154398/ruby-code-to-display-table-element-details

But I use map a lot in debugging and I pretty much always forget to do #to_a first. This should make it easier to do what I expect is a common action.

I'm not sure I have the comment documentation correct, though. 