### PR TITLE
6 2 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,4 @@ env:
   - RAKE_TASK=spec:firefox RELAXED_LOCATE=false
   - RAKE_TASK=spec:chrome
   - RAKE_TASK=spec:chrome RELAXED_LOCATE=false
-  - RAKE_TASK=spec:phantomjs
-  - RAKE_TASK=spec:phantomjs RELAXED_LOCATE=false
   - RAKE_TASK=yard:doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: trusty
 sudo: require
 rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 addons:
   firefox: latest
   apt:
@@ -20,8 +20,6 @@ notifications:
   slack:
     secure: BLsBCm33R32VNRccrLx9F0P24X6BVpVHj1OWaN4Kyn6g9qXteIwC2VKVMnKNbifpojfMkrn0OeFQFK1O1DSOsC3mgzn/udoB+DnUGcSemFUn04xhbYF5SI+3zGPKPo0JLvjjdEKSSma84YwKdrj88pGUK34p01gL8hiaqjFzWdk=
 before_script:
-  - mkdir travis-drivers
-  - export PATH=$PWD/travis-drivers:$PATH
   - support/travis.sh
 script: bundle exec rake $RAKE_TASK
 env:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 ### 6.2.2 (Unreleased)
 
 * Allow locating elements by attribute presence/absence (#345)
+* Element#flash configurable by color, number, and delay (thanks Paul3816547290)
+* Implement Select#text like Select#value (thanks Arik Jones)
+* Optimize Select#selected_options, Select#value, and Select#text with javascript (thanks Andrei Botalov)
+* Support #execute_script from inside frame context
+* Deprecate PhantomJS Support
 
 ### 6.2.1 (2017-03-22)
 

--- a/Rakefile
+++ b/Rakefile
@@ -126,7 +126,6 @@ namespace :spec do
   task browsers: [:chrome,
                   :firefox,
                   :ff_legacy,
-                  :phantomjs,
                   (:safari if Selenium::WebDriver::Platform.mac?),
                   (:ie if Selenium::WebDriver::Platform.windows?),
                   (:edge if Selenium::WebDriver::Platform.windows?)].compact
@@ -135,12 +134,11 @@ namespace :spec do
   task remote_browsers: [:remote_chrome,
                          :remote_firefox,
                          :remote_ff_legacy,
-                         :remote_phantomjs,
                          (:remote_safari if Selenium::WebDriver::Platform.mac?),
                          (:remote_ie if Selenium::WebDriver::Platform.windows?),
                          (:remote_edge if Selenium::WebDriver::Platform.windows?)].compact
 
-  %w(firefox ff_legacy chrome safari phantomjs ie edge).each do |browser|
+  %w(firefox ff_legacy chrome safari ie edge).each do |browser|
     desc "Run specs in #{browser}"
     task browser do
       ENV['WATIR_BROWSER'] = browser

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -258,7 +258,7 @@ module Watir
       args.map! { |e| e.kind_of?(Watir::Element) ? e.wd : e }
       returned = @driver.execute_script(script, *args)
 
-      wrap_elements_in(returned)
+      wrap_elements_in(self, returned)
     end
 
     #
@@ -324,14 +324,14 @@ module Watir
 
     private
 
-    def wrap_elements_in(obj)
+    def wrap_elements_in(scope, obj)
       case obj
       when Selenium::WebDriver::Element
-        wrap_element(obj)
+        wrap_element(scope, obj)
       when Array
-        obj.map { |e| wrap_elements_in(e) }
+        obj.map { |e| wrap_elements_in(scope, e) }
       when Hash
-        obj.each { |k,v| obj[k] = wrap_elements_in(v) }
+        obj.each { |k,v| obj[k] = wrap_elements_in(scope, v) }
 
         obj
       else
@@ -339,8 +339,8 @@ module Watir
       end
     end
 
-    def wrap_element(element)
-      Watir.element_class_for(element.tag_name.downcase).new(self, element: element)
+    def wrap_element(scope, element)
+      Watir.element_class_for(element.tag_name.downcase).new(scope, element: element)
     end
 
   end # Browser

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -468,6 +468,13 @@ module Watir
     end
 
     #
+    # Delegates script execution to browser or frame.
+    #
+    def execute_script(script, *args)
+      @query_scope.execute_script(script, *args)
+    end
+
+    #
     # Returns true if a previously located element is no longer attached to DOM.
     #
     # @return [Boolean]

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -54,8 +54,17 @@ module Watir
       wd.page_source
     end
 
-    def execute_script(*args)
-      browser.execute_script(*args)
+    #
+    # Executes JavaScript snippet in context of frame.
+    #
+    # @see Watir::Browser#execute_script
+    #
+
+    def execute_script(script, *args)
+      args.map! { |e| e.kind_of?(Watir::Element) ? e.wd : e }
+      returned = driver.execute_script(script, *args)
+
+      browser.send :wrap_elements_in, self, returned
     end
 
     private

--- a/lib/watir/elements/image.rb
+++ b/lib/watir/elements/image.rb
@@ -23,8 +23,9 @@ module Watir
     #
 
     def width
-      wait_for_exists
-      driver.execute_script "return arguments[0].width", @element
+      element_call do
+        driver.execute_script "return arguments[0].width", @element
+      end
     end
 
   end # Image

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -100,8 +100,8 @@ module Watir
     #
 
     def value
-      o = options.find { |e| e.selected? } || return
-      o.value
+      option = selected_options.first
+      option && option.value
     end
 
     #
@@ -122,7 +122,18 @@ module Watir
     #
 
     def selected_options
-      options.select { |e| e.selected? }
+      element_call do
+        script = <<-SCRIPT
+          var result = [];
+          var options = arguments[0].options;
+          for (var i = 0; i < options.length; i++) {
+            var option = options[i];
+            if (option.selected) { result.push(option) }
+          }
+          return result;
+        SCRIPT
+        browser.execute_script(script, self)
+      end
     end
 
     private

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -132,7 +132,7 @@ module Watir
           }
           return result;
         SCRIPT
