### PR TITLE
Validate that path has valid extension when saving a screenshot (closes #400)

### DIFF
--- a/lib/watir/screenshot.rb
+++ b/lib/watir/screenshot.rb
@@ -1,6 +1,8 @@
 module Watir
   class Screenshot
 
+    PNG_EXTENSIONS = ['.png']
+
     def initialize(driver)
       @driver = driver
     end
@@ -12,9 +14,14 @@ module Watir
     #   browser.screenshot.save "screenshot.png"
     #
     # @param [String] path
+    # @raise [ArgumentError] if path has a non-png extension
     #
 
     def save(path)
+      extension = File.extname(path).downcase
+      if !extension.empty? && !PNG_EXTENSIONS.include?(extension)
+        raise ArgumentError, "#save can only save PNG files so paths with non-PNG extensions are not supported"
+      end
       @driver.save_screenshot(path)
     end
 

--- a/lib/watir/screenshot.rb
+++ b/lib/watir/screenshot.rb
@@ -20,7 +20,7 @@ module Watir
     def save(path)
       extension = File.extname(path).downcase
       if !extension.empty? && !PNG_EXTENSIONS.include?(extension)
-        raise ArgumentError, "#save can only save PNG files so paths with non-PNG extensions are not supported"
+        warn "#save will save an image in PNG format because Webdriver supports only PNG screenshots"
       end
       @driver.save_screenshot(path)
     end

--- a/spec/watirspec/screenshot_spec.rb
+++ b/spec/watirspec/screenshot_spec.rb
@@ -19,28 +19,28 @@ describe "Watir::Screenshot" do
 
   describe '#save' do
     it 'saves screenshot to given file' do
-      path = "#{Dir.tmpdir}/test#{Time.now.to_i}.png"
+      path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}.png"
       assert_saves_png_file(path) do
         browser.screenshot.save(path)
       end
     end
 
     it 'saves a file to a path without extension' do
-      path = "#{Dir.tmpdir}/test#{Time.now.to_i}"
+      path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}"
       assert_saves_png_file(path) do
         browser.screenshot.save(path)
       end
     end
 
     it 'saves a file to a path with an uppercase PNG extension' do
-      path = "#{Dir.tmpdir}/test#{Time.now.to_i}.PNG"
+      path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}.PNG"
       assert_saves_png_file(path) do
         browser.screenshot.save(path)
       end
     end
 
     it 'raises an ArgumentError if extension of provided file is not png' do
-      path = "#{Dir.tmpdir}/test#{Time.now.to_i}.jpg"
+      path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}.jpg"
       expect do
         browser.screenshot.save(path)
       end.to raise_error(ArgumentError)

--- a/spec/watirspec/screenshot_spec.rb
+++ b/spec/watirspec/screenshot_spec.rb
@@ -20,8 +20,35 @@ describe "Watir::Screenshot" do
   describe '#save' do
     it 'saves screenshot to given file' do
       path = "#{Dir.tmpdir}/test#{Time.now.to_i}.png"
+      assert_saves_png_file(path) do
+        browser.screenshot.save(path)
+      end
+    end
+
+    it 'saves a file to a path without extension' do
+      path = "#{Dir.tmpdir}/test#{Time.now.to_i}"
+      assert_saves_png_file(path) do
+        browser.screenshot.save(path)
+      end
+    end
+
+    it 'saves a file to a path with an uppercase PNG extension' do
+      path = "#{Dir.tmpdir}/test#{Time.now.to_i}.PNG"
+      assert_saves_png_file(path) do
+        browser.screenshot.save(path)
+      end
+    end
+
+    it 'raises an ArgumentError if extension of provided file is not png' do
+      path = "#{Dir.tmpdir}/test#{Time.now.to_i}.jpg"
+      expect do
+        browser.screenshot.save(path)
+      end.to raise_error(ArgumentError)
+    end
+
+    def assert_saves_png_file(path)
       expect(File).to_not exist(path)
-      browser.screenshot.save(path)
+      yield
       expect(File).to exist(path)
       expect(File.open(path, "rb") { |io| io.read }[0..3]).to eq png_header
     end

--- a/spec/watirspec/screenshot_spec.rb
+++ b/spec/watirspec/screenshot_spec.rb
@@ -41,9 +41,12 @@ describe "Watir::Screenshot" do
 
     it 'raises an ArgumentError if extension of provided file is not png' do
       path = "#{Dir.tmpdir}/test#{SecureRandom.urlsafe_base64}.jpg"
+      message = "#save will save an image in PNG format because Webdriver supports only PNG screenshots\n"
       expect do
-        browser.screenshot.save(path)
-      end.to raise_error(ArgumentError)
+        assert_saves_png_file(path) do
+          browser.screenshot.save(path)
+        end
+      end.to output(message).to_stderr
     end
 
     def assert_saves_png_file(path)


### PR DESCRIPTION
Webdriver spec [says that only PNG is supported](https://w3c.github.io/webdriver/webdriver-spec.html#dfn-encode-as-base64-a-canvas-element).