### PR TITLE
Spec updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,31 +3,65 @@
 # use host's /dev/shm.
 sudo: required
 dist: trusty
-rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-addons:
-  firefox: latest
-  apt:
-    packages:
-      - unzip
-      - libxss1
-      - google-chrome-stable
 cache: bundler
 notifications:
-  recipients:
-    - p0deje@gmail.com
-    - jarmo.p@gmail.com
-    - titusfortner@gmail.com
   slack:
     secure: BLsBCm33R32VNRccrLx9F0P24X6BVpVHj1OWaN4Kyn6g9qXteIwC2VKVMnKNbifpojfMkrn0OeFQFK1O1DSOsC3mgzn/udoB+DnUGcSemFUn04xhbYF5SI+3zGPKPo0JLvjjdEKSSma84YwKdrj88pGUK34p01gL8hiaqjFzWdk=
 before_script:
   - support/travis.sh
 script: bundle exec rake $RAKE_TASK
-env:
-  - RAKE_TASK=spec:firefox
-  - RAKE_TASK=spec:firefox RELAXED_LOCATE=false
-  - RAKE_TASK=spec:chrome
-  - RAKE_TASK=spec:chrome RELAXED_LOCATE=false
-  - RAKE_TASK=yard:doctest
+
+_version:
+  two: &two
+    language: ruby
+    rvm: 2.2.7
+  three: &three
+    language: ruby
+    rvm: 2.3.4
+  four: &four
+    language: ruby
+    rvm: 2.4.1
+
+_browsers:
+  firefox: &firefox-latest
+    addons:
+      firefox: latest
+  chrome: &chrome
+     addons:
+       chrome: stable
+
+matrix:
+  include:
+      - env: RAKE_TASK=yard:doctest
+        <<: *four
+        <<: *chrome
+      - env: RAKE_TASK=spec:chrome
+        <<: *two
+        <<: *chrome
+      - env: RAKE_TASK=spec:chrome
+        <<: *three
+        <<: *chrome
+      - env: RAKE_TASK=spec:chrome
+        <<: *four
+        <<: *chrome
+      - env: RAKE_TASK=spec:chrome RELAXED_LOCATE=false
+        <<: *four
+        <<: *chrome
+      - env: RAKE_TASK=spec:firefox
+        <<: *two
+        <<: *firefox-latest
+      - env: RAKE_TASK=spec:firefox
+        <<: *three
+        <<: *firefox-latest
+      - env: RAKE_TASK=spec:firefox
+        <<: *four
+        <<: *firefox-latest
+      - env: RAKE_TASK=spec:firefox RELAXED_LOCATE=false
+        <<: *four
+        <<: *firefox-latest
+      - env: RAKE_TASK=spec:remote_chrome
+        <<: *four
+        <<: *chrome
+      - env: RAKE_TASK=spec:remote_firefox
+        <<: *four
+        <<: *firefox-latest

--- a/Rakefile
+++ b/Rakefile
@@ -125,7 +125,6 @@ namespace :spec do
   desc 'Run specs locally for all browsers'
   task browsers: [:chrome,
                   :firefox,
-                  :ff_legacy,
                   (:safari if Selenium::WebDriver::Platform.mac?),
                   (:ie if Selenium::WebDriver::Platform.windows?),
                   (:edge if Selenium::WebDriver::Platform.windows?)].compact
@@ -133,12 +132,11 @@ namespace :spec do
   desc 'Run specs remotely for all browsers'
   task remote_browsers: [:remote_chrome,
                          :remote_firefox,
-                         :remote_ff_legacy,
                          (:remote_safari if Selenium::WebDriver::Platform.mac?),
                          (:remote_ie if Selenium::WebDriver::Platform.windows?),
                          (:remote_edge if Selenium::WebDriver::Platform.windows?)].compact
 
-  %w(firefox ff_legacy chrome safari ie edge).each do |browser|
+  %w(firefox chrome safari ie edge).each do |browser|
     desc "Run specs in #{browser}"
     task browser do
       ENV['WATIR_BROWSER'] = browser

--- a/Rakefile
+++ b/Rakefile
@@ -145,8 +145,8 @@ namespace :spec do
 
     desc "Run specs in Remote #{browser}"
     task "remote_#{browser}" do
-      ENV['WATIR_BROWSER'] = 'remote'
-      ENV['REMOTE_BROWSER'] = browser
+      ENV['WATIR_BROWSER'] = browser
+      ENV["USE_REMOTE"] = 'true'
       Rake::Task[:spec].execute
     end
   end

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -58,8 +58,10 @@ module Watir
 
     def inspect
       '#<%s:0x%x url=%s title=%s>' % [self.class, hash*2, url.inspect, title.inspect]
-    rescue
-      '#<%s:0x%x closed=%s>' % [self.class, hash*2, @closed.to_s]
+    rescue Errno::ECONNREFUSED
+      '#<%s:0x%x closed=true>' % [self.class, hash*2]
+    rescue Selenium::WebDriver::Error::UnhandledAlertError
+      '#<%s:0x%x alert=true>' % [self.class, hash*2]
     end
     alias selector_string inspect
 

--- a/lib/watir/cookies.rb
+++ b/lib/watir/cookies.rb
@@ -56,12 +56,11 @@ module Watir
     def add(name, value, opts = {})
       cookie = {
         name: name,
-        value: value,
-        secure: opts[:secure],
-        path: opts[:path],
-        expires: opts[:expires],
-        domain: opts[:domain]
-      }
+        value: value}
+      cookie[:secure] = opts[:secure] if opts.key?(:secure)
+      cookie[:path] = opts[:path] if opts.key?(:path)
+      cookie[:expires] = opts[:expires] if opts.key?(:expires)
+      cookie[:domain] = opts[:domain] if opts.key?(:domain)
 
       @control.add_cookie cookie
     end

--- a/lib/watirspec/implementation.rb
+++ b/lib/watirspec/implementation.rb
@@ -30,11 +30,14 @@ module WatirSpec
     end
 
     def inspect_args
-      caps = browser_args.last.delete(:desired_capabilities).send(:capabilities)
+      hash = browser_args.last
+      desired_capabilities = hash.delete(:desired_capabilities)
+      caps = desired_capabilities.send(:capabilities)
       string = "driver: #{browser_args.first}\n"
-      browser_args.last.each { |arg| string << "#{arg.inspect}\n" }
+      hash.each { |arg| string << "#{arg.inspect}\n" }
       string << "capabilities:\n"
       caps.each { |k, v| string << "\t#{k}: #{v}\n"}
+      hash[:desired_capabilities] = desired_capabilities
       string
     end
   end # Implementation

--- a/lib/watirspec/remote_server.rb
+++ b/lib/watirspec/remote_server.rb
@@ -1,0 +1,38 @@
+module WatirSpec
+  class RemoteServer
+    attr_reader :server
+
+    def start(port = 4444)
+      require 'selenium/server'
+
+      @server ||= Selenium::Server.new(jar,
+                                       port: Selenium::WebDriver::PortProber.above(port),
+                                       log: !!$DEBUG,
+                                       background: true,
+                                       timeout: 60)
+      @server.start
+      at_exit { @server.stop }
+    end
+
+    private
+
+    def jar
+      if ENV['LOCAL_SELENIUM']
+        local = File.expand_path('../selenium/buck-out/gen/java/server/src/org/openqa/grid/selenium/selenium.jar')
+      end
+
+      if File.exist?(ENV['REMOTE_SERVER_BINARY'] || '')
+        ENV['REMOTE_SERVER_BINARY']
+      elsif ENV['LOCAL_SELENIUM'] && File.exists?(local)
+        local
+      elsif !Dir.glob('*selenium*.jar').empty?
+        Dir.glob('*selenium*.jar').first
+      else
+        Selenium::Server.download :latest
+      end
+    rescue SocketError
+      # not connected to internet
+      raise Watir::Exception::Error, "unable to find or download selenium-server-standalone jar"
+    end
+  end
+end

--- a/lib/watirspec/runner.rb
+++ b/lib/watirspec/runner.rb
@@ -35,8 +35,8 @@ module WatirSpec
         config.include(BrowserHelper)
         config.include(MessagesHelper)
 
-        $browser = WatirSpec.new_browser
-        at_exit { $browser.close }
+        config.before(:suite) { $browser = WatirSpec.new_browser }
+        config.after(:suite) { $browser.close }
       end
     end
 

--- a/spec/browser_spec.rb
+++ b/spec/browser_spec.rb
@@ -67,11 +67,11 @@ describe Watir::Browser do
 
   bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1290814", :firefox do
     it "raises an error when trying to interact with a closed browser" do
-      b = WatirSpec.new_browser
-      b.goto WatirSpec.url_for "definition_lists.html"
-      b.close
+      browser.goto WatirSpec.url_for "definition_lists.html"
+      browser.close
 
-      expect { b.dl(id: "experience-list").id }.to raise_error(Watir::Exception::Error, "browser was closed")
+      expect { browser.dl(id: "experience-list").id }.to raise_error(Watir::Exception::Error, "browser was closed")
+      $browser = WatirSpec.new_browser
     end
   end
 

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -130,10 +130,7 @@ describe "Browser::AfterHooks" do
           browser.after_hooks.add @page_after_hook
           browser.goto url
           expect { browser.button(id: "alert").click }.to raise_error(Selenium::WebDriver::Error::UnhandledAlertError)
-
-          not_compliant_on :ff_legacy do
-            browser.alert.ok
-          end
+          browser.alert.ok
         end
       end
     end

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -71,40 +71,37 @@ describe "Browser::AfterHooks" do
     end
 
     bug "AutomatedTester: 'known bug with execute script'", :firefox do
-      it "runs after_hooks after Element#submit" do
-        browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
-        @page_after_hook = Proc.new { @yield = browser.div(id: 'messages').text == 'submit' }
+      not_compliant_on :safari do
+        it "runs after_hooks after Element#submit" do
+          browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+          @page_after_hook = Proc.new { @yield = browser.div(id: 'messages').text == 'submit' }
+          browser.after_hooks.add @page_after_hook
+          browser.form(id: "new_user").submit
+          expect(@yield).to be true
+        end
+      end
+    end
+
+    bug "Actions Endpoint Not Yet Implemented", :firefox do
+      it "runs after_hooks after Element#double_click" do
+        browser.goto(WatirSpec.url_for("non_control_elements.html"))
+        @page_after_hook = Proc.new { @yield = browser.title == "Non-control elements" }
         browser.after_hooks.add @page_after_hook
-        browser.form(id: "new_user").submit
+        browser.div(id: 'html_test').double_click
         expect(@yield).to be true
       end
     end
 
-    not_compliant_on :safari do
-      bug "Actions Endpoint Not Yet Implemented", :firefox do
-        it "runs after_hooks after Element#double_click" do
-          browser.goto(WatirSpec.url_for("non_control_elements.html"))
-          @page_after_hook = Proc.new { @yield = browser.title == "Non-control elements" }
-          browser.after_hooks.add @page_after_hook
-          browser.div(id: 'html_test').double_click
-          expect(@yield).to be true
-        end
+    bug "Actions Endpoint Not Yet Implemented", :firefox do
+      it "runs after_hooks after Element#right_click" do
+        browser.goto(WatirSpec.url_for("right_click.html"))
+        @page_after_hook = Proc.new { @yield = browser.title == "Right Click Test" }
+        browser.after_hooks.add @page_after_hook
+        browser.div(id: "click").right_click
+        expect(@yield).to be true
       end
     end
 
-    not_compliant_on :safari do
-      bug "Actions Endpoint Not Yet Implemented", :firefox do
-        it "runs after_hooks after Element#right_click" do
-          browser.goto(WatirSpec.url_for("right_click.html"))
-          @page_after_hook = Proc.new { @yield = browser.title == "Right Click Test" }
-          browser.after_hooks.add @page_after_hook
-          browser.div(id: "click").right_click
-          expect(@yield).to be true
-        end
-      end
-    end
-
-    not_compliant_on :safari do
       it "runs after_hooks after Alert#ok" do
         browser.goto(WatirSpec.url_for("alerts.html"))
         @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
@@ -114,18 +111,19 @@ describe "Browser::AfterHooks" do
         expect(@yield).to be true
       end
 
-      bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
-        it "runs after_hooks after Alert#close" do
-          browser.goto(WatirSpec.url_for("alerts.html"))
-          @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
-          browser.after_hooks.add @page_after_hook
-          browser.after_hooks.without { browser.button(id: 'alert').click }
-          browser.alert.close
-          expect(@yield).to be true
-        end
+    bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+      it "runs after_hooks after Alert#close" do
+        browser.goto(WatirSpec.url_for("alerts.html"))
+        @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
+        browser.after_hooks.add @page_after_hook
+        browser.after_hooks.without { browser.button(id: 'alert').click }
+        browser.alert.close
+        expect(@yield).to be true
       end
+    end
 
-      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1279211", :firefox do
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1279211", :firefox do
+      not_compliant_on :safari do
         it "raises UnhandledAlertError error when running error checks with alert present" do
           url = WatirSpec.url_for("alerts.html")
           @page_after_hook = Proc.new { browser.url }
@@ -138,25 +136,25 @@ describe "Browser::AfterHooks" do
           end
         end
       end
+    end
 