-        browser.execute_script(script, self)
+        @query_scope.execute_script(script, self)
       end
     end
 

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -112,8 +112,8 @@ module Watir
     #
 
     def text
-      o = options.find { |e| e.selected? } || return
-      o.text
+      option = selected_options.first
+      option && option.text
     end
     
     # Returns an array of currently selected options.

--- a/lib/watir/extensions/select_text.rb
+++ b/lib/watir/extensions/select_text.rb
@@ -3,8 +3,9 @@ Watir::Atoms.load :selectText
 module Watir
   class Element
     def select_text(str)
-      wait_for_exists
-      execute_atom :selectText, @element, str
+      element_call do
+        execute_atom :selectText, @element, str
+      end
     end
   end # Element
 end # Watir

--- a/lib/watirspec/rake_tasks.rb
+++ b/lib/watirspec/rake_tasks.rb
@@ -83,9 +83,9 @@ WatirSpec.implementation do |watirspec|
   #
   # watirspec.name = :watizzle
   # watirspec.browser_class = Watir::Browser
-  # watirspec.browser_args = [:phantomjs, {}]
+  # watirspec.browser_args = [:firefox, {}]
   # watirspec.guard_proc = lambda do |args|
-  #   args.include?(:phantomjs)
+  #   args.include?(:firefox)
   # end
 end
 

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -104,60 +104,58 @@ describe "Browser::AfterHooks" do
       end
     end
 
-    bug "https://github.com/detro/ghostdriver/issues/20", :phantomjs do
-      not_compliant_on :safari do
-        it "runs after_hooks after Alert#ok" do
+    not_compliant_on :safari do
+      it "runs after_hooks after Alert#ok" do
+        browser.goto(WatirSpec.url_for("alerts.html"))
+        @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
+        browser.after_hooks.add @page_after_hook
+        browser.after_hooks.without { browser.button(id: 'alert').click }
+        browser.alert.ok
+        expect(@yield).to be true
+      end
+
+      bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+        it "runs after_hooks after Alert#close" do
           browser.goto(WatirSpec.url_for("alerts.html"))
           @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
           browser.after_hooks.add @page_after_hook
           browser.after_hooks.without { browser.button(id: 'alert').click }
-          browser.alert.ok
+          browser.alert.close
           expect(@yield).to be true
         end
+      end
 
-        bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
-          it "runs after_hooks after Alert#close" do
-            browser.goto(WatirSpec.url_for("alerts.html"))
-            @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
-            browser.after_hooks.add @page_after_hook
-            browser.after_hooks.without { browser.button(id: 'alert').click }
-            browser.alert.close
-            expect(@yield).to be true
-          end
-        end
-
-        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1279211", :firefox do
-          it "raises UnhandledAlertError error when running error checks with alert present" do
-            url = WatirSpec.url_for("alerts.html")
-            @page_after_hook = Proc.new { browser.url }
-            browser.after_hooks.add @page_after_hook
-            browser.goto url
-            expect { browser.button(id: "alert").click }.to raise_error(Selenium::WebDriver::Error::UnhandledAlertError)
-
-            not_compliant_on :ff_legacy do
-              browser.alert.ok
-            end
-          end
-        end
-
-        it "does not raise error when running error checks using #after_hooks#without with alert present" do
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1279211", :firefox do
+        it "raises UnhandledAlertError error when running error checks with alert present" do
           url = WatirSpec.url_for("alerts.html")
           @page_after_hook = Proc.new { browser.url }
           browser.after_hooks.add @page_after_hook
           browser.goto url
