### PR TITLE
use default Travis Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,7 @@ rvm:
   - 2.4.1
 addons:
   firefox: latest
-  apt:
-    packages:
-      - unzip
-      - libxss1
-      - google-chrome-stable
+  chrome: stable
 cache: bundler
 notifications:
   recipients:

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -1,5 +1,3 @@
-require 'active_support/ordered_hash'
-
 module LocatorSpecHelper
   def browser
     @browser ||= double(Watir::Browser, wd: driver)
@@ -48,7 +46,7 @@ module LocatorSpecHelper
     when Hash
       selector
     when Array
-      ActiveSupport::OrderedHash[*selector]
+      Hash[*selector]
     else
       raise ArgumentError, "couldn't create hash for #{selector.inspect}"
     end

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -25,13 +25,18 @@ It facilitates the writing of automated tests by mimicing the behavior of a user
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'yard', '> 0.8.2.1'
-  s.add_development_dependency 'webidl', '>= 0.1.5'
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'fuubar'
-  s.add_development_dependency 'nokogiri'
-  s.add_development_dependency 'activesupport', '~> 3.0' # for pluralization during code generation
-  s.add_development_dependency 'pry'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'yard-doctest', '>= 0.1.8'
   s.add_development_dependency 'webdrivers'
+
+  # Used in rake tasks not run on Travis
+  unless ENV['TRAVIS']
+    s.add_development_dependency 'activesupport', '~> 3.0' # for pluralization during code generation
+    s.add_development_dependency 'nokogiri'
+    s.add_development_dependency 'pry'
+    s.add_development_dependency 'webidl', '>= 0.1.5'
+  end
+
 end

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -25,18 +25,13 @@ It facilitates the writing of automated tests by mimicing the behavior of a user
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'yard', '> 0.8.2.1'
+  s.add_development_dependency 'webidl', '>= 0.1.5'
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'fuubar'
+  s.add_development_dependency 'nokogiri'
+  s.add_development_dependency 'activesupport', '~> 3.0' # for pluralization during code generation
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'yard-doctest', '>= 0.1.8'
   s.add_development_dependency 'webdrivers'
-
-  # Used in rake tasks not run on Travis
-  unless ENV['TRAVIS']
-    s.add_development_dependency 'activesupport', '~> 3.0' # for pluralization during code generation
-    s.add_development_dependency 'nokogiri'
-    s.add_development_dependency 'pry'
-    s.add_development_dependency 'webidl', '>= 0.1.5'
-  end
-
 end


### PR DESCRIPTION
Alex, I see your comment about Chrome & shared memory on Travis, but I don't really understand it. When I ran on the container everything passed, and they seem to be about the same speed between the runs, though I didn't do a thorough comparison.

Regardless, can we use default Travis package, or do we need the current sudo libs?