-      it "does not raise error when running error checks using #after_hooks#without with alert present" do
-        url = WatirSpec.url_for("alerts.html")
-        @page_after_hook = Proc.new { browser.url }
-        browser.after_hooks.add @page_after_hook
-        browser.goto url
-        expect { browser.after_hooks.without { browser.button(id: "alert").click } }.to_not raise_error
-        browser.alert.ok
-      end
+    it "does not raise error when running error checks using #after_hooks#without with alert present" do
+      url = WatirSpec.url_for("alerts.html")
+      @page_after_hook = Proc.new { browser.url }
+      browser.after_hooks.add @page_after_hook
+      browser.goto url
+      expect { browser.after_hooks.without { browser.button(id: "alert").click } }.to_not raise_error
+      browser.alert.ok
+    end
 
-      it "does not raise error if no error checks are defined with alert present" do
-        url = WatirSpec.url_for("alerts.html")
-        @page_after_hook = Proc.new { browser.url }
-        browser.after_hooks.add @page_after_hook
-        browser.goto url
-        browser.after_hooks.delete @page_after_hook
-        expect { browser.button(id: "alert").click }.to_not raise_error
-        browser.alert.ok
-      end
+    it "does not raise error if no error checks are defined with alert present" do
+      url = WatirSpec.url_for("alerts.html")
+      @page_after_hook = Proc.new { browser.url }
+      browser.after_hooks.add @page_after_hook
+      browser.goto url
+      browser.after_hooks.delete @page_after_hook
+      expect { browser.button(id: "alert").click }.to_not raise_error
+      browser.alert.ok
     end
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do

--- a/spec/watirspec/alert_spec.rb
+++ b/spec/watirspec/alert_spec.rb
@@ -1,43 +1,47 @@
 require "watirspec_helper"
 
 describe 'Alert API' do
-  not_compliant_on :safari do
-    before do
-      browser.goto WatirSpec.url_for("alerts.html")
+  before do
+    browser.goto WatirSpec.url_for("alerts.html")
+  end
+
+  after do
+    browser.alert.ok if browser.alert.exists?
+  end
+
+  context 'alert' do
+    describe '#text' do
+      it 'returns text of alert' do
+        browser.button(id: 'alert').click
+        expect(browser.alert.text).to include('ok')
+      end
     end
 
-    after do
-      browser.alert.ok if browser.alert.exists?
-    end
-
-    context 'alert' do
-      describe '#text' do
-        it 'returns text of alert' do
-          browser.button(id: 'alert').click
-          expect(browser.alert.text).to include('ok')
-        end
+    describe '#exists?' do
+      it 'returns false if alert is not present' do
+        expect(browser.alert).to_not exist
       end
 
-      describe '#exists?' do
-        it 'returns false if alert is not present' do
-          expect(browser.alert).to_not exist
-        end
-
+      bug "Alert exception not thrown, so Browser#inspect hangs", :safari do
         it 'returns true if alert is present' do
           browser.button(id: 'alert').click
           browser.wait_until(timeout: 10) { browser.alert.exists? }
         end
       end
+    end
 
-      describe '#ok' do
+    describe '#ok' do
+      not_compliant_on :safari do
         it 'closes alert' do
           browser.button(id: 'alert').click
           browser.alert.ok
           expect(browser.alert).to_not exist
         end
       end
+    end
 
-      bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+    bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+      not_compliant_on :safari do
         describe '#close' do
           it 'closes alert' do
             browser.button(id: 'alert').click
@@ -46,57 +50,57 @@ describe 'Alert API' do
           end
         end
       end
+    end
 
-      not_compliant_on :relaxed_locate do
-        describe 'wait_until_present' do
-          it 'waits until alert is present and goes on' do
-            browser.button(id: 'timeout-alert').click
-            browser.alert.wait_until_present.ok
+    not_compliant_on :relaxed_locate do
+      describe 'wait_until_present' do
+        it 'waits until alert is present and goes on' do
+          browser.button(id: 'timeout-alert').click
+          browser.alert.wait_until_present.ok
 
-            expect(browser.alert).to_not exist
-          end
+          expect(browser.alert).to_not exist
+        end
 
-          it 'raises error if alert is not present after timeout' do
-            begin
-              Watir.default_timeout = 2
-              expect {
-                browser.alert.wait_until_present.ok
-              }.to raise_error(Watir::Wait::TimeoutError)
-            ensure
-              Watir.default_timeout = 30
-            end
+        it 'raises error if alert is not present after timeout' do
+          begin
+            Watir.default_timeout = 2
+            expect {
+              browser.alert.wait_until_present.ok
+            }.to raise_error(Watir::Wait::TimeoutError)
+          ensure
+            Watir.default_timeout = 30
           end
         end
       end
     end
+  end
 
-    context 'confirm' do
-      describe '#ok' do
-        it 'accepts confirm' do
-          browser.button(id: 'confirm').click
+  context 'confirm' do
+    describe '#ok' do
+      it 'accepts confirm' do
+        browser.button(id: 'confirm').click
+        browser.alert.ok
+        expect(browser.button(id: 'confirm').value).to eq "true"
+      end
+    end
+
+    describe '#close' do
+      it 'cancels confirm' do
+        browser.button(id: 'confirm').click
+        browser.alert.close
+        expect(browser.button(id: 'confirm').value).to eq "false"
+      end
+    end
+  end
+
+  context 'prompt' do
+    describe '#set' do
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
+        it 'enters text to prompt' do
+          browser.button(id: 'prompt').click
+          browser.alert.set 'My Name'
           browser.alert.ok
-          expect(browser.button(id: 'confirm').value).to eq "true"
-        end
-      end
-
-      describe '#close' do
-        it 'cancels confirm' do
-          browser.button(id: 'confirm').click
-          browser.alert.close
-          expect(browser.button(id: 'confirm').value).to eq "false"
-        end
-      end
-    end
-
-    context 'prompt' do
-      describe '#set' do
-        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
-          it 'enters text to prompt' do
-            browser.button(id: 'prompt').click
-            browser.alert.set 'My Name'
-            browser.alert.ok
-            expect(browser.button(id: 'prompt').value).to eq 'My Name'
-          end
+          expect(browser.button(id: 'prompt').value).to eq 'My Name'
         end
       end
     end

--- a/spec/watirspec/browser_spec.rb
+++ b/spec/watirspec/browser_spec.rb
@@ -170,18 +170,6 @@ describe "Browser" do
       end
     end
 
-    compliant_on :ff_legacy do
-      it "goes to internal Firefox URL 'about:mozilla' without raising errors" do
-        expect { browser.goto("about:mozilla") }.to_not raise_error
-      end
-    end
-
-    compliant_on :opera do
-      it "goes to internal Opera URL 'opera:config' without raising errors" do
-        expect { browser.goto("opera:config") }.to_not raise_error
-      end
-    end
-
     compliant_on :chrome do
       it "goes to internal Chrome URL 'chrome://settings/browser' without raising errors" do
         expect { browser.goto("chrome://settings/browser") }.to_not raise_error

--- a/spec/watirspec/browser_spec.rb
+++ b/spec/watirspec/browser_spec.rb
@@ -78,7 +78,13 @@ describe "Browser" do
   bug "Capitalization bug fixed in upcoming release", %i(remote firefox) do
     describe "#name" do
       it "returns browser name" do
-        expect(browser.name).to eq(WatirSpec.implementation.browser_args.first)
+        not_compliant_on :remote do
+          expect(browser.name).to eq(WatirSpec.implementation.browser_args.first)
+        end
+
+        deviates_on :remote do
+          expect(browser.name).to eq WatirSpec.implementation.browser_args[1][:desired_capabilities].browser_name.to_sym
+        end
       end
     end
   end

--- a/spec/watirspec/cookies_spec.rb
+++ b/spec/watirspec/cookies_spec.rb
@@ -113,17 +113,19 @@ describe "Browser#cookies" do
     end
 
     describe '#load' do
-      it 'loads cookies from file' do
-        browser.cookies.clear
-        browser.cookies.load file
-        expected = browser.cookies.to_a
-        actual = YAML.load(IO.read(file))
+      bug "invalid expiration issue", :firefox do
+        it 'loads cookies from file' do
+          browser.cookies.clear
+          browser.cookies.load file
+          expected = browser.cookies.to_a
+          actual = YAML.load(IO.read(file))
 
-        # https://code.google.com/p/selenium/issues/detail?id=6834
-        expected.each { |cookie| cookie.delete(:expires) }
-        actual.each { |cookie| cookie.delete(:expires) }
+          # https://code.google.com/p/selenium/issues/detail?id=6834
+          expected.each { |cookie| cookie.delete(:expires) }
+          actual.each { |cookie| cookie.delete(:expires) }
 
-        expect(actual).to eq(expected)
+          expect(actual).to eq(expected)
+        end
       end
     end
   end

--- a/spec/watirspec/cookies_spec.rb
+++ b/spec/watirspec/cookies_spec.rb
@@ -48,11 +48,6 @@ describe "Browser#cookies" do
 
       browser.cookies.add 'foo', 'bar'
       verify_cookies_count 2
-
-      compliant_on :safari do
-        $browser.close
-        $browser = WatirSpec.new_browser
-      end
     end
   end
 

--- a/spec/watirspec/drag_and_drop_spec.rb
+++ b/spec/watirspec/drag_and_drop_spec.rb
@@ -2,13 +2,13 @@ require "watirspec_helper"
 
 describe "Element" do
   bug "Actions Endpoint Not Yet Implemented", :firefox do
-    context "drag and drop" do
-      before { browser.goto WatirSpec.url_for("drag_and_drop.html") }
+    bug "Safari does not strip text", :safari do
+      context "drag and drop" do
+        before { browser.goto WatirSpec.url_for("drag_and_drop.html") }
 
-      let(:draggable) { browser.div id: "draggable" }
-      let(:droppable) { browser.div id: "droppable" }
+        let(:draggable) { browser.div id: "draggable" }
+        let(:droppable) { browser.div id: "droppable" }
 
-      not_compliant_on :safari do
         it "can drag and drop an element onto another" do
           expect(droppable.text).to eq 'Drop here'
           draggable.drag_and_drop_on droppable

--- a/spec/watirspec/drag_and_drop_spec.rb
+++ b/spec/watirspec/drag_and_drop_spec.rb
@@ -15,16 +15,14 @@ describe "Element" do
           expect(droppable.text).to eq 'Dropped!'
         end
 
-        bug "http://code.google.com/p/selenium/issues/detail?id=3075", :ff_legacy do
-          it "can drag and drop an element onto another when draggable is out of viewport" do
-            reposition "draggable"
-            perform_drag_and_drop_on_droppable
-          end
+        it "can drag and drop an element onto another when draggable is out of viewport" do
+          reposition "draggable"
+          perform_drag_and_drop_on_droppable
+        end
 
-          it "can drag and drop an element onto another when droppable is out of viewport" do
-            reposition "droppable"
-            perform_drag_and_drop_on_droppable
-          end
+        it "can drag and drop an element onto another when droppable is out of viewport" do
+          reposition "droppable"
+          perform_drag_and_drop_on_droppable
         end
 
         it "can drag an element by the given offset" do

--- a/spec/watirspec/elements/button_spec.rb
+++ b/spec/watirspec/elements/button_spec.rb
@@ -132,13 +132,7 @@ describe "Button" do
   end
 
   describe "#style" do
-    not_compliant_on :internet_explorer, :safari do
-      it "returns the style attribute if the button exists" do
-        expect(browser.button(id: 'delete_user_submit').style).to eq "border: 4px solid red;"
-      end
-    end
-
-    deviates_on :safari do
+    not_compliant_on :internet_explorer do
       it "returns the style attribute if the button exists" do
         expect(browser.button(id: 'delete_user_submit').style).to eq "border: 4px solid red;"
       end

--- a/spec/watirspec/elements/dd_spec.rb
+++ b/spec/watirspec/elements/dd_spec.rb
@@ -77,8 +77,10 @@ describe "Dd" do
       expect(browser.dd(id: "someone").text).to eq "John Doe"
     end
 
-    it "returns an empty string if the element exists but contains no text" do
-      expect(browser.dd(class: 'noop').text).to eq ""
+    bug "Safari does not strip text", :safari do
+      it "returns an empty string if the element exists but contains no text" do
+        expect(browser.dd(class: 'noop').text).to eq ""
+      end
     end
 
     it "raises UnknownObjectException if the element does not exist" do

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -114,8 +114,10 @@ describe "Div" do
       expect(browser.div(index: 0).text.strip).to eq ""
     end
 
-    it "returns an empty string if the div is hidden" do
-      expect(browser.div(id: 'hidden').text).to eq ""
+    not_compliant_on :safari do
+      it "returns an empty string if the div is hidden" do
+        expect(browser.div(id: 'hidden').text).to eq ""
+      end
     end
 
     it "raises UnknownObjectException if the element does not exist" do

--- a/spec/watirspec/elements/dl_spec.rb
+++ b/spec/watirspec/elements/dl_spec.rb
@@ -77,8 +77,10 @@ describe "Dl" do
       expect(browser.dl(id: "experience-list").text).to include("11 years")
     end
 
-    it "returns an empty string if the element exists but contains no text" do
-      expect(browser.dl(id: 'noop').text).to eq ""
+    bug "Safari does not strip text", :safari do
+      it "returns an empty string if the element exists but contains no text" do
+        expect(browser.dl(id: 'noop').text).to eq ""
+      end
     end
 
     it "raises UnknownObjectException if the element does not exist" do

--- a/spec/watirspec/elements/form_spec.rb
+++ b/spec/watirspec/elements/form_spec.rb
@@ -57,12 +57,14 @@ describe "Form" do
         expect(browser.text).to include("Semantic table")
       end
 