-          expect { browser.after_hooks.without {browser.button(id: "alert").click} }.to_not raise_error
-          browser.alert.ok
-        end
+          expect { browser.button(id: "alert").click }.to raise_error(Selenium::WebDriver::Error::UnhandledAlertError)
 
-        it "does not raise error if no error checks are defined with alert present" do
-          url = WatirSpec.url_for("alerts.html")
-          @page_after_hook = Proc.new { browser.url }
-          browser.after_hooks.add @page_after_hook
-          browser.goto url
-          browser.after_hooks.delete @page_after_hook
-          expect { browser.button(id: "alert").click }.to_not raise_error
-          browser.alert.ok
+          not_compliant_on :ff_legacy do
+            browser.alert.ok
+          end
         end
+      end
+
+      it "does not raise error when running error checks using #after_hooks#without with alert present" do
+        url = WatirSpec.url_for("alerts.html")
+        @page_after_hook = Proc.new { browser.url }
+        browser.after_hooks.add @page_after_hook
+        browser.goto url
+        expect { browser.after_hooks.without { browser.button(id: "alert").click } }.to_not raise_error
+        browser.alert.ok
+      end
+
+      it "does not raise error if no error checks are defined with alert present" do
+        url = WatirSpec.url_for("alerts.html")
+        @page_after_hook = Proc.new { browser.url }
+        browser.after_hooks.add @page_after_hook
+        browser.goto url
+        browser.after_hooks.delete @page_after_hook
+        expect { browser.button(id: "alert").click }.to_not raise_error
+        browser.alert.ok
       end
     end
 

--- a/spec/watirspec/alert_spec.rb
+++ b/spec/watirspec/alert_spec.rb
@@ -1,98 +1,96 @@
 require "watirspec_helper"
 
 describe 'Alert API' do
-  bug "https://github.com/detro/ghostdriver/issues/20", :phantomjs do
-    not_compliant_on :safari do
-      before do
-        browser.goto WatirSpec.url_for("alerts.html")
+  not_compliant_on :safari do
+    before do
+      browser.goto WatirSpec.url_for("alerts.html")
+    end
+
+    after do
+      browser.alert.ok if browser.alert.exists?
+    end
+
+    context 'alert' do
+      describe '#text' do
+        it 'returns text of alert' do
+          browser.button(id: 'alert').click
+          expect(browser.alert.text).to include('ok')
+        end
       end
 
-      after do
-        browser.alert.ok if browser.alert.exists?
+      describe '#exists?' do
+        it 'returns false if alert is not present' do
+          expect(browser.alert).to_not exist
+        end
+
+        it 'returns true if alert is present' do
+          browser.button(id: 'alert').click
+          browser.wait_until(timeout: 10) { browser.alert.exists? }
+        end
       end
 
-      context 'alert' do
-        describe '#text' do
-          it 'returns text of alert' do
-            browser.button(id: 'alert').click
-            expect(browser.alert.text).to include('ok')
-          end
+      describe '#ok' do
+        it 'closes alert' do
+          browser.button(id: 'alert').click
+          browser.alert.ok
+          expect(browser.alert).to_not exist
         end
+      end
 
-        describe '#exists?' do
-          it 'returns false if alert is not present' do
-            expect(browser.alert).to_not exist
-          end
-
-          it 'returns true if alert is present' do
-            browser.button(id: 'alert').click
-            browser.wait_until(timeout: 10) { browser.alert.exists? }
-          end
-        end
-
-        describe '#ok' do
+      bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+        describe '#close' do
           it 'closes alert' do
             browser.button(id: 'alert').click
-            browser.alert.ok
+            browser.alert.close
             expect(browser.alert).to_not exist
           end
         end
+      end
 
-        bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
-          describe '#close' do
-            it 'closes alert' do
-              browser.button(id: 'alert').click
-              browser.alert.close
-              expect(browser.alert).to_not exist
-            end
+      not_compliant_on :relaxed_locate do
+        describe 'wait_until_present' do
+          it 'waits until alert is present and goes on' do
+            browser.button(id: 'timeout-alert').click
+            browser.alert.wait_until_present.ok
+
+            expect(browser.alert).to_not exist
           end
-        end
 
