### PR TITLE
Select all

### DIFF
--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -40,6 +40,22 @@ module Watir
     alias_method :size, :length
 
     #
+    # Returns true if no elements are found
+    #
+    # @example
+    #   browser.select_list(name: "new_user_languages").options(class: 'not_here').empty?
+    #   #=> true
+    #
+    # @example
+    #   browser.select_list(name: "new_user_languages").options(id: 'danish').empty?
+    #   #=> false
+    #
+
+    def empty?
+      length == 0
+    end
+
+    #
     # Get the element at the given index.
     #
     # Also note that because of Watir's lazy loading, this will return an Element
@@ -96,6 +112,7 @@ module Watir
             end
           end
     end
+    alias_method :locate, :to_a
 
     #
     # Returns true if two element collections are equal.

--- a/lib/watir/elements/option.rb
+++ b/lib/watir/elements/option.rb
@@ -60,13 +60,12 @@ module Watir
       # A little unintuitive - we'll return the 'label' or 'text' attribute if
       # they exist, otherwise the inner text of the element
 
-      attribute = [:label, :text].find { |a| attribute? a }
-
-      if attribute
-        attribute_value(attribute)
-      else
-        super
+      [:label, :text].each do |a|
+        val = attribute_value(a)
+        return val unless val.nil?
       end
+
+      super
     end
 
   end # Option

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -10,7 +10,7 @@ module Watir
       raise Error, "you can only clear multi-selects" unless multiple?
 
       options.each do |o|
-        click_option(o) if o.selected?
+        o.click if o.selected?
       end
     end
 
@@ -21,7 +21,7 @@ module Watir
     #
 
     def options(*)
-      element_call(:wait_for_exists) { super }
+      super
     end
 
     #
@@ -32,11 +32,7 @@ module Watir
     #
 
     def include?(str_or_rx)
-      element_call do
-        @element.find_elements(:tag_name, 'option').any? do |e|
-          str_or_rx === e.text || str_or_rx === e.attribute(:label)
-        end
-      end
+      option(text: str_or_rx).exist? || option(label: str_or_rx).exist?
     end
 
     #
@@ -75,21 +71,15 @@ module Watir
     #
 
     def selected?(str_or_rx)
-      match_found = false
+      by_text = options(text: str_or_rx)
+      return true if by_text.find(&:selected?)
 
-      element_call do
-        @element.find_elements(:tag_name, 'option').each do |e|
-          matched = str_or_rx === e.text || str_or_rx === e.attribute(:label)
-          if matched
-            return true if e.selected?
-            match_found = true
-          end
-        end
-      end
+      by_label = options(label: str_or_rx)
+      return true if by_label.find(&:selected?)
 
-      raise(UnknownObjectException, "Unable to locate option matching #{str_or_rx.inspect}") unless match_found
+      return false unless by_text.size + by_label.size == 0
 
-      false
+      raise(UnknownObjectException, "Unable to locate option matching #{str_or_rx.inspect}")
     end
 
     #
@@ -148,18 +138,18 @@ module Watir
             found = options(label: str_or_rx) if found.to_a.empty?
           else
             raise TypeError, "expected String or Regexp, got #{str_or_rx.inspect}:#{str_or_rx.class}"
-           end
+          end
           !found.to_a.empty?
         end
       rescue Wait::TimeoutError
-        no_value_found(str_or_rx)
+        raise NoValueFoundException, "#{str_or_rx.inspect} not found in select list"
       end
       select_matching(found)
     end
 
     def select_matching(elements)
       elements = [elements.first] unless multiple?
-      elements.each { |e| click_option(e) unless e.selected? }
+      elements.each { |e| e.click unless e.selected? }
       elements.first.exist? ? elements.first.text : ''
     end
 
@@ -173,19 +163,10 @@ module Watir
         raise Error, "unknown how: #{how.inspect}"
       end
     end
-
-    def click_option(element)
-      element = Option.new(self, element: element) unless element.is_a?(Option)
-      element.click
-    end
-
-    def no_value_found(arg, msg = nil)
-      raise NoValueFoundException, msg || "#{arg.inspect} not found in select list"
-    end
   end # Select
 
   module Container
-    alias_method :select_list,  :select
+    alias_method :select_list, :select
     alias_method :select_lists, :selects
 
     Watir.tag_to_class[:select_list] = Select

--- a/spec/watirspec/elements/collections_spec.rb
+++ b/spec/watirspec/elements/collections_spec.rb
@@ -14,7 +14,7 @@ describe "Collections" do
 
   it "returns correct subtype of elements" do
     browser.goto(WatirSpec.url_for("collections.html"))
-    collection = browser.span(id: "a_span").spans.to_a
+    collection = browser.span(id: "a_span").spans
     expect(collection.all? { |el| el.is_a? Watir::Span}).to eq true
   end
 
@@ -31,5 +31,22 @@ describe "Collections" do
     tag = collection[3].tag_name
     browser.refresh
     expect(collection[3].tag_name).to eq tag
+  end
+
+  it "returns value for #empty?" do
+    browser.goto(WatirSpec.url_for("collections.html"))
+    expect(browser.span(id: "a_span").options.empty?).to eq true
+  end
+
+  it "returns value for #any?" do
+    browser.goto(WatirSpec.url_for("collections.html"))
+    expect(browser.span(id: "a_span").spans.any?).to eq true
+  end
+
+  it "locates elements" do
+    browser.goto(WatirSpec.url_for("collections.html"))
+    spans = browser.span(id: "a_span").spans
+    expect(spans).to receive(:elements).and_return([])
+    spans.locate
   end
 end

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -118,7 +118,7 @@ describe "IFrame" do
 
   it 'switches back to top level browsing context' do
     # Point driver to browsing context of first iframe
-    browser.iframes.first.ps.to_a
+    browser.iframes.first.ps.locate
 
     expect(browser.h1s.first.text).to be == 'Iframes'
   end

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -298,13 +298,13 @@ describe "SelectList" do
 
           it "selects multiple items using :name and a Regexp" do
             browser.select_list(name: "new_user_languages").clear
-            browser.select_list(name: "new_user_languages").select(/ish/)
+            browser.select_list(name: "new_user_languages").select_all(/ish/)
             expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
           end
 
           it "selects multiple items using :xpath" do
             browser.select_list(xpath: "//select[@name='new_user_languages']").clear
-            browser.select_list(xpath: "//select[@name='new_user_languages']").select(/ish/)
+            browser.select_list(xpath: "//select[@name='new_user_languages']").select_all(/ish/)
             expect(browser.select_list(xpath: "//select[@name='new_user_languages']").selected_options.map(&:text)).to eq ["Danish", "English", "Swedish"]
           end
 
@@ -321,7 +321,7 @@ describe "SelectList" do
     end
 
     it "returns the first matching value if there are multiple matches" do
-      expect(browser.select_list(name: "new_user_languages").select(/ish/)).to eq "Danish"
+      expect(browser.select_list(name: "new_user_languages").select_all(/ish/)).to eq "Danish"
     end
 
     not_compliant_on :safari do


### PR DESCRIPTION
1. Removes a few reasons to use `ElementCollection#to_a`

2. Implements `Select#select_all` and deprecates, but does not remove functionality for selecting multiple options with `Select#select`

The issue here is performance. If we only want to click one thing, we can search for it directly, instead of iterating over a collection, which is very slow, especially for large select lists.
Note that the performance will not actually improve until we change the implementation of `#select`, but I thought we should provide a deprecation warning for some set amount of time before we pull the trigger on the change.