### PR TITLE
implement Watir::Executor

### DIFF
--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -14,6 +14,7 @@ require 'watir/cookies'
 require 'watir/browser'
 require 'watir/screenshot'
 require 'watir/after_hooks'
+require 'watir/executor'
 
 module Watir
 
@@ -21,7 +22,7 @@ module Watir
 
   class << self
 
-    attr_writer :relaxed_locate, :always_locate, :default_timeout, :prefer_css, :locator_namespace
+    attr_writer :always_locate, :default_timeout, :prefer_css, :locator_namespace
 
     #
     # Whether or not Watir should wait for an element to be found or present
@@ -31,6 +32,11 @@ module Watir
 
     def relaxed_locate?
       @relaxed_locate
+    end
+
+    def relaxed_locate=(val)
+      warn "`Watir#relaxed_locate=` is deprecated, use `Watir#executor#no_wait!` instead"
+      executor.no_waits! if val
     end
 
     #
@@ -82,6 +88,14 @@ require the watir_css gem - https://github.com/watir/watir_css
 
     def locator_namespace
       @locator_namespace ||= Watir::Locators
+    end
+
+    #
+    # Stores the Watir executor
+    #
+
+    def executor
+      @executor ||= Watir::Executor.new
     end
 
     #

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -3,6 +3,8 @@ module Watir
     include EventuallyPresent
     include Waitable
 
+    attr_reader :browser
+
     def initialize(browser)
       @browser = browser
       @alert = nil
@@ -19,8 +21,7 @@ module Watir
     #
 
     def text
-      wait_for_exists
-      @alert.text
+      Watir.executor.go(self) { @alert.text }
     end
 
     #
@@ -33,9 +34,7 @@ module Watir
     #
 
     def ok
-      wait_for_exists
-      @alert.accept
-      @browser.after_hooks.run
+      Watir.executor.go(self) { @alert.accept }
     end
 
     #
@@ -48,9 +47,7 @@ module Watir
     #
 
     def close
-      wait_for_exists
-      @alert.dismiss
-      @browser.after_hooks.run
+      Watir.executor.go(self) { @alert.dismiss }
     end
 
     #
@@ -64,8 +61,7 @@ module Watir
     #
 
     def set(value)
-      wait_for_exists
-      @alert.send_keys(value)
+      Watir.executor.go(self) { @alert.send_keys(value) }
     end
 
     #
@@ -100,20 +96,8 @@ module Watir
       raise Exception::UnknownObjectException, 'unable to locate alert'
     end
 
-    def wait_for_exists
-      return assert_exists unless Watir.relaxed_locate?
-
-      begin
-        wait_until(message: "waiting for alert", &:exists?)
-      rescue Wait::TimeoutError
-        unless Watir.default_timeout == 0
-          message = "This code has slept for the duration of the default timeout "
-          message << "waiting for an Alert to exist. If the test is still passing, "
-          message << "consider using Alert#exists? instead of rescuing UnknownObjectException"
-          warn message
-        end
-        raise Exception::UnknownObjectException, 'unable to locate alert'
-      end
+    def unknown_exception
+      Watir::Exception::UnknownObjectException
     end
 
   end # Alert

--- a/lib/watir/elements/checkbox.rb
+++ b/lib/watir/elements/checkbox.rb
@@ -25,7 +25,7 @@ module Watir
     #
 
     def set?
-      element_call { @element.selected? }
+      Watir.executor.go(self) { @element.selected? }
     end
 
     #

--- a/lib/watir/elements/file_field.rb
+++ b/lib/watir/elements/file_field.rb
@@ -21,7 +21,7 @@ module Watir
 
     def value=(path)
       path = path.gsub(File::SEPARATOR, File::ALT_SEPARATOR) if File::ALT_SEPARATOR
-      element_call { @element.send_keys path }
+      Watir.executor.go(self) { @element.send_keys path }
     end
 
   end # FileField

--- a/lib/watir/elements/form.rb
+++ b/lib/watir/elements/form.rb
@@ -8,8 +8,7 @@ module Watir
     #
 
     def submit
-      element_call(:wait_for_present) { @element.submit }
-      browser.after_hooks.run
+      Watir.executor.go(self) { @element.submit }
     end
 
   end # Form

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -50,8 +50,7 @@ module Watir
     #
 
     def html