-        not_compliant_on :relaxed_locate do
-          describe 'wait_until_present' do
-            it 'waits until alert is present and goes on' do
-              browser.button(id: 'timeout-alert').click
+          it 'raises error if alert is not present after timeout' do
+            expect {
               browser.alert.wait_until_present.ok
-
-              expect(browser.alert).to_not exist
-            end
-
-            it 'raises error if alert is not present after timeout' do
-              expect {
-                browser.alert.wait_until_present.ok
-              }.to raise_error(Watir::Wait::TimeoutError)
-            end
+            }.to raise_error(Watir::Wait::TimeoutError)
           end
         end
       end
+    end
 
-      context 'confirm' do
-        describe '#ok' do
-          it 'accepts confirm' do
-            browser.button(id: 'confirm').click
+    context 'confirm' do
+      describe '#ok' do
+        it 'accepts confirm' do
+          browser.button(id: 'confirm').click
+          browser.alert.ok
+          expect(browser.button(id: 'confirm').value).to eq "true"
+        end
+      end
+
+      describe '#close' do
+        it 'cancels confirm' do
+          browser.button(id: 'confirm').click
+          browser.alert.close
+          expect(browser.button(id: 'confirm').value).to eq "false"
+        end
+      end
+    end
+
+    context 'prompt' do
+      describe '#set' do
+        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
+          it 'enters text to prompt' do
+            browser.button(id: 'prompt').click
+            browser.alert.set 'My Name'
             browser.alert.ok
-            expect(browser.button(id: 'confirm').value).to eq "true"
-          end
-        end
-
-        describe '#close' do
-          it 'cancels confirm' do
-            browser.button(id: 'confirm').click
-            browser.alert.close
-            expect(browser.button(id: 'confirm').value).to eq "false"
-          end
-        end
-      end
-
-      context 'prompt' do
-        describe '#set' do
-          bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
-            it 'enters text to prompt' do
-              browser.button(id: 'prompt').click
-              browser.alert.set 'My Name'
-              browser.alert.ok
-              expect(browser.button(id: 'prompt').value).to eq 'My Name'
-            end
+            expect(browser.button(id: 'prompt').value).to eq 'My Name'
           end
         end
       end

--- a/spec/watirspec/cookies_spec.rb
+++ b/spec/watirspec/cookies_spec.rb
@@ -1,147 +1,145 @@
 require "watirspec_helper"
 
-bug "https://github.com/ariya/phantomjs/issues/13115", :phantomjs do
-  describe "Browser#cookies" do
-    after { browser.cookies.clear }
+describe "Browser#cookies" do
+  after { browser.cookies.clear }
 
-    it 'gets an empty list of cookies' do
-      browser.goto WatirSpec.url_for 'collections.html' # no cookie set.
-      expect(browser.cookies.to_a).to eq []
+  it 'gets an empty list of cookies' do
+    browser.goto WatirSpec.url_for 'collections.html' # no cookie set.
+    expect(browser.cookies.to_a).to eq []
+  end
+
+  it "gets any cookies set" do
+    browser.goto set_cookie_url
+
+    verify_cookies_count 1
+
+    cookie = browser.cookies.to_a.first
+    expect(cookie[:name]).to eq 'monster'
+    expect(cookie[:value]).to eq '1'
+  end
+
+  describe '#[]' do
+    before do
+      browser.goto set_cookie_url
+      verify_cookies_count 1
     end
 
-    it "gets any cookies set" do
-      browser.goto set_cookie_url
+    it 'returns cookie by symbol name' do
+      cookie = browser.cookies[:monster]
+      expect(cookie[:name]).to eq('monster')
+      expect(cookie[:value]).to eq('1')
+    end
 
+    it 'returns cookie by string name' do
+      cookie = browser.cookies['monster']
+      expect(cookie[:name]).to eq('monster')
+      expect(cookie[:value]).to eq('1')
+    end
+
+    it 'returns nil if there is no cookie with such name' do
+      expect(browser.cookies[:non_monster]).to eq(nil)
+    end
+  end
+
+  not_compliant_on :internet_explorer do
+    it 'adds a cookie' do
+      browser.goto set_cookie_url
       verify_cookies_count 1
 
-      cookie = browser.cookies.to_a.first
-      expect(cookie[:name]).to eq 'monster'
-      expect(cookie[:value]).to eq '1'
-    end
+      browser.cookies.add 'foo', 'bar'
+      verify_cookies_count 2
 
-    describe '#[]' do
-      before do
-        browser.goto set_cookie_url
-        verify_cookies_count 1
-      end
-
-      it 'returns cookie by symbol name' do
-        cookie = browser.cookies[:monster]
-        expect(cookie[:name]).to eq('monster')
-        expect(cookie[:value]).to eq('1')
-      end
-
-      it 'returns cookie by string name' do
-        cookie = browser.cookies['monster']
-        expect(cookie[:name]).to eq('monster')
-        expect(cookie[:value]).to eq('1')
-      end
-
-      it 'returns nil if there is no cookie with such name' do
-        expect(browser.cookies[:non_monster]).to eq(nil)
+      compliant_on :safari do
+        $browser.close
+        $browser = WatirSpec.new_browser
       end
     end
