### PR TITLE
Add #text method for select lists

### DIFF
--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -106,7 +106,7 @@ module Watir
 
 
     #
-    # Returns an array of currently selected options.
+    # Returns a single selected option.
     #
     # @return [Array<Watir::Option>]
     #

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -104,25 +104,25 @@ module Watir
       o.value
     end
 
-
     #
-    # Returns a single selected option.
+    # Returns the text of the first selected option in the select list.
+    # Returns nil if no option is selected.
+    #
+    # @return [String, nil]
+    #
+
+    def text
+      o = options.find { |e| e.selected? } || return
+      o.text
+    end
+    
+    # Returns an array of currently selected options.
     #
     # @return [Array<Watir::Option>]
     #
 
     def selected_options
       options.select { |e| e.selected? }
-    end
-
-
-    # Returns an array of currently selected options.
-    #
-    # @return [Array<Watir::Option>]
-    #
-
-    def selected_option
-      options.find { |e| e.selected? }
     end
 
 

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -115,6 +115,17 @@ module Watir
       options.select { |e| e.selected? }
     end
 
+
+    # Returns an array of currently selected options.
+    #
+    # @return [Array<Watir::Option>]
+    #
+
+    def selected_option
+      options.find { |e| e.selected? }
+    end
+
+
     private
 
     def select_by(how, str_or_rx)

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -167,6 +167,16 @@ describe "SelectList" do
       expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["English", "Norwegian"]
     end
   end
+  
+  describe "#selected_option" do
+    it "should raise UnknownObjectException if the select list doesn't exist" do
+      expect(browser.select_list(name: 'no_such_name').selected_option).to raise_unknown_object_exception
+    end
+    
+    it "gets the only currently selected item" do
+      expect(browser.select_list(id: "new_user_country").selected_option.text).to eq "Norway"
+    end
+  end
 
   describe "#clear" do
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -102,6 +102,18 @@ describe "SelectList" do
       expect { browser.select_list(index: 1337).value }.to raise_unknown_object_exception
     end
   end
+  
+  describe "#text" do
+    it "returns the text of the selected option" do
+      expect(browser.select_list(index: 0).text).to eq "Norway"
+      browser.select_list(index: 0).select(/Sweden/)
+      expect(browser.select_list(index: 0).text).to eq "Sweden"
+    end
+    
+    it "raises UnknownObjectException if the select list doesn't exist" do
+      expect { browser.select_list(index: 1337).text }.to raise_unknown_object_exception
+    end
+  end
 
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
@@ -165,16 +177,6 @@ describe "SelectList" do
     it "gets the currently selected item(s)" do
       expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Norway"]
       expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["English", "Norwegian"]
-    end
-  end
-  
-  describe "#selected_option" do
-    it "should raise UnknownObjectException if the select list doesn't exist" do
-      expect(browser.select_list(name: 'no_such_name').selected_option).to raise_unknown_object_exception
-    end
-    
-    it "gets the only currently selected item" do
-      expect(browser.select_list(id: "new_user_country").selected_option.text).to eq "Norway"
     end
   end
 


### PR DESCRIPTION
If I want to access the text of a selected option in a select list that doesn't use the multiple attribute, I have to do this:

`some_select_list(name: 'list').selected_options.first.text`

While its not the most egregious thing ever, its just inconvenient if the majority of your select lists don't use the multiple attribute. This PR allows the following:

`some_select_list(name: 'list').selected_option.text`

**UPDATE**:

After some discussion with @titusfortner and other folks on Slack, `selected_option` was a bit dangerous when used with select lists that use the `multiple` attribute. Following the same pattern as the `value` method, I opted for a `text` method instead.

If you need to output the text of everything inside a select_list, I would just map/collect them.

`select_list.options.map(&:text)`

Let me know your suggestions.