-      wait_for_exists
-      @element.page_source
+      Watir.executor.go(self) { @element.page_source }
     end
 
     #

--- a/lib/watir/elements/image.rb
+++ b/lib/watir/elements/image.rb
@@ -23,7 +23,7 @@ module Watir
     #
 
     def width
-      element_call do
+      Watir.executor.go(self) do
         driver.execute_script "return arguments[0].width", @element
       end
     end

--- a/lib/watir/elements/option.rb
+++ b/lib/watir/elements/option.rb
@@ -42,7 +42,7 @@ module Watir
     #
 
     def selected?
-      element_call { @element.selected? }
+      Watir.executor.go(self) { @element.selected? }
     end
 
     #

--- a/lib/watir/elements/radio.rb
+++ b/lib/watir/elements/radio.rb
@@ -16,7 +16,7 @@ module Watir
     #
 
     def set?
-      element_call { @element.selected? }
+      Watir.executor.go(self) { @element.selected? }
     end
 
   end # Radio

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -123,7 +123,7 @@ module Watir
     #
 
     def selected_options
-      element_call do
+      Watir.executor.go(self) do
         script = <<-SCRIPT
           var result = [];
           var options = arguments[0].options;

--- a/lib/watir/executor.rb
+++ b/lib/watir/executor.rb
@@ -1,0 +1,204 @@
+require 'yaml'
+
+module Watir
+  class Executor
+
+    DOM_CHANGES = %i(click double_click right_click submit ok close goto refresh)
+
+    def initialize
+      @strategies = {element: element_strategies,
+                     alert: alert_strategies,
+                     window: window_strategies}
+
+      @actions = Hash.new(->(*) {})
+
+      DOM_CHANGES.each do |act|
+        @actions["after_#{act}".to_sym] = ->(obj) { obj.browser.after_hooks.run }
+      end
+
+      allowed_strategies.each do |act|
+        next if act == :none
+        @actions["retry_#{act}".to_sym] = ->(ex) do
+          return false unless element_errors.include?(ex.class)
+          Wait.timer.remaining_time > 0
+        end
+      end
+
+      @actions[:retry_global] = ->(ex) { ex.is_a? Selenium::WebDriver::Error::StaleElementReferenceError }
+    end
+
+    def go obj
+      already_locked = Wait.timer.locked?
+
+      # TODO - implement dynamic timeout
+      timeout = Watir.default_timeout
+
+      Wait.timer = Wait::Timer.new(timeout: timeout) unless already_locked
+
+      caller = caller_locations(1, 1).first.label.to_sym
+      wait_strategy = case obj
+                      when Alert
+                        @strategies[:alert][caller]
+                      when Element
+                        @strategies[:element][caller]
+                      when Window
+                        @strategies[:window][caller]
+                      end
+
+      begin
+        self.send "wait_for_#{wait_strategy}", obj, timeout
+
+        result = yield
+        @actions["after_#{caller}".to_sym].call(obj)
+        result
+      rescue => ex
+        retry if @actions[:retry_global].call(ex)
+        retry if @actions["retry_#{wait_strategy}".to_sym].call(ex)
+        raise_exception(ex, obj, timeout)
+      ensure
+        Wait.timer.reset! unless already_locked
+      end
+    end
+
+    def raise_exception(ex, obj, timeout)
+      case ex
+      when Selenium::WebDriver::Error::ElementNotVisibleError, interact_error
+        error = obj.send :unknown_exception
+        message = "element located, but timed out after #{timeout} seconds, waiting for #{obj.inspect} to be present"
+      when Selenium::WebDriver::Error::InvalidElementStateError
+        error = ObjectDisabledException
+        message = "element present and enabled, but timed out after #{timeout} seconds, waiting for #{obj.inspect} to not be disabled"
+      when Selenium::WebDriver::Error::NoSuchWindowError
+        error = Exception::NoMatchingWindowFoundException
+        message = "browser window was closed"
+      else
+        raise
+      end
+      raise error, message
+    end
+
+    def element_errors
+      [Selenium::WebDriver::Error::ElementNotVisibleError,
+       interact_error,
+       Selenium::WebDriver::Error::InvalidElementStateError].freeze
+    end
+
+    # Support for Selenium < 3.4.1 with latest Geckodriver
+    def interact_error
+      if defined?(Selenium::WebDriver::Error::ElementNotInteractable)
+        Selenium::WebDriver::Error::ElementNotInteractable
+      else
+        Selenium::WebDriver::Error::ElementNotInteractableError
+      end
+    end
+
+    def wait_for_exists(obj, timeout)
+      return if obj.exists? # Performance shortcut
+
+      begin
+        wait_for_exists(obj.query_scope, timeout) if obj.respond_to? :query_scope
+        obj.wait_until(&:exists?)
+      rescue Watir::Wait::TimeoutError
+        msg = "timed out after #{timeout} seconds, waiting for #{obj.inspect} to be located"
+        raise obj.send(:unknown_exception), msg
+      end
+    end
+
+    def wait_for_present(obj, timeout)
+      return if obj.present? # Performance shortcut
+
+      begin
+        wait_for_present(obj.query_scope, timeout)
+        obj.wait_until(&:present?)
+      rescue Watir::Wait::TimeoutError
+        msg = "element located, but timed out after #{timeout} seconds, waiting for #{obj.inspect} to be present"
+        raise obj.send :unknown_exception, msg
+      end
+    end
+
+    def wait_for_enabled(obj, timeout)
+      wait_for_exists(obj, timeout)
+
+      case obj
+      when Input, Button, Select, Option
+        # noop
+      else
+        return
+      end
+
+      begin
+        obj.wait_until(&:enabled?)
+      rescue Watir::Wait::TimeoutError
+        message = "element present, but timed out after #{timeout} seconds, waiting for #{obj.inspect} to be enabled"
+        raise Exception::ObjectDisabledException, message
+      end
+    end
+
+    def wait_for_none(obj, _timeout)
+      obj.send :assert_exists
+    end
+
+    def wait_for_writable(obj, timeout)
+      wait_for_enabled(obj, timeout)
+
+      begin
+        obj.wait_until { |obj| !obj.respond_to?(:readonly?) || !obj.readonly? }
+      rescue Watir::Wait::TimeoutError
+        message = "element present and enabled, but timed out after #{timeout} seconds, waiting for #{obj.inspect} to not be readonly"
+        raise Exception::ObjectReadOnlyException, message
+      end
+    end
+
+    def allowed_strategies
+      @allowed_strategies ||= %i(none exists writable enabled present)
+    end
+
+    def alert_strategies
+      @alert_strategies ||= {text: :exists,
+                             ok: :exists,
+                             close: :exists,
+                             set: :exists}
+    end
+
+    def element_strategies
+      @element_strategies ||={click: :enabled,
+                              set: :writable,
+                              clear: :writable,
+                              set?: :exists, #change to none?
+                              text: :exists,
+                              tag_name: :exists,
+                              double_click: :present,
+                              right_click: :present,
+                              hover: :present,
+                              drag_and_drop_on: :present,
+                              drag_and_drop_by: :present,
+                              attribute_value: :exists,
+                              outer_html: :exists,
+                              inner_html: :exists,
+                              send_keys: :writable,
+                              focus: :exists,
+                              focused?: :exists, #change to none?,
+                              fire_event: :exists,
+                              visible?: :none,
+                              enabled?: :none,
+                              style: :exists,
+                              'value=': :exists,
+                              submit: :present,
+                              width: :exists,
+                              selected?: :exists, #change to none?
+                              selected_options: :exists,
+                              select_text: :exists,
+                              html: :none}
+    end
+
+    def window_strategies
+      @window_strategies ||= {use: :exists}
+    end
+
+    def no_waits!
+      @strategies = {element: Hash.new(:none),
+                     alert: Hash.new(:none),
+                     window: Hash.new(:none)}
+    end
+  end # Executor
+end # Watir