+  end
 
-    not_compliant_on :internet_explorer do
-      it 'adds a cookie' do
+  # TODO - Split this up into multiple tests or figure out which parts are not compliant
+  not_compliant_on :chrome, :internet_explorer, :safari, :firefox do
+    it 'adds a cookie with options' do
+      browser.goto set_cookie_url
+
+      expires = Time.now + 10000
+      options = {path: "/set_cookie",
+                 secure: true,
+                 expires: expires}
+
+      browser.cookies.add 'a', 'b', options
+      cookie = browser.cookies.to_a.find { |e| e[:name] == 'a' }
+      expect(cookie).to_not be_nil
+
+      expect(cookie[:name]).to eq 'a'
+      expect(cookie[:value]).to eq 'b'
+
+      expect(cookie[:path]).to eq "/set_cookie"
+      expect(cookie[:secure]).to be true
+
+      expect(cookie[:expires]).to be_kind_of(Time)
+      # a few ms slack
+      expect((cookie[:expires]).to_i).to be_within(2).of(expires.to_i)
+    end
+  end
+
+  not_compliant_on :internet_explorer do
+    it 'removes a cookie' do
+      browser.goto set_cookie_url
+      verify_cookies_count 1
+
+      browser.cookies.delete 'monster'
+      verify_cookies_count 0
+    end
+
+    bug "https://code.google.com/p/selenium/issues/detail?id=5487", :safari do
+      it 'clears all cookies' do
         browser.goto set_cookie_url
-        verify_cookies_count 1
-
         browser.cookies.add 'foo', 'bar'
         verify_cookies_count 2
 
-        compliant_on :safari do
-          $browser.close
-          $browser = WatirSpec.new_browser
-        end
-      end
-    end
-
-    # TODO - Split this up into multiple tests or figure out which parts are not compliant
-    not_compliant_on :chrome, :internet_explorer, :safari, :firefox do
-      it 'adds a cookie with options' do
-        browser.goto set_cookie_url
-
-        expires = Time.now + 10000
-        options = {path: "/set_cookie",
-                   secure: true,
-                   expires: expires}
-
-        browser.cookies.add 'a', 'b', options
-        cookie = browser.cookies.to_a.find { |e| e[:name] == 'a' }
-        expect(cookie).to_not be_nil
-
-        expect(cookie[:name]).to eq 'a'
-        expect(cookie[:value]).to eq 'b'
-
-        expect(cookie[:path]).to eq "/set_cookie"
-        expect(cookie[:secure]).to be true
-
-        expect(cookie[:expires]).to be_kind_of(Time)
-        # a few ms slack
-        expect((cookie[:expires]).to_i).to be_within(2).of(expires.to_i)
-      end
-    end
-
-    not_compliant_on :internet_explorer do
-      it 'removes a cookie' do
-        browser.goto set_cookie_url
-        verify_cookies_count 1
-
-        browser.cookies.delete 'monster'
+        browser.cookies.clear
         verify_cookies_count 0
       end
+    end
+  end
 
-      bug "https://code.google.com/p/selenium/issues/detail?id=5487", :safari do
-        it 'clears all cookies' do
-          browser.goto set_cookie_url
-          browser.cookies.add 'foo', 'bar'
-          verify_cookies_count 2
+  not_compliant_on :internet_explorer do
+    let(:file) { "#{Dir.tmpdir}/cookies" }
 
-          browser.cookies.clear
-          verify_cookies_count 0
-        end
+    before do
+      browser.goto set_cookie_url
+      browser.cookies.save file
+    end
+
+    describe '#save' do
+      it 'saves cookies to file' do
+        expect(IO.read(file)).to eq(browser.cookies.to_a.to_yaml)
       end
     end
 
-    not_compliant_on :internet_explorer do
-      let(:file) { "#{Dir.tmpdir}/cookies" }
+    describe '#load' do
+      it 'loads cookies from file' do
+        browser.cookies.clear
+        browser.cookies.load file
+        expected = browser.cookies.to_a
+        actual = YAML.load(IO.read(file))
 
-      before do
-        browser.goto set_cookie_url
-        browser.cookies.save file
-      end
+        # https://code.google.com/p/selenium/issues/detail?id=6834
+        expected.each { |cookie| cookie.delete(:expires) }
+        actual.each { |cookie| cookie.delete(:expires) }
 
