### PR TITLE
implement classes locator

### DIFF
--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -2,7 +2,7 @@ module Watir
   module Locators
     class Element
       class SelectorBuilder
-        VALID_WHATS = [String, Regexp, TrueClass, FalseClass].freeze
+        VALID_WHATS = [Array, String, Regexp, TrueClass, FalseClass].freeze
         WILDCARD_ATTRIBUTE = /^(aria|data)_(.+)$/
 
         def initialize(query_scope, selector, valid_attributes)
@@ -35,6 +35,9 @@ module Watir
               raise TypeError, "expected TrueClass or FalseClass, got #{what.inspect}:#{what.class}"
             end
           else
+            if what.is_a?(Array) && how != :class
+              raise TypeError, "Only :class locator can have a value of an Array"
+            end
             unless VALID_WHATS.any? { |t| what.is_a? t }
               raise TypeError, "expected one of #{VALID_WHATS.inspect}, got #{what.inspect}:#{what.class}"
             end

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -303,7 +303,7 @@ describe Watir::Locators::Element::Locator do
       it "raises a TypeError if selector value is not a String, Regexp or Boolean" do
         num_type = RUBY_VERSION[/^\d+\.(\d+)/, 1].to_i >= 4 ? 'Integer' : 'Fixnum'
         expect { locate_one(tag_name: 123) }.to \
-        raise_error(TypeError, %[expected one of [String, Regexp, TrueClass, FalseClass], got 123:#{num_type}])
+        raise_error(TypeError, %[expected one of [Array, String, Regexp, TrueClass, FalseClass], got 123:#{num_type}])
       end
 
       it "raises a MissingWayOfFindingObjectException if the attribute is not valid" do

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -237,15 +237,41 @@ describe "Element" do
       it "matches when the element has several classes" do
         e = browser.div(class: "b")
         expect(e).to exist
-        expect(e.class_name).to eq "a b"
+        expect(e.class_name).to eq "a b c"
       end
 
       it "does not match only part of the class name" do
-        expect(browser.div(class: "c")).to_not exist
+        expect(browser.div(class: "bc")).to_not exist
       end
 
       it "matches part of the class name when given a regexp" do
         expect(browser.div(class: /c/)).to exist
+      end
+
+      context "with multiple classes" do
+        it "matches when the element has a single class" do
+          e = browser.div(class: ["a"])
+          expect(e).to exist
+          expect(e.class_name).to eq "a"
+        end
+
+        it "matches a non-ordered subset" do
+          e = browser.div(class: ["c", "a"])
+          expect(e).to exist
+          expect(e.class_name).to eq "a b c"
+        end
+
+        it "matches one with a negation" do
+          e = browser.div(class: ["!a"])
+          expect(e).to exist
+          expect(e.class_name).to eq "abc"
+        end
+
+        it "matches multiple with a negation" do
+          e = browser.div(class: ["a", "!c", "b"])
+          expect(e).to exist
+          expect(e.class_name).to eq "a b"
+        end
       end
     end
 

--- a/spec/watirspec/html/class_locator.html
+++ b/spec/watirspec/html/class_locator.html
@@ -2,6 +2,7 @@
 <html>
   <body>
     <div class="a">a</div>
+    <div class="a b c">a b c</div>
     <div class="a b">a b</div>
     <div class="abc">abc</div>
   </body>


### PR DESCRIPTION
Here's an implementation for #578 
I haven't spent a lot of time in the SelectorBuilder code for XPath, so let me know if I'm putting things in wrong places.

```ruby
browser.div(classes: ["a"])
browser.div(classes: ["c", "a"])
browser.div(classes: ["a", "!c", "b"])
```