--- a/lib/watir/extensions/select_text.rb
+++ b/lib/watir/extensions/select_text.rb
@@ -3,9 +3,7 @@ Watir::Atoms.load :selectText
 module Watir
   class Element
     def select_text(str)
-      element_call do
-        execute_atom :selectText, @element, str
-      end
+      Watir.executor.go(self) { execute_atom :selectText, @element, str }
     end
   end # Element
 end # Watir

--- a/lib/watir/row_container.rb
+++ b/lib/watir/row_container.rb
@@ -24,8 +24,6 @@ module Watir
     #
 
     def strings
-      wait_for_exists
-
       rows.inject [] do |res, row|
         res << row.cells.map(&:text)
       end

--- a/lib/watir/user_editable.rb
+++ b/lib/watir/user_editable.rb
@@ -8,7 +8,7 @@ module Watir
     #
 
     def set(*args)
-      element_call(:wait_for_writable) do
+      Watir.executor.go(self) do
         @element.clear
         @element.send_keys(*args)
       end
@@ -31,9 +31,7 @@ module Watir
     #
 
     def clear
-      element_call(:wait_for_writable) do
-        @element.clear
-      end
+      Watir.executor.go(self) { @element.clear }
     end
 
   end # UserEditable

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -106,7 +106,7 @@ module Watir
     def exists?
       assert_exists
       true