-      describe '#save' do
-        it 'saves cookies to file' do
-          expect(IO.read(file)).to eq(browser.cookies.to_a.to_yaml)
-        end
-      end
-
-      describe '#load' do
-        it 'loads cookies from file' do
-          browser.cookies.clear
-          browser.cookies.load file
-          expected = browser.cookies.to_a
-          actual = YAML.load(IO.read(file))
-
-          # https://code.google.com/p/selenium/issues/detail?id=6834
-          expected.each { |cookie| cookie.delete(:expires) }
-          actual.each { |cookie| cookie.delete(:expires) }
-
-          expect(actual).to eq(expected)
-        end
+        expect(actual).to eq(expected)
       end
     end
+  end
 
-    def set_cookie_url
-      # add timestamp to url to avoid caching in IE8
-      WatirSpec.url_for('set_cookie/index.html') + "?t=#{Time.now.to_i + Time.now.usec}"
-    end
+  def set_cookie_url
+    # add timestamp to url to avoid caching in IE8
+    WatirSpec.url_for('set_cookie/index.html') + "?t=#{Time.now.to_i + Time.now.usec}"
+  end
 
-    def verify_cookies_count expected_size
-      cookies = browser.cookies.to_a
-      expect(cookies.size).to eq(expected_size), "expected #{expected_size} cookies, got #{cookies.size}: #{cookies.inspect}"
-    end
+  def verify_cookies_count expected_size
+    cookies = browser.cookies.to_a
+    expect(cookies.size).to eq(expected_size), "expected #{expected_size} cookies, got #{cookies.size}: #{cookies.inspect}"
   end
 end

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -166,9 +166,7 @@ describe "Div" do
         it "fires the oncontextmenu event" do
           browser.goto(WatirSpec.url_for("right_click.html"))
           browser.div(id: "click").right_click
-          bug "https://github.com/detro/ghostdriver/issues/125", :phantomjs do
-            expect(messages.first).to eq 'right-clicked'
-          end
+          expect(messages.first).to eq 'right-clicked'
         end
       end
     end

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -291,8 +291,7 @@ describe "Element" do
   bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
     describe '#send_keys' do
       before(:each) do
-        phantom = browser.driver.capabilities.browser_name == 'phantomjs'
-        @c = Selenium::WebDriver::Platform.mac? && !phantom ? :command : :control
+        @c = Selenium::WebDriver::Platform.mac? ? :command : :control
         browser.goto(WatirSpec.url_for('keylogger.html'))
       end
 

--- a/spec/watirspec/elements/filefield_spec.rb
+++ b/spec/watirspec/elements/filefield_spec.rb
@@ -110,20 +110,18 @@ describe "FileField" do
   describe "#set" do
     not_compliant_on :safari do
       bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
-        bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
-          it "is able to set a file path in the field and click the upload button and fire the onchange event" do
-            browser.goto WatirSpec.url_for("forms_with_input_elements.html")
+        it "is able to set a file path in the field and click the upload button and fire the onchange event" do
+          browser.goto WatirSpec.url_for("forms_with_input_elements.html")
 
-            path = File.expand_path(__FILE__)
-            element = browser.file_field(name: "new_user_portrait")
+          path = File.expand_path(__FILE__)
+          element = browser.file_field(name: "new_user_portrait")
 
-            element.set path
+          element.set path
 
-            expect(element.value).to include(File.basename(path)) # only some browser will return the full path
-            expect(messages.first).to include(File.basename(path))
+          expect(element.value).to include(File.basename(path)) # only some browser will return the full path
+          expect(messages.first).to include(File.basename(path))
 
-            browser.button(name: "new_user_submit").click
-          end
+          browser.button(name: "new_user_submit").click
         end
 
         it "raises an error if the file does not exist" do
@@ -135,41 +133,38 @@ describe "FileField" do
     end
   end
 
+  not_compliant_on :safari do
+    describe "#value=" do
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
+        it "is able to set a file path in the field and click the upload button and fire the onchange event" do
+          browser.goto WatirSpec.url_for("forms_with_input_elements.html")
 
-  bug "https://github.com/detro/ghostdriver/issues/183", :phantomjs do
-    not_compliant_on :safari do
-        describe "#value=" do
-          bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1260233", :firefox do
-            it "is able to set a file path in the field and click the upload button and fire the onchange event" do
-            browser.goto WatirSpec.url_for("forms_with_input_elements.html")
+          path = File.expand_path(__FILE__)
+          element = browser.file_field(name: "new_user_portrait")
 
-            path = File.expand_path(__FILE__)
-            element = browser.file_field(name: "new_user_portrait")
+          element.value = path
+          expect(element.value).to include(File.basename(path)) # only some browser will return the full path
+        end
 
