### PR TITLE
retain entire selector when using #to_subtype

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -451,7 +451,7 @@ module Watir
                 Watir.element_class_for(tag)
               end
 
-      klass.new(@query_scope, element: wd)
+      klass.new(@query_scope, @selector.merge(element: wd))
     end
 
     #

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -26,7 +26,7 @@ module Watir
     end
 
     def assert_exists
-      if @selector.key? :element
+      if @element && @selector.empty?
         raise UnknownFrameException, "wrapping a Selenium element as a Frame is not currently supported"
       end
 

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -45,7 +45,7 @@ describe Watir::Element do
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.element(name: "no_such_name").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.element(name: "no_such_name").enabled? }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -116,6 +116,11 @@ describe "IFrame" do
     end
   end
 
+  it 'switches when the frame is created by subtype' do
+    subtype = browser.iframe.to_subtype
+    expect { subtype.iframe.exist? }.to_not raise_exception
+  end
+
   it 'switches back to top level browsing context' do
     # Point driver to browsing context of first iframe
     browser.iframes.first.ps.locate

--- a/support/doctest_helper.rb
+++ b/support/doctest_helper.rb
@@ -74,7 +74,7 @@ YARD::Doctest.configure do |doctest|
   end
 
   doctest.after('Watir::Logger') do
-    Watir.logger.level = :info
+    Watir.logger.level = :warn
   end
 
   doctest.after('Watir::AfterHooks') do


### PR DESCRIPTION
Fix for #588 