-    rescue Exception::NoMatchingWindowFoundException
+    rescue unknown_exception
       false
     end
 
@@ -190,8 +190,7 @@ module Watir
     #
 
     def use(&blk)
-      wait_for_exists
-      @driver.switch_to.window(handle, &blk)
+      Watir.executor.go(self) { @driver.switch_to.window(handle, &blk) }
       self
     end
 
@@ -219,7 +218,7 @@ module Watir
     end
 
     def assert_exists
-      raise(Exception::NoMatchingWindowFoundException, @selector.inspect) unless @driver.window_handles.include?(handle)
+      raise(unknown_exception, @selector.inspect) unless @driver.window_handles.include?(handle)
     end
 
     # return a handle to the currently active window if it is still open; otherwise nil
@@ -241,13 +240,8 @@ module Watir
       false
     end
 
-    def wait_for_exists
-      return assert_exists unless Watir.relaxed_locate?
-      begin
-        wait_until(&:exists?)
-      rescue Wait::TimeoutError
-        raise Exception::NoMatchingWindowFoundException, @selector.inspect
-      end
+    def unknown_exception
+      Exception::NoMatchingWindowFoundException
     end
 
   end # Window

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -69,28 +69,6 @@ describe Watir::Element do
     end
   end
 
-  describe "#element_call" do
-
-    it 'handles exceptions when taking an action on an element that goes stale during execution' do
-      browser.goto WatirSpec.url_for('removed_element.html')
-
-      watir_element = browser.div(id: "text")
-
-      # simulate element going stale after assert_exists and before action taken, but not when block retried
-      allow(watir_element).to receive(:text) do
-        watir_element.send(:element_call) do
-          @already_stale ||= false
-          browser.refresh unless @already_stale
-          @already_stale = true
-          watir_element.instance_variable_get('@element').text
-        end
-      end
-
-      expect { watir_element.text }.to_not raise_error
-    end
-
-  end
-
   bug "Actions Endpoint Not Yet Implemented", :firefox do
     describe "#hover" do
       not_compliant_on :internet_explorer, :safari do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,9 @@ require 'rspec'
 
 SELENIUM_SELECTORS = %i(class class_name css id tag_name xpath)
 
-if ENV['RELAXED_LOCATE'] == "false"
+#if ENV['RELAXED_LOCATE'] == "false"
   Watir.relaxed_locate = false
-end
+#end
 
 ENV['DISPLAY'] = ':99.0' if ENV['TRAVIS']
 


### PR DESCRIPTION
I believe this is closer to the implementation we discussed a year ago for the waiting strategies.

This code is just providing parity with existing code. I actually like pulling all of this out of the Element class since it removes so much clutter.

There are several additional features I'm thinking about, but for now I'd like to consider this a private api while we figure out what things we want to open up for users to do. 

Looking for input on syntax, naming, implementation, anything. Thanks!


-------------------------

Future features I'm imagining:
```
Watir.executor.add_hook(:before_click, ->(o) { puts "I'm so excited to click #{o.inspect}!" }
Watir.executor.add_hook(:after_text, ->(o) { puts "Retrieving text from #{o.inspect} made me happy" }
Watir.executor.add_hook(:rescue_submit, ->(o) { puts "Uh Oh: #{o.browser.span(class: 'error').text}" }
```
Changing wait strategies can currently be done by subclassing
Something like these could be fun:
```
Watir.executor.change_strategy(:element, :set, :exist, timeout: 4, include: [:text_field, :textarea])
Watir.executor.change_strategy(:alert, :ok, :none, timeout: 4)
```
We could also do these as arrays so you can take more than one action at a time, essentially re-implementing after_hooks in an extensible way.

These things are all likely low priority, though