-            element.value = path
-            expect(element.value).to include(File.basename(path)) # only some browser will return the full path
+        not_compliant_on :internet_explorer do
+          bug "Raises File not found error - File Bug Report", :firefox do
+            it "does not raise an error if the file does not exist" do
+              path = File.join(Dir.tmpdir, 'unlikely-to-exist')
+              browser.file_field.value = path
+
+              expected = path
+              expected.gsub!("/", "\\") if Selenium::WebDriver::Platform.windows?
+
+              expect(browser.file_field.value).to include(File.basename(expected)) # only some browser will return the full path
+            end
           end
 
-          not_compliant_on :internet_explorer do
+          not_compliant_on %i(chrome windows) do
             bug "Raises File not found error - File Bug Report", :firefox do
-              it "does not raise an error if the file does not exist" do
-                path = File.join(Dir.tmpdir, 'unlikely-to-exist')
-                browser.file_field.value = path
-
-                expected = path
-                expected.gsub!("/", "\\") if Selenium::WebDriver::Platform.windows?
-
-                expect(browser.file_field.value).to include(File.basename(expected)) # only some browser will return the full path
-              end
-            end
-
-            not_compliant_on %i(chrome windows) do
-              bug "Raises File not found error - File Bug Report", :firefox do
-                it "does not alter its argument" do
-                  value = '/foo/bar'
-                  browser.file_field.value = value
-                  expect(value).to eq '/foo/bar'
-                end
+              it "does not alter its argument" do
+                value = '/foo/bar'
+                browser.file_field.value = value
+                expect(value).to eq '/foo/bar'
               end
             end
           end

--- a/spec/watirspec/elements/frame_spec.rb
+++ b/spec/watirspec/elements/frame_spec.rb
@@ -50,15 +50,13 @@ describe "Frame" do
       expect(browser.frame(xpath: "//frame[@id='no_such_id']")).to_not exist
     end
 
-    bug "https://github.com/detro/ghostdriver/issues/159", :phantomjs do
-      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255946", :firefox do
-        it "handles nested frames" do
-          browser.goto(WatirSpec.url_for("nested_frames.html"))
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255946", :firefox do
+      it "handles nested frames" do
+        browser.goto(WatirSpec.url_for("nested_frames.html"))
 
-          browser.frame(id: "two").frame(id: "three").link(id: "four").click
+        browser.frame(id: "two").frame(id: "three").link(id: "four").click
 
-          Watir::Wait.until { browser.title == "definition_lists" }
-        end
+        Watir::Wait.until { browser.title == "definition_lists" }
       end
     end
 

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -82,15 +82,13 @@ describe "IFrame" do
     end
 
 
-    bug "https://github.com/detro/ghostdriver/issues/159", :phantomjs do
-      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255946", :firefox do
-        it "handles nested iframes" do
-          browser.goto(WatirSpec.url_for("nested_iframes.html"))
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255946", :firefox do
+      it "handles nested iframes" do
+        browser.goto(WatirSpec.url_for("nested_iframes.html"))
 
-          browser.iframe(id: "two").iframe(id: "three").link(id: "four").click
+        browser.iframe(id: "two").iframe(id: "three").link(id: "four").click
 
-          Watir::Wait.until { browser.title == "definition_lists" }
-        end
+        Watir::Wait.until { browser.title == "definition_lists" }
       end
     end
 

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -201,12 +201,10 @@ describe "SelectList" do
     end
 
     not_compliant_on :safari do
-      bug "Not firing events", :phantomjs do
-        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-          it "fires onchange event" do
-            browser.select_list(name: "new_user_languages").clear
-            expect(messages.size).to eq 2
-          end
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+        it "fires onchange event" do
+          browser.select_list(name: "new_user_languages").clear
+          expect(messages.size).to eq 2
         end
       end
 
@@ -317,23 +315,19 @@ describe "SelectList" do
     end
 
     not_compliant_on :safari do
-      bug "Not firing events", :phantomjs do
-        it "fires onchange event when selecting an item" do
-          browser.select_list(id: "new_user_languages").select("Danish")
-          expect(messages).to eq ['changed language']
-        end
+      it "fires onchange event when selecting an item" do
+        browser.select_list(id: "new_user_languages").select("Danish")
+        expect(messages).to eq ['changed language']
       end
 
-      bug "Not firing events", :phantomjs do
-        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-          it "doesn't fire onchange event when selecting an already selected item" do
-            browser.select_list(id: "new_user_languages").clear # removes the two pre-selected options
-            browser.select_list(id: "new_user_languages").select("English")
-            expect(messages.size).to eq 3
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+        it "doesn't fire onchange event when selecting an already selected item" do
+          browser.select_list(id: "new_user_languages").clear # removes the two pre-selected options
+          browser.select_list(id: "new_user_languages").select("English")
+          expect(messages.size).to eq 3
 
