### PR TITLE
allow collection elements to be relocated

### DIFF
--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -80,10 +80,21 @@ module Watir
     #
 
     def to_a
-      @to_a ||= elements.map.with_index do |e, idx|
-        element = element_class.new(@query_scope, @selector.merge(element: e, index: idx))
-        element_class == Watir::HTMLElement ? element.to_subtype : element
-      end
+      hash = {}
+      @to_a ||=
+          elements.map.with_index do |e, idx|
+            element = element_class.new(@query_scope, @selector.merge(element: e, index: idx))
+            if [Watir::HTMLElement, Watir::Input].include? element.class
+              element = element.to_subtype
+              hash[element.class] ||= []
+              hash[element.class] << element
+              element.class.new(@query_scope, @selector.merge(element: e,
+                                                              tag_name: element.tag_name,
+                                                              index: hash[element.class].size - 1))
+            else
+              element
+            end
+          end
     end
 
     #

--- a/spec/watirspec/elements/collections_spec.rb
+++ b/spec/watirspec/elements/collections_spec.rb
@@ -24,4 +24,12 @@ describe "Collections" do
     expect(collection.any? { |el| el.is_a? Watir::Span}).to eq true
     expect(collection.any? { |el| el.is_a? Watir::Div}).to eq true
   end
+
+  it "relocates the same element" do
+    browser.goto(WatirSpec.url_for("nested_elements.html"))
+    collection = browser.div(id: "parent").children
+    tag = collection[3].tag_name
+    browser.refresh
+    expect(collection[3].tag_name).to eq tag
+  end
 end


### PR DESCRIPTION
Instead of just doing `#to_subtype`, this stores the index of the tag name so it can be relocated.
The alternative is to figure out when to throw an exception when the only locator is `@element`.