-      it "triggers onsubmit event and takes its result into account" do
-        form = browser.form(name: "user_new")
-        form.submit
-        expect(form).to exist
-        expect(messages.size).to eq 1
-        expect(messages[0]).to eq "submit"
+      not_compliant_on :safari do
+        it "triggers onsubmit event and takes its result into account" do
+          form = browser.form(name: "user_new")
+          form.submit
+          expect(form).to exist
+          expect(messages.size).to eq 1
+          expect(messages[0]).to eq "submit"
+        end
       end
     end
   end

--- a/spec/watirspec/elements/frame_spec.rb
+++ b/spec/watirspec/elements/frame_spec.rb
@@ -10,13 +10,15 @@ describe "Frame" do
     browser.goto(WatirSpec.url_for("frames.html"))
   end
 
-  it "handles crossframe javascript" do
-    browser.goto WatirSpec.url_for("frames.html")
+  not_compliant_on :safari do
+    it "handles crossframe javascript" do
+      browser.goto WatirSpec.url_for("frames.html")
 
-    expect(browser.frame(id: "frame_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
-    expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'old_value'
-    browser.frame(id: "frame_1").button(id: 'send').click
-    expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'send_this_value'
+      expect(browser.frame(id: "frame_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
+      expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'old_value'
+      browser.frame(id: "frame_1").button(id: 'send').click
+      expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'send_this_value'
+    end
   end
 
   describe "#exist?" do
@@ -51,12 +53,14 @@ describe "Frame" do
     end
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255946", :firefox do
-      it "handles nested frames" do
-        browser.goto(WatirSpec.url_for("nested_frames.html"))
+      not_compliant_on :safari do
+        it "handles nested frames" do
+          browser.goto(WatirSpec.url_for("nested_frames.html"))
 
-        browser.frame(id: "two").frame(id: "three").link(id: "four").click
+          browser.frame(id: "two").frame(id: "three").link(id: "four").click
 
-        Watir::Wait.until { browser.title == "definition_lists" }
+          Watir::Wait.until { browser.title == "definition_lists" }
+        end
       end
     end
 
@@ -94,18 +98,22 @@ describe "Frame" do
     expect(browser.frame(index: 0).text_field(name: 'senderElement').value).to eq "new value"
   end
 
-  it "can access the frame's parent element after use" do
-    el = browser.frameset
-    el.frame.text_field.value
-    expect(el.attribute_value("cols")).to be_kind_of(String)
+  bug "Safari does not strip text", :safari do
+    it "can access the frame's parent element after use" do
+      el = browser.frameset
+      el.frame.text_field.value
+      expect(el.attribute_value("cols")).to be_kind_of(String)
+    end
   end
 
   describe "#execute_script" do
-    it "executes the given javascript in the specified frame" do
-      frame = browser.frame(index: 0)
-      expect(frame.div(id: 'set_by_js').text).to eq ""
-      frame.execute_script(%Q{document.getElementById('set_by_js').innerHTML = 'Art consists of limitation. The most beautiful part of every picture is the frame.'})
-      expect(frame.div(id: 'set_by_js').text).to eq "Art consists of limitation. The most beautiful part of every picture is the frame."
+    bug "Safari does not strip text", :safari do
+      it "executes the given javascript in the specified frame" do
+        frame = browser.frame(index: 0)
+        expect(frame.div(id: 'set_by_js').text).to eq ""
+        frame.execute_script(%Q{document.getElementById('set_by_js').innerHTML = 'Art consists of limitation. The most beautiful part of every picture is the frame.'})
+        expect(frame.div(id: 'set_by_js').text).to eq "Art consists of limitation. The most beautiful part of every picture is the frame."
+      end
     end
   end
 

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -11,13 +11,15 @@ describe "IFrame" do
   end
 
   bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
-    it "handles crossframe javascript" do
-      browser.goto WatirSpec.url_for("iframes.html")
+    not_compliant_on :safari do
+      it "handles crossframe javascript" do
+        browser.goto WatirSpec.url_for("iframes.html")
 
-      expect(browser.iframe(id: "iframe_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
-      expect(browser.iframe(id: "iframe_2").text_field(name: 'recieverElement').value).to eq 'old_value'
-      browser.iframe(id: "iframe_1").button(id: 'send').click
-      expect(browser.iframe(id: "iframe_2").text_field(name: 'recieverElement').value).to eq 'send_this_value'
+        expect(browser.iframe(id: "iframe_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
+        expect(browser.iframe(id: "iframe_2").text_field(name: 'recieverElement').value).to eq 'old_value'
+        browser.iframe(id: "iframe_1").button(id: 'send').click
+        expect(browser.iframe(id: "iframe_2").text_field(name: 'recieverElement').value).to eq 'send_this_value'
+      end
     end
   end
 
@@ -83,12 +85,14 @@ describe "IFrame" do
 
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255946", :firefox do
-      it "handles nested iframes" do
-        browser.goto(WatirSpec.url_for("nested_iframes.html"))
+      not_compliant_on :safari do
+        it "handles nested iframes" do
+          browser.goto(WatirSpec.url_for("nested_iframes.html"))
 
-        browser.iframe(id: "two").iframe(id: "three").link(id: "four").click
+          browser.iframe(id: "two").iframe(id: "three").link(id: "four").click
 
-        Watir::Wait.until { browser.title == "definition_lists" }
+          Watir::Wait.until { browser.title == "definition_lists" }
+        end
       end
     end
 
@@ -147,11 +151,13 @@ describe "IFrame" do
   end
 
   describe "#execute_script" do
-    it "executes the given javascript in the specified frame" do
-      frame = browser.iframe(index: 0)
-      expect(frame.div(id: 'set_by_js').text).to eq ""
-      frame.execute_script(%Q{document.getElementById('set_by_js').innerHTML = 'Art consists of limitation. The most beautiful part of every picture is the frame.'})
-      expect(frame.div(id: 'set_by_js').text).to eq "Art consists of limitation. The most beautiful part of every picture is the frame."
+    bug "Safari does not strip text", :safari do
+      it "executes the given javascript in the specified frame" do
+        frame = browser.iframe(index: 0)
+        expect(frame.div(id: 'set_by_js').text).to eq ""
+        frame.execute_script(%Q{document.getElementById('set_by_js').innerHTML = 'Art consists of limitation. The most beautiful part of every picture is the frame.'})
+        expect(frame.div(id: 'set_by_js').text).to eq "Art consists of limitation. The most beautiful part of every picture is the frame."
+      end
     end
   end
 

--- a/spec/watirspec/elements/option_spec.rb
+++ b/spec/watirspec/elements/option_spec.rb
@@ -93,24 +93,6 @@ describe "Option" do
           browser.select_list(name: 'new_user_country').option(text: 'Sweden').select
           expect(browser.select_list(name: 'new_user_country').option(text: 'Sweden')).to be_selected
         end
-
-        # there's no onclick event for Option in IE / WebKit
-        # http://msdn.microsoft.com/en-us/library/ms535877(VS.85).aspx
-        compliant_on :ff_legacy do
-          it "fires the onclick event (page context)" do
-            browser.option(text: "Username 3").select
-            expect(browser.textarea(id: 'delete_user_comment').value).to eq 'Don\'t do it!'
-          end
-        end
-      end
-    end
-
-    # there's no onclick event for Option in IE / WebKit
-    # http://msdn.microsoft.com/en-us/library/ms535877(VS.85).aspx
-    compliant_on :ff_legacy do
-      it "fires onclick event (select_list context)" do
-        browser.select_list(id: 'delete_user_username').option(text: "Username 3").select
-        expect(browser.textarea(id: 'delete_user_comment').value).to eq 'Don\'t do it!'
       end
     end
 

--- a/spec/watirspec/elements/option_spec.rb
+++ b/spec/watirspec/elements/option_spec.rb
@@ -72,33 +72,35 @@ describe "Option" do
   end
 
   bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-    describe "#select" do
-      it "selects the chosen option (page context)" do
-        browser.option(text: "Denmark").select
-        expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
-      end
+    not_compliant_on :safari do
+      describe "#select" do
+        it "selects the chosen option (page context)" do
+          browser.option(text: "Denmark").select
+          expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
+        end
 
-      it "selects the chosen option (select_list context)" do
-        browser.select_list(name: "new_user_country").option(text: "Denmark").select
-        expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
-      end
+        it "selects the chosen option (select_list context)" do
+          browser.select_list(name: "new_user_country").option(text: "Denmark").select
+          expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
+        end
 
-      it "selects the option when found by text (page context)" do
-        browser.option(text: 'Sweden').select
-        expect(browser.option(text: 'Sweden')).to be_selected
-      end
+        it "selects the option when found by text (page context)" do
+          browser.option(text: 'Sweden').select
+          expect(browser.option(text: 'Sweden')).to be_selected
+        end
 
-      it "selects the option when found by text (select_list context)" do
-        browser.select_list(name: 'new_user_country').option(text: 'Sweden').select
-        expect(browser.select_list(name: 'new_user_country').option(text: 'Sweden')).to be_selected
-      end
+        it "selects the option when found by text (select_list context)" do
+          browser.select_list(name: 'new_user_country').option(text: 'Sweden').select
+          expect(browser.select_list(name: 'new_user_country').option(text: 'Sweden')).to be_selected
+        end
 
-      # there's no onclick event for Option in IE / WebKit
-      # http://msdn.microsoft.com/en-us/library/ms535877(VS.85).aspx
-      compliant_on :ff_legacy do
-        it "fires the onclick event (page context)" do
-          browser.option(text: "Username 3").select
-          expect(browser.textarea(id: 'delete_user_comment').value).to eq 'Don\'t do it!'
+        # there's no onclick event for Option in IE / WebKit
+        # http://msdn.microsoft.com/en-us/library/ms535877(VS.85).aspx
+        compliant_on :ff_legacy do
+          it "fires the onclick event (page context)" do
+            browser.option(text: "Username 3").select
+            expect(browser.textarea(id: 'delete_user_comment').value).to eq 'Don\'t do it!'
+          end
         end
       end
     end

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -91,10 +91,12 @@ describe "SelectList" do
 
   describe "#value" do
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-      it "returns the value of the selected option" do
-        expect(browser.select_list(index: 0).value).to eq "2"
-        browser.select_list(index: 0).select(/Sweden/)
-        expect(browser.select_list(index: 0).value).to eq "3"
+      not_compliant_on :safari do
+        it "returns the value of the selected option" do
+          expect(browser.select_list(index: 0).value).to eq "2"
+          browser.select_list(index: 0).select(/Sweden/)
+          expect(browser.select_list(index: 0).value).to eq "3"
+        end
       end
     end
 
@@ -104,14 +106,16 @@ describe "SelectList" do
   end
   
   describe "#text" do
-    it "returns the text of the selected option" do
-      expect(browser.select_list(index: 0).text).to eq "Norway"
-      browser.select_list(index: 0).select(/Sweden/)
-      expect(browser.select_list(index: 0).text).to eq "Sweden"
-    end
-    
-    it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(index: 1337).text }.to raise_unknown_object_exception
+    not_compliant_on :safari do
+      it "returns the text of the selected option" do
+        expect(browser.select_list(index: 0).text).to eq "Norway"
+        browser.select_list(index: 0).select(/Sweden/)
+        expect(browser.select_list(index: 0).text).to eq "Sweden"
+      end
+
+      it "raises UnknownObjectException if the select list doesn't exist" do
+        expect {browser.select_list(index: 1337).text}.to raise_unknown_object_exception
+      end
     end
   end
 
@@ -182,9 +186,11 @@ describe "SelectList" do
 
   describe "#clear" do
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-      it "clears the selection when possible" do
-        browser.select_list(name: "new_user_languages").clear
-        expect(browser.select_list(name: "new_user_languages").selected_options).to be_empty
+      not_compliant_on :safari do
+        it "clears the selection when possible" do
+          browser.select_list(name: "new_user_languages").clear
+          expect(browser.select_list(name: "new_user_languages").selected_options).to be_empty
+        end
       end
     end
 
@@ -229,79 +235,83 @@ describe "SelectList" do
     end
   end
 
-  describe "#selected?" do
-    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-      it "returns true if the given option is selected by text" do
-        browser.select_list(name: 'new_user_country').select('Denmark')
-        expect(browser.select_list(name: 'new_user_country')).to be_selected('Denmark')
+  not_compliant_on :safari do
+    describe "#selected?" do
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+        it "returns true if the given option is selected by text" do
+          browser.select_list(name: 'new_user_country').select('Denmark')
+          expect(browser.select_list(name: 'new_user_country')).to be_selected('Denmark')
+        end
       end
-    end
 
-    it "returns false if the given option is not selected by text" do
-      expect(browser.select_list(name: 'new_user_country')).to_not be_selected('Sweden')
-    end
-
-    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-      it "returns true if the given option is selected by label" do
-        browser.select_list(name: 'new_user_country').select('Germany')
-        expect(browser.select_list(name: 'new_user_country')).to be_selected('Germany')
+      it "returns false if the given option is not selected by text" do
+        expect(browser.select_list(name: 'new_user_country')).to_not be_selected('Sweden')
       end
-    end
 
-    it "returns false if the given option is not selected by label" do
-      expect(browser.select_list(name: 'new_user_country')).to_not be_selected('Germany')
-    end
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+        it "returns true if the given option is selected by label" do
+          browser.select_list(name: 'new_user_country').select('Germany')
+          expect(browser.select_list(name: 'new_user_country')).to be_selected('Germany')
+        end
+      end
 
-    it "raises UnknownObjectException if the option doesn't exist" do
-      expect { browser.select_list(name: 'new_user_country').selected?('missing_option') }.to raise_unknown_object_exception
+      it "returns false if the given option is not selected by label" do
+        expect(browser.select_list(name: 'new_user_country')).to_not be_selected('Germany')
+      end
+
+      it "raises UnknownObjectException if the option doesn't exist" do
+        expect { browser.select_list(name: 'new_user_country').selected?('missing_option') }.to raise_unknown_object_exception
+      end
     end
   end
 
-  describe "#select" do
-    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-      context "when interacting with options" do
-        it "selects the given item when given a String" do
-          browser.select_list(name: "new_user_country").select("Denmark")
-          expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
-        end
+  not_compliant_on :safari do
+    describe "#select" do
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+        context "when interacting with options" do
+          it "selects the given item when given a String" do
+            browser.select_list(name: "new_user_country").select("Denmark")
+            expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
+          end
 
-        it "selects options by label" do
-          browser.select_list(name: "new_user_country").select("Germany")
-          expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Germany"]
-        end
+          it "selects options by label" do
+            browser.select_list(name: "new_user_country").select("Germany")
+            expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Germany"]
+          end
 
-        it "selects the given item when given a Regexp" do
-          browser.select_list(name: "new_user_country").select(/Denmark/)
-          expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
-        end
+          it "selects the given item when given a Regexp" do
+            browser.select_list(name: "new_user_country").select(/Denmark/)
+            expect(browser.select_list(name: "new_user_country").selected_options.map(&:text)).to eq ["Denmark"]
+          end
 
-        it "selects the given item when given an Xpath" do
-          browser.select_list(xpath: "//select[@name='new_user_country']").select("Denmark")
-          expect(browser.select_list(xpath: "//select[@name='new_user_country']").selected_options.map(&:text)).to eq ["Denmark"]
-        end
+          it "selects the given item when given an Xpath" do
+            browser.select_list(xpath: "//select[@name='new_user_country']").select("Denmark")
+            expect(browser.select_list(xpath: "//select[@name='new_user_country']").selected_options.map(&:text)).to eq ["Denmark"]
+          end
 
-        it "selects multiple items using :name and a String" do
-          browser.select_list(name: "new_user_languages").clear
-          browser.select_list(name: "new_user_languages").select("Danish")
-          browser.select_list(name: "new_user_languages").select("Swedish")
-          expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
-        end
+          it "selects multiple items using :name and a String" do
+            browser.select_list(name: "new_user_languages").clear
+            browser.select_list(name: "new_user_languages").select("Danish")
+            browser.select_list(name: "new_user_languages").select("Swedish")
+            expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
+          end
 
-        it "selects multiple items using :name and a Regexp" do
-          browser.select_list(name: "new_user_languages").clear
-          browser.select_list(name: "new_user_languages").select(/ish/)
-          expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
-        end
+          it "selects multiple items using :name and a Regexp" do
+            browser.select_list(name: "new_user_languages").clear
+            browser.select_list(name: "new_user_languages").select(/ish/)
+            expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
+          end
 
-        it "selects multiple items using :xpath" do
-          browser.select_list(xpath: "//select[@name='new_user_languages']").clear
-          browser.select_list(xpath: "//select[@name='new_user_languages']").select(/ish/)
-          expect(browser.select_list(xpath: "//select[@name='new_user_languages']").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
-        end
+          it "selects multiple items using :xpath" do
+            browser.select_list(xpath: "//select[@name='new_user_languages']").clear
+            browser.select_list(xpath: "//select[@name='new_user_languages']").select(/ish/)
+            expect(browser.select_list(xpath: "//select[@name='new_user_languages']").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
+          end
 
-        it "selects empty options" do
-          browser.select_list(id: "delete_user_username").select("")
-          expect(browser.select_list(id: "delete_user_username").selected_options.map(&:text)).to eq [""]
+          it "selects empty options" do
+            browser.select_list(id: "delete_user_username").select("")
+            expect(browser.select_list(id: "delete_user_username").selected_options.map(&:text)).to eq [""]
+          end
         end
       end
     end
@@ -337,8 +347,10 @@ describe "SelectList" do
     end
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-      it "returns an empty string when selecting an option that disappears when selected" do
-        expect(browser.select_list(id: 'obsolete').select('sweden')).to eq ''
+      not_compliant_on :safari do
+        it "returns an empty string when selecting an option that disappears when selected" do
+          expect(browser.select_list(id: 'obsolete').select('sweden')).to eq ''
+        end
       end
     end
 
@@ -361,24 +373,26 @@ describe "SelectList" do
   end
 
   # deprecate?
-  describe "#select_value" do
-    it "selects the item by value string" do
-      browser.select_list(name: "new_user_languages").clear
-      browser.select_list(name: "new_user_languages").select_value("2")
-      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq %w[English]
-    end
-
-    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
-      it "selects the items by value regexp" do
+  not_compliant_on :safari do
+    describe "#select_value" do
+      it "selects the item by value string" do
         browser.select_list(name: "new_user_languages").clear
-        browser.select_list(name: "new_user_languages").select_value(/1|3/)
-        expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq %w[Danish Norwegian]
+        browser.select_list(name: "new_user_languages").select_value("2")
+        expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq %w[English]
       end
-    end
 
-    it "raises NoValueFoundException if the option doesn't exist" do
-      expect { browser.select_list(name: "new_user_languages").select_value("no_such_option") }.to raise_no_value_found_exception
-      expect { browser.select_list(name: "new_user_languages").select_value(/no_such_option/) }.to raise_no_value_found_exception
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
+        it "selects the items by value regexp" do
+          browser.select_list(name: "new_user_languages").clear
+          browser.select_list(name: "new_user_languages").select_value(/1|3/)
+          expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq %w[Danish Norwegian]
+        end
+      end
+
+      it "raises NoValueFoundException if the option doesn't exist" do
+        expect { browser.select_list(name: "new_user_languages").select_value("no_such_option") }.to raise_no_value_found_exception
+        expect { browser.select_list(name: "new_user_languages").select_value(/no_such_option/) }.to raise_no_value_found_exception
+      end
     end
   end
 

--- a/spec/watirspec/elements/table_spec.rb
+++ b/spec/watirspec/elements/table_spec.rb
@@ -41,17 +41,19 @@ describe "Table" do
   end
 
   # Other
-  describe "#strings" do
-    it "returns a two-dimensional array representation of the table" do
-      expect(browser.table(id: 'inner').strings).to eq [
-        ["Table 2, Row 1, Cell 1",
-         "Table 2, Row 1, Cell 2"]
-      ]
-      expect(browser.table(id: 'outer').strings).to eq [
-        ["Table 1, Row 1, Cell 1", "Table 1, Row 1, Cell 2"],
-        ["Table 1, Row 2, Cell 1", "Table 1, Row 2, Cell 2\nTable 2, Row 1, Cell 1 Table 2, Row 1, Cell 2"],
-        ["Table 1, Row 3, Cell 1", "Table 1, Row 3, Cell 2"]
-     ]
+  bug "Safari does not strip text", :safari do
+    describe "#strings" do
+      it "returns a two-dimensional array representation of the table" do
+        expect(browser.table(id: 'inner').strings).to eq [
+          ["Table 2, Row 1, Cell 1",
+           "Table 2, Row 1, Cell 2"]
+        ]
+        expect(browser.table(id: 'outer').strings).to eq [
+          ["Table 1, Row 1, Cell 1", "Table 1, Row 1, Cell 2"],
+          ["Table 1, Row 2, Cell 1", "Table 1, Row 2, Cell 2\nTable 2, Row 1, Cell 1 Table 2, Row 1, Cell 2"],
+          ["Table 1, Row 3, Cell 1", "Table 1, Row 3, Cell 2"]
+       ]
+      end
     end
   end
 

--- a/spec/watirspec/elements/tbody_spec.rb
+++ b/spec/watirspec/elements/tbody_spec.rb
@@ -50,17 +50,19 @@ describe "TableBody" do
     end
   end
 
-  describe "#[]" do
-    it "returns the row at the given index (page context)" do
-      expect(browser.tbody(id: 'first')[0].text).to eq 'March 2008'
-      expect(browser.tbody(id: 'first')[1][0].text).to eq 'Gregory House'
-      expect(browser.tbody(id: 'first')[2][0].text).to eq 'Hugh Laurie'
-    end
+  bug "Safari does not strip text", :safari do
+    describe "#[]" do
+      it "returns the row at the given index (page context)" do
+        expect(browser.tbody(id: 'first')[0].text).to eq 'March 2008'
+        expect(browser.tbody(id: 'first')[1][0].text).to eq 'Gregory House'
+        expect(browser.tbody(id: 'first')[2][0].text).to eq 'Hugh Laurie'
+      end
 
-    it "returns the row at the given index (table context)" do
-      expect(browser.table(index: 0).tbody(id: 'first')[0].text).to eq 'March 2008'
-      expect(browser.table(index: 0).tbody(id: 'first')[1][0].text).to eq 'Gregory House'
-      expect(browser.table(index: 0).tbody(id: 'first')[2][0].text).to eq 'Hugh Laurie'
+      it "returns the row at the given index (table context)" do
+        expect(browser.table(index: 0).tbody(id: 'first')[0].text).to eq 'March 2008'
+        expect(browser.table(index: 0).tbody(id: 'first')[1][0].text).to eq 'Gregory House'
+        expect(browser.table(index: 0).tbody(id: 'first')[2][0].text).to eq 'Hugh Laurie'
+      end
     end
   end
 

--- a/spec/watirspec/elements/td_spec.rb
+++ b/spec/watirspec/elements/td_spec.rb
@@ -47,10 +47,12 @@ describe "TableCell" do
   end
 
   # Attribute methods
-  describe "#text" do
-    it "returns the text inside the table cell" do
-      expect(browser.td(id: 't1_r2_c1').text).to eq 'Table 1, Row 2, Cell 1'
-      expect(browser.td(id: 't2_r1_c1').text).to eq 'Table 2, Row 1, Cell 1'
+  bug "Safari does not strip text", :safari do
+    describe "#text" do
+      it "returns the text inside the table cell" do
+        expect(browser.td(id: 't1_r2_c1').text).to eq 'Table 1, Row 2, Cell 1'
+        expect(browser.td(id: 't2_r1_c1').text).to eq 'Table 2, Row 1, Cell 1'
+      end
     end
   end
 

--- a/spec/watirspec/elements/text_field_spec.rb
+++ b/spec/watirspec/elements/text_field_spec.rb
@@ -204,27 +204,29 @@ describe "TextField" do
   end
 
   # Manipulation methods
-  describe "#append" do
-    it "appends the text to the text field" do
-      browser.text_field(name: "new_user_occupation").append(" Append This")
-      expect(browser.text_field(name: "new_user_occupation").value).to eq "Developer Append This"
-    end
+  not_compliant_on :safari do
+    describe "#append" do
+      it "appends the text to the text field" do
+        browser.text_field(name: "new_user_occupation").append(" Append This")
+        expect(browser.text_field(name: "new_user_occupation").value).to eq "Developer Append This"
+      end
 
-    it "appends multi-byte characters" do
-      browser.text_field(name: "new_user_occupation").append(" ĳĳ")
-      expect(browser.text_field(name: "new_user_occupation").value).to eq "Developer ĳĳ"
-    end
+      it "appends multi-byte characters" do
+        browser.text_field(name: "new_user_occupation").append(" ĳĳ")
+        expect(browser.text_field(name: "new_user_occupation").value).to eq "Developer ĳĳ"
+      end
 
-    it "raises ObjectReadOnlyException if the object is read only" do
-      expect { browser.text_field(id: "new_user_code").append("Append This") }.to raise_object_read_only_exception
-    end
+      it "raises ObjectReadOnlyException if the object is read only" do
+        expect { browser.text_field(id: "new_user_code").append("Append This") }.to raise_object_read_only_exception
+      end
 
-    it "raises ObjectDisabledException if the object is disabled" do
-      expect { browser.text_field(name: "new_user_species").append("Append This") }.to raise_object_disabled_exception
-    end
+      it "raises ObjectDisabledException if the object is disabled" do
+        expect { browser.text_field(name: "new_user_species").append("Append This") }.to raise_object_disabled_exception
+      end
 
-    it "raises UnknownObjectException if the object doesn't exist" do
-      expect { browser.text_field(name: "no_such_name").append("Append This") }.to raise_unknown_object_exception
+      it "raises UnknownObjectException if the object doesn't exist" do
+        expect { browser.text_field(name: "no_such_name").append("Append This") }.to raise_unknown_object_exception
+      end
     end
   end
 

--- a/spec/watirspec/elements/tr_spec.rb
+++ b/spec/watirspec/elements/tr_spec.rb
@@ -36,9 +36,11 @@ describe "TableRow" do
 
   describe "#click" do
     bug "http://github.com/watir/watir/issues/issue/32", :internet_explorer, :chrome do
-      it "fires the row's onclick event" do
-        browser.tr(id: 'inner_first').click
-        expect(messages).to include('tr')
+      not_compliant_on :firefox do
+        it "fires the row's onclick event" do
+          browser.tr(id: 'inner_first').click
+          expect(messages).to include('tr')
+        end
       end
     end
   end

--- a/spec/watirspec/elements/tr_spec.rb
+++ b/spec/watirspec/elements/tr_spec.rb
@@ -43,12 +43,14 @@ describe "TableRow" do
     end
   end
 
-  describe "#[]" do
-    let(:table) { browser.table(id: 'outer') }
+  bug "Safari does not strip text", :safari do
+    describe "#[]" do
+      let(:table) { browser.table(id: 'outer') }
 
-    it "returns the nth cell of the row" do
-      expect(table[0][0].text).to eq "Table 1, Row 1, Cell 1"
-      expect(table[2][0].text).to eq "Table 1, Row 3, Cell 1"
+      it "returns the nth cell of the row" do
+        expect(table[0][0].text).to eq "Table 1, Row 1, Cell 1"
+        expect(table[2][0].text).to eq "Table 1, Row 3, Cell 1"
+      end
     end
   end
 

--- a/spec/watirspec/html/javascript/helpers.js
+++ b/spec/watirspec/html/javascript/helpers.js
@@ -2,11 +2,11 @@ var WatirSpec = function() {
     
   return {
     addMessage: function(string) {
-        var text = document.createTextNode(string)
+        var text = document.createTextNode(string);
         var message = document.createElement('div');
         var messages = document.getElementById('messages');
 
-        message.appendChild(text)
+        message.appendChild(text);
         messages.appendChild(message);
     }
   };

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -37,15 +37,17 @@ describe 'Watir#relaxed_locate?' do
       end
 
       context 'when acting on an element that eventually becomes present' do
-        it 'waits until present and then takes action' do
-          begin
-            Watir.default_timeout = 3
-            start_time = ::Time.now
-            browser.a(id: 'show_bar').click
-            expect { browser.div(id: 'bar').click }.to_not raise_exception
-            expect(::Time.now - start_time).to be < 3
-          ensure
-            Watir.default_timeout = 30
+        bug "https://github.com/SeleniumHQ/selenium/issues/4380", %i{remote firefox} do
+          it 'waits until present and then takes action' do
+            begin
+              Watir.default_timeout = 3
+              start_time = ::Time.now
+              browser.a(id: 'show_bar').click
+              expect { browser.div(id: 'bar').click }.to_not raise_exception
+              expect(::Time.now - start_time).to be < 3
+            ensure
+              Watir.default_timeout = 30
+            end
           end
         end
       end

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -26,10 +26,10 @@ describe 'Watir#relaxed_locate?' do
       context 'when acting on an element that is already present' do
         it 'does not wait' do
           begin
-            Watir.default_timeout = 2
+            Watir.default_timeout = 5
             start_time = ::Time.now
             expect { browser.link.click }.to_not raise_exception
-            expect(::Time.now - start_time).to be < 2
+            expect(::Time.now - start_time).to be < 5
           ensure
             Watir.default_timeout = 30
           end

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -1,398 +1,398 @@
 require "watirspec_helper"
 
-not_compliant_on :safari do
-  describe Watir::Wait do
-    describe "#until" do
-      it "waits until the block returns true" do
-        Watir::Wait.until(timeout: 0.5) { @result = true }
-        expect(@result).to be true
+describe Watir::Wait do
+  describe "#until" do
+    it "waits until the block returns true" do
+      Watir::Wait.until(timeout: 0.5) { @result = true }
+      expect(@result).to be true
+    end
+
+    it "executes block if timeout is zero" do
+      Watir::Wait.until(timeout: 0) { @result = true }
+      expect(@result).to be true
+    end
+
+    it "times out" do
+      expect { Watir::Wait.until(timeout: 0.5) { false } }.to raise_error(Watir::Wait::TimeoutError)
+    end
+
+    it "times out with a custom message" do
+      expect {
+        Watir::Wait.until(timeout: 0.5, message: "oops") { false }
+      }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
+    end
+
+    it "uses provided interval" do
+      begin
+        Watir::Wait.until(timeout: 0.4, interval: 0.2) do
+          @result = @result.nil? ? 1 : @result + 1
+          false
+        end
+      rescue Watir::Wait::TimeoutError
+      end
+      expect(@result).to eq 2
+    end
+
+    it "uses timer for waiting" do
+      timer = Watir::Wait.timer
+      expect(timer).to receive(:wait).with(0.5).and_call_original
+      Watir::Wait.until(timeout: 0.5) { true }
+    end
+
+    it "ordered pairs are deprecated" do
+      message = /Instead of passing arguments into Wait#until method, use keywords/
+      expect { Watir::Wait.until(0) { true } }.to output(message).to_stderr
+    end
+  end
+
+  describe "#while" do
+    it "waits while the block returns true" do
+      expect(Watir::Wait.while(timeout: 0.5) { false }).to be_nil
+    end
+
+    it "executes block if timeout is zero" do
+      expect(Watir::Wait.while(timeout: 0) { false }).to be_nil
+    end
+
+    it "times out" do
+      expect { Watir::Wait.while(timeout: 0.5) { true } }.to raise_error(Watir::Wait::TimeoutError)
+    end
+
+    it "times out with a custom message" do
+      expect {
+        Watir::Wait.while(timeout: 0.5, message: "oops") { true }
+      }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
+    end
+
+    it "uses provided interval" do
+      begin
+        Watir::Wait.while(timeout: 0.4, interval: 0.2) do
+          @result = @result.nil? ? 1 : @result + 1
+          true
+        end
+      rescue Watir::Wait::TimeoutError
+      end
+      expect(@result).to eq 2
+    end
+
+    it "uses timer for waiting" do
+      timer = Watir::Wait.timer
+      expect(timer).to receive(:wait).with(0.5).and_call_original
+      Watir::Wait.while(timeout: 0.5) { false }
+    end
+
+    it "ordered pairs are deprecated" do
+      message = /Instead of passing arguments into Wait#while method, use keywords/
+      expect { Watir::Wait.while(0) { false } }.to output(message).to_stderr
+    end
+  end
+
+  describe "#timer" do
+    it "returns default timer" do
+      expect(Watir::Wait.timer).to be_a(Watir::Wait::Timer)
+    end
+  end
+
+  describe "#timer=" do
+    after { Watir::Wait.timer = nil }
+
+    it "changes default timer" do
+      timer = Class.new
+      Watir::Wait.timer = timer
+      expect(Watir::Wait.timer).to eq(timer)
+    end
+  end
+end
+
+describe Watir::Element do
+  before do
+    browser.goto WatirSpec.url_for("wait.html")
+  end
+
+  # TODO: This is deprecated; remove in future version
+  not_compliant_on :relaxed_locate do
+    describe "#when_present" do
+      it "invokes subsequent method calls when the element becomes present" do
+        browser.a(id: 'show_bar').click
+
+        bar = browser.div(id: 'bar')
+        bar.when_present(2).click
+        expect(bar.text).to eq "changed"
       end
 
-      it "executes block if timeout is zero" do
-        Watir::Wait.until(timeout: 0) { @result = true }
-        expect(@result).to be true
+      it "times out when given a block" do
+        expect { browser.div(id: 'bar').when_present(1) {} }.to raise_error(Watir::Wait::TimeoutError)
       end
 
-      it "times out" do
-        expect { Watir::Wait.until(timeout: 0.5) { false } }.to raise_error(Watir::Wait::TimeoutError)
+      it "times out when not given a block" do
+        message = /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
+        expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Watir::Wait::TimeoutError, message)
       end
 
-      it "times out with a custom message" do
-        expect {
-          Watir::Wait.until(timeout: 0.5, message: "oops") { false }
-        }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
+      it "responds to Element methods" do
+        decorator = browser.div.when_present
+
+        expect(decorator).to respond_to(:exist?)
+        expect(decorator).to respond_to(:present?)
+        expect(decorator).to respond_to(:click)
       end
 
-      it "uses provided interval" do
-        begin
-          Watir::Wait.until(timeout: 0.4, interval: 0.2) do
-            @result = @result.nil? ? 1 : @result + 1
+      it "delegates present? to element" do
+        Object.class_eval do
+          def present?
             false
           end
-        rescue Watir::Wait::TimeoutError
         end
-        expect(@result).to eq 2
+        element = browser.a(id: "show_bar").when_present(1)
+        expect(element).to be_present
       end
 
-      it "uses timer for waiting" do
-        timer = Watir::Wait.timer
-        expect(timer).to receive(:wait).with(0.5).and_call_original
-        Watir::Wait.until(timeout: 0.5) { true }
-      end
-
-      it "ordered pairs are deprecated" do
-        message = /Instead of passing arguments into Wait#until method, use keywords/
-        expect { Watir::Wait.until(0) { true } }.to output(message).to_stderr
-      end
-    end
-
-    describe "#while" do
-      it "waits while the block returns true" do
-        expect(Watir::Wait.while(timeout: 0.5) { false }).to be_nil
-      end
-
-      it "executes block if timeout is zero" do
-        expect(Watir::Wait.while(timeout: 0) { false }).to be_nil
-      end
-
-      it "times out" do
-        expect { Watir::Wait.while(timeout: 0.5) { true } }.to raise_error(Watir::Wait::TimeoutError)
-      end
-
-      it "times out with a custom message" do
-        expect {
-          Watir::Wait.while(timeout: 0.5, message: "oops") { true }
-        }.to raise_error(Watir::Wait::TimeoutError, "timed out after 0.5 seconds, oops")
-      end
-
-      it "uses provided interval" do
-        begin
-          Watir::Wait.while(timeout: 0.4, interval: 0.2) do
-            @result = @result.nil? ? 1 : @result + 1
-            true
-          end
-        rescue Watir::Wait::TimeoutError
-        end
-        expect(@result).to eq 2
-      end
-
-      it "uses timer for waiting" do
-        timer = Watir::Wait.timer
-        expect(timer).to receive(:wait).with(0.5).and_call_original
-        Watir::Wait.while(timeout: 0.5) { false }
-      end
-
-      it "ordered pairs are deprecated" do
-        message = /Instead of passing arguments into Wait#while method, use keywords/
-        expect { Watir::Wait.while(0) { false } }.to output(message).to_stderr
-      end
-    end
-
-    describe "#timer" do
-      it "returns default timer" do
-        expect(Watir::Wait.timer).to be_a(Watir::Wait::Timer)
-      end
-    end
-
-    describe "#timer=" do
-      after { Watir::Wait.timer = nil }
-
-      it "changes default timer" do
-        timer = Class.new
-        Watir::Wait.timer = timer
-        expect(Watir::Wait.timer).to eq(timer)
+      it "processes before calling present?" do
+        browser.a(id: 'show_bar').click
+        expect(browser.div(id: 'bar').when_present.present?).to be true
       end
     end
   end
 
-  describe Watir::Element do
-    before do
-      browser.goto WatirSpec.url_for("wait.html")
-    end
+  not_compliant_on :relaxed_locate do
+    describe "#wait_until &:enabled?" do
+      it "invokes subsequent method calls when the element becomes enabled" do
+        browser.a(id: 'enable_btn').click
 
-    # TODO: This is deprecated; remove in future version
-    not_compliant_on :relaxed_locate do
-      describe "#when_present" do
-        it "invokes subsequent method calls when the element becomes present" do
-          browser.a(id: 'show_bar').click
-
-          bar = browser.div(id: 'bar')
-          bar.when_present(2).click
-          expect(bar.text).to eq "changed"
-        end
-
-        it "times out when given a block" do
-          expect { browser.div(id: 'bar').when_present(1) {} }.to raise_error(Watir::Wait::TimeoutError)
-        end
-
-        it "times out when not given a block" do
-          message = /^timed out after 1 seconds, waiting for (\{:id=>"bar", :tag_name=>"div"\}|\{:tag_name=>"div", :id=>"bar"\}) to become present$/
-          expect { browser.div(id: 'bar').when_present(1).click }.to raise_error(Watir::Wait::TimeoutError, message)
-        end
-
-        it "responds to Element methods" do
-          decorator = browser.div.when_present
-
-          expect(decorator).to respond_to(:exist?)
-          expect(decorator).to respond_to(:present?)
-          expect(decorator).to respond_to(:click)
-        end
-
-        it "delegates present? to element" do
-          Object.class_eval do
-            def present?
-              false
-            end
-          end
-          element = browser.a(id: "show_bar").when_present(1)
-          expect(element).to be_present
-        end
-
-        it "processes before calling present?" do
-          browser.a(id: 'show_bar').click
-          expect(browser.div(id: 'bar').when_present.present?).to be true
-        end
-      end
-    end
-
-    not_compliant_on :relaxed_locate do
-      describe "#wait_until &:enabled?" do
-        it "invokes subsequent method calls when the element becomes enabled" do
-          browser.a(id: 'enable_btn').click
-
-          btn = browser.button(id: 'btn')
-          btn.wait_until(timeout: 2, &:enabled?).click
-          Watir::Wait.while { btn.enabled? }
-          expect(btn.disabled?).to be true
-        end
-
-        it "times out" do
-          error = Watir::Wait::TimeoutError
-          inspected = '#<Watir::Button: located: false; {:id=>"btn", :tag_name=>"button"}>'
-          message = "timed out after 1 seconds, waiting for true condition on #{inspected}"
-          element = browser.button(id: 'btn')
-          expect { element.wait_until(timeout: 1, &:enabled?).click }.to raise_error(error, message)
-        end
-
-        it "responds to Element methods" do
-          element = browser.button.wait_until { true }
-
-          expect(element).to respond_to(:exist?)
-          expect(element).to respond_to(:present?)
-          expect(element).to respond_to(:click)
-        end
-
-        it "can be chained with #wait_until &:present?" do
-          browser.a(id: 'show_and_enable_btn').click
-          browser.button(id: 'btn2').wait_until(&:present?).wait_until(&:enabled?).click
-
-          expect(browser.button(id: 'btn2')).to exist
-          expect(browser.button(id: 'btn2')).to be_enabled
-        end
-      end
-    end
-
-    describe "#wait_until_present" do
-      it "waits until the element appears" do
-        browser.a(id: 'show_bar').click
-        expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
+        btn = browser.button(id: 'btn')
+        btn.wait_until(timeout: 2, &:enabled?).click
+        Watir::Wait.while { btn.enabled? }
+        expect(btn.disabled?).to be true
       end
 
-      it "times out if the element doesn't appear" do
-        inspected = '#<Watir::Div: located: false; {:id=>"bar", :tag_name=>"div"}>'
+      it "times out" do
         error = Watir::Wait::TimeoutError
+        inspected = '#<Watir::Button: located: false; {:id=>"btn", :tag_name=>"button"}>'
         message = "timed out after 1 seconds, waiting for true condition on #{inspected}"
-
-        expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(error, message)
+        element = browser.button(id: 'btn')
+        expect { element.wait_until(timeout: 1, &:enabled?).click }.to raise_error(error, message)
       end
 
-      it "uses provided interval" do
-        element = browser.div(id: 'bar')
-        expect(element).to receive(:present?).twice
+      it "responds to Element methods" do
+        element = browser.button.wait_until { true }
 
-        begin
-          element.wait_until_present(timeout: 0.4, interval: 0.2)
-        rescue Watir::Wait::TimeoutError
-        end
+        expect(element).to respond_to(:exist?)
+        expect(element).to respond_to(:present?)
+        expect(element).to respond_to(:click)
       end
 
-      it "ordered pairs are deprecated" do
-        browser.a(id: 'show_bar').click
-        message = /Instead of passing arguments into #wait_until_present method, use keywords/
-        expect { browser.div(id: 'bar').wait_until_present(5) }.to output(message).to_stderr
-      end
+      it "can be chained with #wait_until &:present?" do
+        browser.a(id: 'show_and_enable_btn').click
+        browser.button(id: 'btn2').wait_until(&:present?).wait_until(&:enabled?).click
 
-      it 'waits to select an option' do
-        browser.a(id: 'add_select').click
-        select_list = browser.select_list(id: 'languages')
-        Watir.default_timeout = 1
-        begin
-          start_time = ::Time.now
-          expect { select_list.select('No') }.to raise_error Watir::Exception::NoValueFoundException
-          expect(::Time.now - start_time).to be > 1
-        ensure
-          Watir.default_timeout = 30
-        end
+        expect(browser.button(id: 'btn2')).to exist
+        expect(browser.button(id: 'btn2')).to be_enabled
+      end
+    end
+  end
+
+  describe "#wait_until_present" do
+    it "waits until the element appears" do
+      browser.a(id: 'show_bar').click
+      expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
+    end
+
+    it "times out if the element doesn't appear" do
+      inspected = '#<Watir::Div: located: false; {:id=>"bar", :tag_name=>"div"}>'
+      error = Watir::Wait::TimeoutError
+      message = "timed out after 1 seconds, waiting for true condition on #{inspected}"
+
+      expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(error, message)
+    end
+
+    it "uses provided interval" do
+      element = browser.div(id: 'bar')
+      expect(element).to receive(:present?).twice
+
+      begin
+        element.wait_until_present(timeout: 0.4, interval: 0.2)
+      rescue Watir::Wait::TimeoutError
       end
     end
 
-    describe "#wait_while_present" do
-      it "waits until the element disappears" do
-        browser.a(id: 'hide_foo').click
-        expect { browser.div(id: 'foo').wait_while_present(timeout: 2) }.to_not raise_exception
+    it "ordered pairs are deprecated" do
+      browser.a(id: 'show_bar').click
+      message = /Instead of passing arguments into #wait_until_present method, use keywords/
+      expect { browser.div(id: 'bar').wait_until_present(5) }.to output(message).to_stderr
+    end
+
+    it 'waits to select an option' do
+      browser.a(id: 'add_select').click
+      select_list = browser.select_list(id: 'languages')
+      Watir.default_timeout = 1
+      begin
+        start_time = ::Time.now
+        expect { select_list.select('No') }.to raise_error Watir::Exception::NoValueFoundException
+        expect(::Time.now - start_time).to be > 1
+      ensure
+        Watir.default_timeout = 30
       end
+    end
+  end
 
-      it "times out if the element doesn't disappear" do
-        error = Watir::Wait::TimeoutError
-        inspected = '#<Watir::Div: located: false; {:id=>"foo", :tag_name=>"div"}>'
-        message = "timed out after 1 seconds, waiting for false condition on #{inspected}"
-        expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(error, message)
-      end
+  describe "#wait_while_present" do
+    it "waits until the element disappears" do
+      browser.a(id: 'hide_foo').click
+      expect { browser.div(id: 'foo').wait_while_present(timeout: 2) }.to_not raise_exception
+    end
 
-      it "uses provided interval" do
-        element = browser.div(id: 'foo')
-        expect(element).to receive(:present?).twice
+    it "times out if the element doesn't disappear" do
+      error = Watir::Wait::TimeoutError
+      inspected = '#<Watir::Div: located: false; {:id=>"foo", :tag_name=>"div"}>'
+      message = "timed out after 1 seconds, waiting for false condition on #{inspected}"
+      expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(error, message)
+    end
 
-        begin
-          element.wait_until_present(timeout: 0.4, interval: 0.2)
-        rescue Watir::Wait::TimeoutError
-        end
-      end
+    it "uses provided interval" do
+      element = browser.div(id: 'foo')
+      expect(element).to receive(:present?).twice
 
-      it "ordered pairs are deprecated" do
-        browser.a(id: 'hide_foo').click
-        message = /Instead of passing arguments into #wait_while_present method, use keywords/
-        expect { browser.div(id: 'foo').wait_while_present(5) }.to output(message).to_stderr
-      end
-
-      it "does not error when element goes stale" do
-        element = browser.div(id: 'foo')
-
-        allow(element).to receive(:stale?).and_return(false, true)
-        allow(element.wd).to receive(:displayed?).and_raise(Selenium::WebDriver::Error::StaleElementReferenceError)
-
-        browser.a(id: 'hide_foo').click
-        expect { element.wait_while_present(timeout: 1) }.to_not raise_exception
-      end
-
-      it "waits until the selector no longer matches" do
-        Watir.default_timeout = 1
-        element = browser.link(name: 'add_select').wait_until(&:exists?)
-        begin
-          start_time = ::Time.now
-          browser.link(id: 'change_select').click
-          expect { element.wait_while_present }.not_to raise_error
-        ensure
-          Watir.default_timeout = 30
-        end
+      begin
+        element.wait_until_present(timeout: 0.4, interval: 0.2)
+      rescue Watir::Wait::TimeoutError
       end
     end
 
-    describe "#wait_until" do
-      it "returns element for additional actions" do
-        element = browser.div(id: 'foo')
-        expect(element.wait_until(&:exist?)).to eq element
-      end
-
-      it "accepts self in block" do
-        element = browser.div(id: 'bar')
-        browser.a(id: 'show_bar').click
-        expect { element.wait_until { |el| el.text == 'bar' } }.to_not raise_exception
-      end
-
-      it "accepts any values in block" do
-        element = browser.div(id: 'bar')
-        expect { element.wait_until { true } }.to_not raise_exception
-      end
-
-      it "accepts just a timeout parameter" do
-        element = browser.div(id: 'bar')
-        expect { element.wait_until(timeout: 0) { true } }.to_not raise_exception
-      end
-
-      it "accepts just a message parameter" do
-        element = browser.div(id: 'bar')
-        expect { element.wait_until(message: 'no') { true } }.to_not raise_exception
-      end
-
-      it "accepts just an interval parameter" do
-        element = browser.div(id: 'bar')
-        expect { element.wait_until(interval: 0.1) { true } }.to_not raise_exception
-      end
+    it "ordered pairs are deprecated" do
+      browser.a(id: 'hide_foo').click
+      message = /Instead of passing arguments into #wait_while_present method, use keywords/
+      expect { browser.div(id: 'foo').wait_while_present(5) }.to output(message).to_stderr
     end
 
-    describe "#wait_while" do
-      it "returns element for additional actions" do
-        element = browser.div(id: 'foo')
-        browser.a(id: 'hide_foo').click
-        expect(element.wait_while(&:present?)).to eq element
-      end
+    it "does not error when element goes stale" do
+      element = browser.div(id: 'foo')
 
+      allow(element).to receive(:stale?).and_return(false, true)
+      allow(element.wd).to receive(:displayed?).and_raise(Selenium::WebDriver::Error::StaleElementReferenceError)
+
+      browser.a(id: 'hide_foo').click
+      expect { element.wait_while_present(timeout: 1) }.to_not raise_exception
+    end
+
+    it "waits until the selector no longer matches" do
+      Watir.default_timeout = 1
+      element = browser.link(name: 'add_select').wait_until(&:exists?)
+      begin
+        start_time = ::Time.now
+        browser.link(id: 'change_select').click
+        expect { element.wait_while_present }.not_to raise_error
+      ensure
+        Watir.default_timeout = 30
+      end
+    end
+  end
+
+  describe "#wait_until" do
+    it "returns element for additional actions" do
+      element = browser.div(id: 'foo')
+      expect(element.wait_until(&:exist?)).to eq element
+    end
+
+    it "accepts self in block" do
+      element = browser.div(id: 'bar')
+      browser.a(id: 'show_bar').click
+      expect { element.wait_until { |el| el.text == 'bar' } }.to_not raise_exception
+    end
+
+    it "accepts any values in block" do
+      element = browser.div(id: 'bar')
+      expect { element.wait_until { true } }.to_not raise_exception
+    end
+
+    it "accepts just a timeout parameter" do
+      element = browser.div(id: 'bar')
+      expect { element.wait_until(timeout: 0) { true } }.to_not raise_exception
+    end
+
+    it "accepts just a message parameter" do
+      element = browser.div(id: 'bar')
+      expect { element.wait_until(message: 'no') { true } }.to_not raise_exception
+    end
+
+    it "accepts just an interval parameter" do
+      element = browser.div(id: 'bar')
+      expect { element.wait_until(interval: 0.1) { true } }.to_not raise_exception
+    end
+  end
+
+  describe "#wait_while" do
+    it "returns element for additional actions" do
+      element = browser.div(id: 'foo')
+      browser.a(id: 'hide_foo').click
+      expect(element.wait_while(&:present?)).to eq element
+    end
+
+    not_compliant_on :safari do
       it "accepts self in block" do
         element = browser.div(id: 'foo')
         browser.a(id: 'hide_foo').click
         expect { element.wait_while { |el| el.text == 'foo' } }.to_not raise_exception
       end
+    end
 
-      it "accepts any values in block" do
-        element = browser.div(id: 'foo')
-        expect { element.wait_while { false } }.to_not raise_exception
-      end
+    it "accepts any values in block" do
+      element = browser.div(id: 'foo')
+      expect { element.wait_while { false } }.to_not raise_exception
+    end
 
-      it "accepts just a timeout parameter" do
-        element = browser.div(id: 'foo')
-        expect { element.wait_while(timeout: 0) { false } }.to_not raise_exception
-      end
+    it "accepts just a timeout parameter" do
+      element = browser.div(id: 'foo')
+      expect { element.wait_while(timeout: 0) { false } }.to_not raise_exception
+    end
 
-      it "accepts just a message parameter" do
-        element = browser.div(id: 'foo')
-        expect { element.wait_while(message: 'no') { false } }.to_not raise_exception
-      end
+    it "accepts just a message parameter" do
+      element = browser.div(id: 'foo')
+      expect { element.wait_while(message: 'no') { false } }.to_not raise_exception
+    end
 
-      it "accepts just an interval parameter" do
-        element = browser.div(id: 'foo')
-        expect { element.wait_while(interval: 0.1) { false } }.to_not raise_exception
-      end
+    it "accepts just an interval parameter" do
+      element = browser.div(id: 'foo')
+      expect { element.wait_while(interval: 0.1) { false } }.to_not raise_exception
     end
   end
+end
 
-  describe Watir do
-    describe "#default_timeout" do
-      before do
-        Watir.default_timeout = 1
+describe Watir do
+  describe "#default_timeout" do
+    before do
+      Watir.default_timeout = 1
 
-        browser.goto WatirSpec.url_for("wait.html")
+      browser.goto WatirSpec.url_for("wait.html")
+    end
+
+    after do
+      # Reset the default timeout
+      Watir.default_timeout = 30
+    end
+
+    context "when no timeout is specified" do
+      it "is used by Wait#until" do
+        expect {
+          Watir::Wait.until { false }
+        }.to raise_error(Watir::Wait::TimeoutError)
       end
 
-      after do
-        # Reset the default timeout
-        Watir.default_timeout = 30
+      it "is used by Wait#while" do
+        expect {
+          Watir::Wait.while { true }
+        }.to raise_error(Watir::Wait::TimeoutError)
       end
 
-      context "when no timeout is specified" do
-        it "is used by Wait#until" do
-          expect {
-            Watir::Wait.until { false }
-          }.to raise_error(Watir::Wait::TimeoutError)
-        end
+      it "is used by Element#wait_until_present" do
+        expect {
+          browser.div(id: 'bar').wait_until_present
+        }.to raise_error(Watir::Wait::TimeoutError)
+      end
 
-        it "is used by Wait#while" do
-          expect {
-            Watir::Wait.while { true }
-          }.to raise_error(Watir::Wait::TimeoutError)
-        end
-
-        it "is used by Element#wait_until_present" do
-          expect {
-            browser.div(id: 'bar').wait_until_present
-          }.to raise_error(Watir::Wait::TimeoutError)
-        end
-
-        it "is used by Element#wait_while_present" do
-          expect {
-            browser.div(id: 'foo').wait_while_present
-          }.to raise_error(Watir::Wait::TimeoutError)
-        end
+      it "is used by Element#wait_while_present" do
+        expect {
+          browser.div(id: 'foo').wait_while_present
+        }.to raise_error(Watir::Wait::TimeoutError)
       end
     end
   end

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -343,7 +343,7 @@ describe "Window" do
       browser.goto WatirSpec.url_for("window_switching.html")
     end
 
-    compliant_on :ff_legacy, :chrome do
+    compliant_on :chrome do
       it "should get the size of the current window" do
         size = browser.window.size
 

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -1,10 +1,102 @@
 require "watirspec_helper"
 
-not_compliant_on :safari do
-  describe "Browser" do
+describe "Browser" do
+  before do
+    url = WatirSpec.url_for("window_switching.html")
+    browser.goto url
+    browser.a(id: "open").click
+    Watir::Wait.until { browser.windows.size == 2 }
+  end
+
+  after do
+    browser.window(index: 0).use
+    browser.windows[1..-1].each(&:close)
+  end
+
+  describe "#windows" do
+    it "returns an array of window handles" do
+      wins = browser.windows
+      expect(wins).to_not be_empty
+      wins.each { |win| expect(win).to be_kind_of(Watir::Window) }
+    end
+
+    it "only returns windows matching the given selector" do
+      expect(browser.windows(title: "closeable window").size).to eq 1
+    end
+
+    it "raises ArgumentError if the selector is invalid" do
+      expect { browser.windows(name: "foo") }.to raise_error(ArgumentError)
+    end
+
+    it "returns an empty array if no window matches the selector" do
+      expect(browser.windows(title: "noop")).to eq []
+    end
+  end
+
+  describe "#window" do
+    it "finds window by :url" do
+      w = browser.window(url: /closeable\.html/).use
+      expect(w).to be_kind_of(Watir::Window)
+    end
+
+    it "finds window by :title" do
+      w = browser.window(title: "closeable window").use
+      expect(w).to be_kind_of(Watir::Window)
+    end
+
+    it "finds window by :index" do
+      w = browser.window(index: 1).use
+      expect(w).to be_kind_of(Watir::Window)
+    end
+
+    it "should not find incorrect handle" do
+      expect(browser.window(handle: 'bar')).to_not be_present
+    end
+
+    it "returns the current window if no argument is given" do
+      expect(browser.window.url).to match(/window_switching\.html/)
+    end
+
+    it "stores the reference to a window when no argument is given" do
+      original_window = browser.window
+      browser.window(index: 1).use
+      expect(original_window.url).to match(/window_switching\.html/)
+    end
+
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+      it "it executes the given block in the window" do
+        browser.window(title: "closeable window") do
+          link = browser.a(id: "close")
+          expect(link).to exist
+          link.click
+        end.wait_while_present
+
+        expect(browser.windows.size).to eq 1
+      end
+    end
+
+    it "raises ArgumentError if the selector is invalid" do
+      expect { browser.window(name: "foo") }.to raise_error(ArgumentError)
+    end
+
+    it "raises a NoMatchingWindowFoundException error if no window matches the selector" do
+      expect { browser.window(title: "noop").use }.to raise_no_matching_window_exception
+    end
+
+    it "raises a NoMatchingWindowFoundException error if there's no window at the given index" do
+      expect { browser.window(index: 100).use }.to raise_no_matching_window_exception
+    end
+
+    it "raises NoMatchingWindowFoundException error when attempting to use a window with an incorrect handle" do
+      expect { browser.window(handle: 'bar').use }.to raise_no_matching_window_exception
+    end
+  end
+end
+
+describe "Window" do
+  context 'multiple windows' do
     before do
-      url = WatirSpec.url_for("window_switching.html")
-      browser.goto url
+      browser.goto WatirSpec.url_for("window_switching.html")
       browser.a(id: "open").click
       Watir::Wait.until { browser.windows.size == 2 }
     end
@@ -14,100 +106,8 @@ not_compliant_on :safari do
       browser.windows[1..-1].each(&:close)
     end
 
-    describe "#windows" do
-      it "returns an array of window handles" do
-        wins = browser.windows
-        expect(wins).to_not be_empty
-        wins.each { |win| expect(win).to be_kind_of(Watir::Window) }
-      end
-
-      it "only returns windows matching the given selector" do
-        expect(browser.windows(title: "closeable window").size).to eq 1
-      end
-
-      it "raises ArgumentError if the selector is invalid" do
-        expect { browser.windows(name: "foo") }.to raise_error(ArgumentError)
-      end
-
-      it "returns an empty array if no window matches the selector" do
-        expect(browser.windows(title: "noop")).to eq []
-      end
-    end
-
-    describe "#window" do
-      it "finds window by :url" do
-        w = browser.window(url: /closeable\.html/).use
-        expect(w).to be_kind_of(Watir::Window)
-      end
-
-      it "finds window by :title" do
-        w = browser.window(title: "closeable window").use
-        expect(w).to be_kind_of(Watir::Window)
-      end
-
-      it "finds window by :index" do
-        w = browser.window(index: 1).use
-        expect(w).to be_kind_of(Watir::Window)
-      end
-
-      it "should not find incorrect handle" do
-        expect(browser.window(handle: 'bar')).to_not be_present
-      end
-
-      it "returns the current window if no argument is given" do
-        expect(browser.window.url).to match(/window_switching\.html/)
-      end
-
-      it "stores the reference to a window when no argument is given" do
-        original_window = browser.window
-        browser.window(index: 1).use
-        expect(original_window.url).to match(/window_switching\.html/)
-      end
-
-      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
-        it "it executes the given block in the window" do
-          browser.window(title: "closeable window") do
-            link = browser.a(id: "close")
-            expect(link).to exist
-            link.click
-          end.wait_while_present
-
-          expect(browser.windows.size).to eq 1
-        end
-      end
-
-      it "raises ArgumentError if the selector is invalid" do
-        expect { browser.window(name: "foo") }.to raise_error(ArgumentError)
-      end
-
-      it "raises a NoMatchingWindowFoundException error if no window matches the selector" do
-        expect { browser.window(title: "noop").use }.to raise_no_matching_window_exception
-      end
-
-      it "raises a NoMatchingWindowFoundException error if there's no window at the given index" do
-        expect { browser.window(index: 100).use }.to raise_no_matching_window_exception
-      end
-
-      it "raises NoMatchingWindowFoundException error when attempting to use a window with an incorrect handle" do
-        expect { browser.window(handle: 'bar').use }.to raise_no_matching_window_exception
-      end
-    end
-  end
-
-  describe "Window" do
-    context 'multiple windows' do
-      before do
-        browser.goto WatirSpec.url_for("window_switching.html")
-        browser.a(id: "open").click
-        Watir::Wait.until { browser.windows.size == 2 }
-      end
-
-      after do
-        browser.window(index: 0).use
-        browser.windows[1..-1].each(&:close)
-      end
-
-      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1280517", :firefox do
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1280517", :firefox do
+      not_compliant_on :safari do
         describe "#close" do
           it "closes a window" do
             browser.a(id: "open").click
@@ -116,127 +116,129 @@ not_compliant_on :safari do
             browser.window(title: "closeable window").close
             expect(browser.windows.size).to eq 2
           end
-
-          it "closes the current window" do
-            browser.a(id: "open").click
-            Watir::Wait.until { browser.windows.size == 3 }
-
-            window = browser.window(title: "closeable window").use
-            window.close
-            expect(browser.windows.size).to eq 2
-          end
-        end
-      end
-
-      describe "#use" do
-        it "switches to the window" do
-          browser.window(title: "closeable window").use
-          expect(browser.title).to eq "closeable window"
-        end
-      end
-
-      describe "#current?" do
-        it "returns true if it is the current window" do
-          expect(browser.window(title: browser.title)).to be_current
         end
 
-        it "returns false if it is not the current window" do
-          expect(browser.window(title: "closeable window")).to_not be_current
-        end
-      end
+        it "closes the current window" do
+          browser.a(id: "open").click
+          Watir::Wait.until { browser.windows.size == 3 }
 
-      describe "#title" do
-        it "returns the title of the window" do
-          titles = browser.windows.map(&:title)
-          expect(titles.size).to eq 2
-
-          expect(titles.sort).to eq ["window switching", "closeable window"].sort
-        end
-
-        it "does not change the current window" do
-          expect(browser.title).to eq "window switching"
-          expect(browser.windows.find { |w| w.title == "closeable window" }).to_not be_nil
-          expect(browser.title).to eq "window switching"
-        end
-      end
-
-      describe "#url" do
-        it "returns the url of the window" do
-          expect(browser.windows.select { |w| w.url =~ (/window_switching\.html/) }.size).to eq 1
-          expect(browser.windows.select { |w| w.url =~ (/closeable\.html$/) }.size).to eq 1
-        end
-
-        it "does not change the current window" do
-          expect(browser.url).to match(/window_switching\.html/)
-          expect(browser.windows.find { |w| w.url =~ (/closeable\.html/) }).to_not be_nil
-          expect(browser.url).to match(/window_switching/)
-        end
-      end
-
-      describe "#eql?" do
-        it "knows when two windows are equal" do
-          expect(browser.window).to eq browser.window(index: 0)
-        end
-
-        it "knows when two windows are not equal" do
-          win1 = browser.window(index: 0)
-          win2 = browser.window(index: 1)
-
-          expect(win1).to_not eq win2
-        end
-      end
-
-      not_compliant_on :relaxed_locate do
-        describe "#wait_until &:present?" do
-          it "times out waiting for a non-present window" do
-            expect {
-              browser.window(title: "noop").wait_until(timeout: 0.5, &:present?)
-            }.to raise_error(Watir::Wait::TimeoutError)
-          end
+          window = browser.window(title: "closeable window").use
+          window.close
+          expect(browser.windows.size).to eq 2
         end
       end
     end
 
-    context "with a closed window" do
-      before do
-        browser.goto WatirSpec.url_for("window_switching.html")
-        browser.a(id: "open").click
-        Watir::Wait.until { browser.windows.size == 2 }
+    describe "#use" do
+      it "switches to the window" do
+        browser.window(title: "closeable window").use
+        expect(browser.title).to eq "closeable window"
+      end
+    end
+
+    describe "#current?" do
+      it "returns true if it is the current window" do
+        expect(browser.window(title: browser.title)).to be_current
       end
 
-      after do
-        browser.window(index: 0).use
-        browser.windows[1..-1].each(&:close)
+      it "returns false if it is not the current window" do
+        expect(browser.window(title: "closeable window")).to_not be_current
+      end
+    end
+
+    describe "#title" do
+      it "returns the title of the window" do
+        titles = browser.windows.map(&:title)
+        expect(titles.size).to eq 2
+
+        expect(titles.sort).to eq ["window switching", "closeable window"].sort
       end
 
-      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
-        describe "#exists?" do
-          it "returns false if previously referenced window is closed" do
-            window = browser.window(title: "closeable window")
-            window.use
-            browser.a(id: "close").click
-            Watir::Wait.until { browser.windows.size == 1 }
-            expect(window).to_not be_present
-          end
+      it "does not change the current window" do
+        expect(browser.title).to eq "window switching"
+        expect(browser.windows.find { |w| w.title == "closeable window" }).to_not be_nil
+        expect(browser.title).to eq "window switching"
+      end
+    end
 
-          it "returns false if closed window is referenced" do
-            browser.window(title: "closeable window").use
-            browser.a(id: "close").click
-            Watir::Wait.until { browser.windows.size == 1 }
-            expect(browser.window).to_not be_present
-          end
+    describe "#url" do
+      it "returns the url of the window" do
+        expect(browser.windows.select { |w| w.url =~ (/window_switching\.html/) }.size).to eq 1
+        expect(browser.windows.select { |w| w.url =~ (/closeable\.html$/) }.size).to eq 1
+      end
+
+      it "does not change the current window" do
+        expect(browser.url).to match(/window_switching\.html/)
+        expect(browser.windows.find { |w| w.url =~ (/closeable\.html/) }).to_not be_nil
+        expect(browser.url).to match(/window_switching/)
+      end
+    end
+
+    describe "#eql?" do
+      it "knows when two windows are equal" do
+        expect(browser.window).to eq browser.window(index: 0)
+      end
+
+      it "knows when two windows are not equal" do
+        win1 = browser.window(index: 0)
+        win2 = browser.window(index: 1)
+
+        expect(win1).to_not eq win2
+      end
+    end
+
+    not_compliant_on :relaxed_locate do
+      describe "#wait_until &:present?" do
+        it "times out waiting for a non-present window" do
+          expect {
+            browser.window(title: "noop").wait_until(timeout: 0.5, &:present?)
+          }.to raise_error(Watir::Wait::TimeoutError)
         end
       end
+    end
+  end
 
-      describe "#current?" do
-        it "returns false if the referenced window is closed" do
-          original_window = browser.window
+  context "with a closed window" do
+    before do
+      browser.goto WatirSpec.url_for("window_switching.html")
+      browser.a(id: "open").click
+      Watir::Wait.until { browser.windows.size == 2 }
+    end
+
+    after do
+      browser.window(index: 0).use
+      browser.windows[1..-1].each(&:close)
+    end
+
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+      describe "#exists?" do
+        it "returns false if previously referenced window is closed" do
+          window = browser.window(title: "closeable window")
+          window.use
+          browser.a(id: "close").click
+          Watir::Wait.until { browser.windows.size == 1 }
+          expect(window).to_not be_present
+        end
+
+        it "returns false if closed window is referenced" do
           browser.window(title: "closeable window").use
-          original_window.close
-          expect(original_window).to_not be_current
+          browser.a(id: "close").click
+          Watir::Wait.until { browser.windows.size == 1 }
+          expect(browser.window).to_not be_present
         end
       end
+    end
 
+    describe "#current?" do
+      it "returns false if the referenced window is closed" do
+        original_window = browser.window
+        browser.window(title: "closeable window").use
+        original_window.close
+        expect(original_window).to_not be_current
+      end
+    end
+
+    not_compliant_on :safari do
       describe "#eql?" do
         it "should return false when checking equivalence to a closed window" do
           original_window = browser.window
@@ -246,162 +248,162 @@ not_compliant_on :safari do
           expect(other_window == original_window).to be false
         end
       end
+    end
 
-      describe "#use" do
+    describe "#use" do
+      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+        it "raises NoMatchingWindowFoundException error when attempting to use a referenced window that is closed" do
+          original_window = browser.window
+          browser.window(index: 1).use
+          original_window.close
+          expect { original_window.use }.to raise_no_matching_window_exception
+        end
+
         bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
-          it "raises NoMatchingWindowFoundException error when attempting to use a referenced window that is closed" do
-            original_window = browser.window
-            browser.window(index: 1).use
-            original_window.close
-            expect { original_window.use }.to raise_no_matching_window_exception
-          end
-
-          bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
-            it "raises NoMatchingWindowFoundException error when attempting to use the current window if it is closed" do
-              browser.window(title: "closeable window").use
-              browser.a(id: "close").click
-              Watir::Wait.until { browser.windows.size == 1 }
-              expect { browser.window.use }.to raise_no_matching_window_exception
-            end
+          it "raises NoMatchingWindowFoundException error when attempting to use the current window if it is closed" do
+            browser.window(title: "closeable window").use
+            browser.a(id: "close").click
+            Watir::Wait.until { browser.windows.size == 1 }
+            expect { browser.window.use }.to raise_no_matching_window_exception
           end
         end
       end
     end
+  end
 
-    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
-      context "with current window closed" do
-        before do
-          browser.goto WatirSpec.url_for("window_switching.html")
-          browser.a(id: "open").click
-          Watir::Wait.until { browser.windows.size == 2 }
-          browser.window(title: "closeable window").use
-          browser.a(id: "close").click
-          Watir::Wait.until { browser.windows.size == 1 }
-        end
-
-        after do
-          browser.window(index: 0).use
-          browser.windows[1..-1].each(&:close)
-        end
-
-        describe "#present?" do
-          it "should find window by index" do
-            expect(browser.window(index: 0)).to be_present
-          end
-
-          it "should find window by url" do
-            expect(browser.window(url: /window_switching\.html/)).to be_present
-          end
-
-          it "should find window by title" do
-            expect(browser.window(title: "window switching")).to be_present
-          end
-        end
-
-        describe "#use" do
-
-          context "switching windows without blocks" do
-            it "by index" do
-              browser.window(index: 0).use
-              expect(browser.title).to be == "window switching"
-            end
-
-            it "by url" do
-              browser.window(url: /window_switching\.html/).use
-              expect(browser.title).to be == "window switching"
-            end
-
-            it "by title" do
-              browser.window(title: "window switching").use
-              expect(browser.url).to match(/window_switching\.html/)
-            end
-          end
-
-          context "Switching windows with blocks" do
-            it "by index" do
-              browser.window(index: 0).use { expect(browser.title).to be == "window switching" }
-            end
-
-            it "by url" do
-              browser.window(url: /window_switching\.html/).use { expect(browser.title).to be == "window switching" }
-            end
-
-            it "by title" do
-              browser.window(title: "window switching").use { expect(browser.url).to match(/window_switching\.html/) }
-            end
-          end
-
-        end
-      end
-    end
-
-    context "manipulating size and position" do
+  bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+    context "with current window closed" do
       before do
         browser.goto WatirSpec.url_for("window_switching.html")
+        browser.a(id: "open").click
+        Watir::Wait.until { browser.windows.size == 2 }
+        browser.window(title: "closeable window").use
+        browser.a(id: "close").click
+        Watir::Wait.until { browser.windows.size == 1 }
       end
 
-      compliant_on :ff_legacy, :chrome do
-        it "should get the size of the current window" do
-          size = browser.window.size
+      after do
+        browser.window(index: 0).use
+        browser.windows[1..-1].each(&:close)
+      end
 
-          expect(size.width).to be > 0
-          expect(size.height).to be > 0
+      describe "#present?" do
+        it "should find window by index" do
+          expect(browser.window(index: 0)).to be_present
         end
 
-        it "should get the position of the current window" do
-          pos = browser.window.position
+        it "should find window by url" do
+          expect(browser.window(url: /window_switching\.html/)).to be_present
+        end
 
-          expect(pos.x).to be >= 0
-          expect(pos.y).to be >= 0
+        it "should find window by title" do
+          expect(browser.window(title: "window switching")).to be_present
         end
       end
 
-      bug "https://github.com/SeleniumHQ/selenium/issues/2856", %i(remote firefox) do
-        it "should resize the window" do
-          initial_size = browser.window.size
-          browser.window.resize_to(
+      describe "#use" do
+
+        context "switching windows without blocks" do
+          it "by index" do
+            browser.window(index: 0).use
+            expect(browser.title).to be == "window switching"
+          end
+
+          it "by url" do
+            browser.window(url: /window_switching\.html/).use
+            expect(browser.title).to be == "window switching"
+          end
+
+          it "by title" do
+            browser.window(title: "window switching").use
+            expect(browser.url).to match(/window_switching\.html/)
+          end
+        end
+
+        context "Switching windows with blocks" do
+          it "by index" do
+            browser.window(index: 0).use { expect(browser.title).to be == "window switching" }
+          end
+
+          it "by url" do
+            browser.window(url: /window_switching\.html/).use { expect(browser.title).to be == "window switching" }
+          end
+
+          it "by title" do
+            browser.window(title: "window switching").use { expect(browser.url).to match(/window_switching\.html/) }
+          end
+        end
+
+      end
+    end
+  end
+
+  context "manipulating size and position" do
+    before do
+      browser.goto WatirSpec.url_for("window_switching.html")
+    end
+
+    compliant_on :ff_legacy, :chrome do
+      it "should get the size of the current window" do
+        size = browser.window.size
+
+        expect(size.width).to be > 0
+        expect(size.height).to be > 0
+      end
+
+      it "should get the position of the current window" do
+        pos = browser.window.position
+
+        expect(pos.x).to be >= 0
+        expect(pos.y).to be >= 0
+      end
+    end
+
+    bug "https://github.com/SeleniumHQ/selenium/issues/2856", %i(remote firefox) do
+      it "should resize the window" do
+        initial_size = browser.window.size
+        browser.window.resize_to(
             initial_size.width - 20,
             initial_size.height - 20
+        )
+
+        new_size = browser.window.size
+
+        expect(new_size.width).to eq initial_size.width - 20
+        expect(new_size.height).to eq initial_size.height - 20
+      end
+    end
+
+    not_compliant_on :firefox do
+      it "should move the window" do
+        initial_pos = browser.window.position
+
+        browser.window.move_to(
+            initial_pos.x + 2,
+            initial_pos.y + 2
+        )
+
+        new_pos = browser.window.position
+        expect(new_pos.x).to eq initial_pos.x + 2
+        expect(new_pos.y).to eq initial_pos.y + 2
+      end
+    end
+
+    compliant_on :window_manager do
+      bug "https://github.com/SeleniumHQ/selenium/issues/2856", %i(remote firefox) do
+        it "should maximize the window" do
+          initial_size = browser.window.size
+          browser.window.resize_to(
+              initial_size.width,
+              initial_size.height - 20
           )
+
+          browser.window.maximize
+          browser.wait_until { browser.window.size != initial_size }
 
           new_size = browser.window.size
-
-          expect(new_size.width).to eq initial_size.width - 20
-          expect(new_size.height).to eq initial_size.height - 20
-        end
-      end
-
-      not_compliant_on :firefox do
-        it "should move the window" do
-          initial_pos = browser.window.position
-
-          browser.window.move_to(
-              initial_pos.x + 2,
-              initial_pos.y + 2
-          )
-
-          new_pos = browser.window.position
-          expect(new_pos.x).to eq initial_pos.x + 2
-          expect(new_pos.y).to eq initial_pos.y + 2
-        end
-      end
-
-      compliant_on :window_manager do
-        bug "https://github.com/SeleniumHQ/selenium/issues/2856", %i(remote firefox) do
-          it "should maximize the window" do
-            initial_size = browser.window.size
-            browser.window.resize_to(
-                initial_size.width,
-                initial_size.height - 20
-            )
-
-            browser.window.maximize
-            browser.wait_until { browser.window.size != initial_size }
-
-            new_size = browser.window.size
-            expect(new_size.width).to be >= initial_size.width
-            expect(new_size.height).to be > (initial_size.height - 20)
-          end
+          expect(new_size.width).to be >= initial_size.width
+          expect(new_size.height).to be > (initial_size.height - 20)
         end
       end
     end

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -157,6 +157,8 @@ class ImplementationConfig
     if remote_browser == :firefox
       path = ENV['FIREFOX_BINARY']
       opts[:firefox_binary] = path if path
+    elsif remote_browser == :safari
+      opts["safari.options"] = {'technologyPreview' => true}
     end
 
     caps = Selenium::WebDriver::Remote::Capabilities.send(remote_browser, opts)

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -64,8 +64,6 @@ class ImplementationConfig
     args = case browser
            when :firefox
              firefox_args
-           when :ff_legacy
-             ff_legacy_args
            when :chrome
              chrome_args
            when :safari
@@ -104,12 +102,10 @@ class ImplementationConfig
       matching_browser = remote_browser
       matching_guards << :remote
       matching_guards << [:remote, matching_browser]
-      matching_guards << [:remote, :ff_legacy] if @ff_legacy
     else
       matching_browser = browser
     end
 
-    matching_guards << :ff_legacy if @ff_legacy
     matching_guards << matching_browser
     matching_guards << [matching_browser, Selenium::WebDriver::Platform.os]
     matching_guards << :relaxed_locate if Watir.relaxed_locate?
@@ -129,15 +125,6 @@ class ImplementationConfig
     path = ENV['FIREFOX_BINARY']
     Selenium::WebDriver::Firefox::Binary.path = path if path
     {desired_capabilities: Selenium::WebDriver::Remote::Capabilities.firefox}
-  end
-
-  def ff_legacy_args
-    @browser = :firefox
-    @ff_legacy = true
-    caps = Selenium::WebDriver::Remote::Capabilities.firefox(marionette: false)
-    path = ENV['FF_LEGACY_BINARY']
-    Selenium::WebDriver::Firefox::Binary.path = path if path
-    {desired_capabilities: caps}
   end
 
   def chrome_args
@@ -167,13 +154,7 @@ class ImplementationConfig
   def remote_args
     url = ENV["REMOTE_SERVER_URL"] || "http://127.0.0.1:#{@server.port}/wd/hub"
     opts = {}
-    if remote_browser == :ff_legacy
-      path = ENV['FF_LEGACY_BINARY']
-      opts[:firefox_binary] = path if path
-      @remote_browser = :firefox
-      @ff_legacy = true
-      opts[:marionette] = false
-    elsif remote_browser == :firefox
+    if remote_browser == :firefox
       path = ENV['FIREFOX_BINARY']
       opts[:firefox_binary] = path if path
     end

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -68,6 +68,8 @@ class ImplementationConfig
              ff_legacy_args
            when :chrome
              chrome_args
+           when :safari
+             safari_args
            when :remote
              remote_args
            else
@@ -155,6 +157,11 @@ class ImplementationConfig
     end
 
     opts
+  end
+
+  def safari_args
+    Selenium::WebDriver::Safari.technology_preview!
+    {desired_capabilities: Selenium::WebDriver::Remote::Capabilities.safari}
   end
 
   def remote_args


### PR DESCRIPTION
1. Stop testing legacy Firefox
2. Use Tech preview for Safari tests since tests actually pass using it
3. Test using the latest released Standalone Server
4. I copied Alex's approach to Selenium Travis here to minimize the number of things that get run. I think this is the right cross section.
5. Does anyone read the emails from Travis results? If so, I'll add back the notifications (@jarmo?)
6. I moved the server startup code into lib/watirspec because `watirspec_helper` was cluttered and because I was going to create a rake task that started the server... Then I decided not to do the rake task. But I think that code is better off in lib than in the spec directory.

Also, any ideas on the failing doctest for `Selenium::WebDriver::Error::UnknownError: unknown error: failed to change window state to maximized, current state is normal`?