-            browser.select_list(id: "new_user_languages").select("English")
-            expect(messages.size).to eq 3
-          end
+          browser.select_list(id: "new_user_languages").select("English")
+          expect(messages.size).to eq 3
         end
       end
     end

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -201,7 +201,14 @@ describe 'Watir#relaxed_locate?' do
         it 'raises exception immediately' do
           start_time = ::Time.now
           browser.a(id: 'show_bar').click
-          expect { browser.div(id: 'bar').click }.to raise_exception(Selenium::WebDriver::Error::ElementNotVisibleError)
+
+          compliant_on :firefox do
+            expect { browser.div(id: 'bar').click }.to raise_exception(Selenium::WebDriver::Error::ElementNotInteractableError)
+          end
+          not_compliant_on :firefox do
+            expect { browser.div(id: 'bar').click }.to raise_exception(Selenium::WebDriver::Error::ElementNotVisibleError)
+          end
+
           expect(::Time.now - start_time).to be < 1
         end
       end

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -372,19 +372,17 @@ not_compliant_on :safari do
       end
 
       not_compliant_on :firefox do
-        bug "https://github.com/detro/ghostdriver/issues/466", :phantomjs do
-          it "should move the window" do
-            initial_pos = browser.window.position
+        it "should move the window" do
+          initial_pos = browser.window.position
 
-            browser.window.move_to(
+          browser.window.move_to(
               initial_pos.x + 2,
               initial_pos.y + 2
-            )
+          )
 
-            new_pos = browser.window.position
-            expect(new_pos.x).to eq initial_pos.x + 2
-            expect(new_pos.y).to eq initial_pos.y + 2
-          end
+          new_pos = browser.window.position
+          expect(new_pos.x).to eq initial_pos.x + 2
+          expect(new_pos.y).to eq initial_pos.y + 2
         end
       end
 

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -91,10 +91,6 @@ class ImplementationConfig
     browser == :safari
   end
 
-  def phantomjs?
-    browser == :phantomjs
-  end
-
   def remote?
     browser == :remote
   end

--- a/support/travis.sh
+++ b/support/travis.sh
@@ -9,29 +9,3 @@ if [[ "$RAKE_TASK" = "yard:doctest" ]]; then
   mkdir ~/.yard
   bundle exec yard config -a autoload_plugins yard-doctest
 fi
-
-if [[ "$RAKE_TASK" = "spec:chrome" ]] || [[ "$RAKE_TASK" = "yard:doctest" ]]; then
-  CHROMEDRIVER_VERSION=$(curl -s http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
-  curl -L -O "http://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip"
-  unzip chromedriver_linux64.zip
-
-  mv chromedriver travis-drivers/chromedriver
-  chmod +x travis-drivers/chromedriver
-fi
-
-if [[ "$RAKE_TASK" = "spec:firefox" ]]; then
-  curl -L -O "http://raw.githubusercontent.com/watir/driver_binaries/master/geckodriver"
-  chmod +x geckodriver
-
-  mv geckodriver travis-drivers/geckodriver
-  geckodriver --version
-  firefox --version
-fi
-
-if [[ "$RAKE_TASK" = "spec:phantomjs" ]]; then
-  curl -L -O "http://raw.githubusercontent.com/watir/driver_binaries/master/phantomjs"
-  chmod +x phantomjs
-
-  mv phantomjs travis-drivers/phantomjs
-  phantomjs --version
-fi

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -33,4 +33,5 @@ It facilitates the writing of automated tests by mimicing the behavior of a user
   s.add_development_dependency 'pry'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'yard-doctest', '>= 0.1.8'
+  s.add_development_dependency 'webdrivers'
 end

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'watir'
-  s.version     = '6.2.1'
+  s.version     = '6.2.2'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Alex Rodionov', 'Titus Fortner']
   s.email       = ['p0deje@gmail.com', 'titusfortner@gmail.com']


### PR DESCRIPTION
I'd like to get a release out there before the major performance overhaul that is in the works.

As for using `webdrivers` gem: it simplifies Travis code, but depending on your ruby environment setup you might need to run `gem uninstall webdrivers` when running Selenium projects that don't include it in the gemfile after running watirspecs.

Regardless, our code is now happy on Travis with the latest drivers

@abotalov I had to tweak `#selected_options` things a bit to get it to work inside frame contexts

PhantomJS: any problems stopping running specs with phantomjs? Maybe "Deprecate PhantomJS Support" is too severe for the changelog?