### PR TITLE
implement direct support for headless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,36 +32,39 @@ _browsers:
 
 matrix:
   include:
-      - env: RAKE_TASK=yard:doctest
-        <<: *four
-        <<: *chrome
-      - env: RAKE_TASK=spec:chrome
-        <<: *two
-        <<: *chrome
-      - env: RAKE_TASK=spec:chrome
-        <<: *three
-        <<: *chrome
-      - env: RAKE_TASK=spec:chrome
-        <<: *four
-        <<: *chrome
-      - env: RAKE_TASK=spec:chrome RELAXED_LOCATE=false
-        <<: *four
-        <<: *chrome
-      - env: RAKE_TASK=spec:firefox
-        <<: *two
-        <<: *firefox-latest
-      - env: RAKE_TASK=spec:firefox
-        <<: *three
-        <<: *firefox-latest
-      - env: RAKE_TASK=spec:firefox
-        <<: *four
-        <<: *firefox-latest
-      - env: RAKE_TASK=spec:firefox RELAXED_LOCATE=false
+      - env: RAKE_TASK=spec:remote_firefox
         <<: *four
         <<: *firefox-latest
       - env: RAKE_TASK=spec:remote_chrome
         <<: *four
         <<: *chrome
-      - env: RAKE_TASK=spec:remote_firefox
+      - env: RAKE_TASK=spec:firefox RELAXED_LOCATE=false
         <<: *four
         <<: *firefox-latest
+      - env: RAKE_TASK=spec:firefox
+        <<: *four
+        <<: *firefox-latest
+      - env: RAKE_TASK=spec:firefox
+        <<: *three
+        <<: *firefox-latest
+      - env: RAKE_TASK=spec:firefox
+        <<: *two
+        <<: *firefox-latest
+      - env: RAKE_TASK=spec:chrome
+        <<: *four
+        <<: *chrome
+      - env: RAKE_TASK=spec:chrome
+        <<: *three
+        <<: *chrome
+      - env: RAKE_TASK=spec:chrome
+        <<: *two
+        <<: *chrome
+      - env: RAKE_TASK=spec:chrome RELAXED_LOCATE=false
+        <<: *four
+        <<: *chrome
+      - env: RAKE_TASK=spec:chrome HEADLESS=true
+        <<: *four
+        <<: *chrome
+      - env: RAKE_TASK=yard:doctest
+        <<: *four
+        <<: *chrome

--- a/lib/watir/capabilities.rb
+++ b/lib/watir/capabilities.rb
@@ -60,11 +60,21 @@ module Watir
           browser_options ||= {}
           browser_options[:args] = @options.delete(:args)
         end
+        if @options.delete(:headless)
+          browser_options ||= {}
+          browser_options[:args] << '--headless'
+          browser_options[:args] << '--disable-gpu'
+        end
         @selenium_opts[:options] = Selenium::WebDriver::Chrome::Options.new(browser_options) if browser_options
       when :firefox
         @selenium_opts[:options] = Selenium::WebDriver::Firefox::Options.new(options) if browser_options
       when :safari
         @selenium_opts["safari.options"] = {'technologyPreview' => true} if @options[:technology_preview]
+      when :remote
+        if @browser == :chrome && @options.delete(:headless)
+          @options.delete(:args)
+          @options['chromeOptions'] = {'args' => ['--headless', '--disable-gpu']}
+        end
       end
     end
 

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -451,7 +451,7 @@ module Watir
                 Watir.element_class_for(tag)
               end
 
-      klass.new(@query_scope, element: wd)
+      klass.new(@query_scope, @selector.merge(element: wd))
     end
 
     #

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -26,7 +26,7 @@ module Watir
     end
 
     def assert_exists
-      if @selector.key? :element
+      if @element && @selector.empty?
         raise UnknownFrameException, "wrapping a Selenium element as a Frame is not currently supported"
       end
 

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -45,7 +45,7 @@ describe Watir::Element do
     end
 
     it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.element(name: "no_such_name").enabled? }.to raise_error(Watir::Exception::UnknownObjectException)
+      expect { browser.element(name: "no_such_name").enabled? }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -102,6 +102,7 @@ describe "Browser::AfterHooks" do
       end
     end
 
+    not_compliant_on :headless do
       it "runs after_hooks after Alert#ok" do
         browser.goto(WatirSpec.url_for("alerts.html"))
         @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
@@ -110,20 +111,23 @@ describe "Browser::AfterHooks" do
         browser.alert.ok
         expect(@yield).to be true
       end
+    end
 
-    bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
-      it "runs after_hooks after Alert#close" do
-        browser.goto(WatirSpec.url_for("alerts.html"))
-        @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
-        browser.after_hooks.add @page_after_hook
-        browser.after_hooks.without { browser.button(id: 'alert').click }
-        browser.alert.close
-        expect(@yield).to be true
+    not_compliant_on :headless do
+      bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+        it "runs after_hooks after Alert#close" do
+          browser.goto(WatirSpec.url_for("alerts.html"))
+          @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
+          browser.after_hooks.add @page_after_hook
+          browser.after_hooks.without { browser.button(id: 'alert').click }
+          browser.alert.close
+          expect(@yield).to be true
+        end
       end
     end
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1279211", :firefox do
-      not_compliant_on :safari do
+      not_compliant_on :safari, :headless do
         it "raises UnhandledAlertError error when running error checks with alert present" do
           url = WatirSpec.url_for("alerts.html")
           @page_after_hook = Proc.new { browser.url }
@@ -135,37 +139,43 @@ describe "Browser::AfterHooks" do
       end
     end
 
-    it "does not raise error when running error checks using #after_hooks#without with alert present" do
-      url = WatirSpec.url_for("alerts.html")
-      @page_after_hook = Proc.new { browser.url }
-      browser.after_hooks.add @page_after_hook
-      browser.goto url
-      expect { browser.after_hooks.without { browser.button(id: "alert").click } }.to_not raise_error
-      browser.alert.ok
-    end
-
-    it "does not raise error if no error checks are defined with alert present" do
-      url = WatirSpec.url_for("alerts.html")
-      @page_after_hook = Proc.new { browser.url }
-      browser.after_hooks.add @page_after_hook
-      browser.goto url
-      browser.after_hooks.delete @page_after_hook
-      expect { browser.button(id: "alert").click }.to_not raise_error
-      browser.alert.ok
-    end
-
-    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
-      it "does not raise error when running error checks on closed window" do
-        url = WatirSpec.url_for("window_switching.html")
+    not_compliant_on :headless do
+      it "does not raise error when running error checks using #after_hooks#without with alert present" do
+        url = WatirSpec.url_for("alerts.html")
         @page_after_hook = Proc.new { browser.url }
         browser.after_hooks.add @page_after_hook
         browser.goto url
-        browser.a(id: "open").click
+        expect { browser.after_hooks.without { browser.button(id: "alert").click } }.to_not raise_error
+        browser.alert.ok
+      end
+    end
 
-        window = browser.window(title: "closeable window")
-        window.use
-        expect { browser.a(id: "close").click }.to_not raise_error
-        browser.window(index: 0).use
+    not_compliant_on :headless do
+      it "does not raise error if no error checks are defined with alert present" do
+        url = WatirSpec.url_for("alerts.html")
+        @page_after_hook = Proc.new { browser.url }
+        browser.after_hooks.add @page_after_hook
+        browser.goto url
+        browser.after_hooks.delete @page_after_hook
+        expect { browser.button(id: "alert").click }.to_not raise_error
+        browser.alert.ok
+      end
+    end
+
+    bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
+      not_compliant_on :headless do
+        it "does not raise error when running error checks on closed window" do
+          url = WatirSpec.url_for("window_switching.html")
+          @page_after_hook = Proc.new { browser.url }
+          browser.after_hooks.add @page_after_hook
+          browser.goto url
+          browser.a(id: "open").click
+
+          window = browser.window(title: "closeable window")
+          window.use
+          expect { browser.a(id: "close").click }.to_not raise_error
+          browser.window(index: 0).use
+        end
       end
     end
   end

--- a/spec/watirspec/alert_spec.rb
+++ b/spec/watirspec/alert_spec.rb
@@ -1,106 +1,108 @@
 require "watirspec_helper"
 
-describe 'Alert API' do
-  before do
-    browser.goto WatirSpec.url_for("alerts.html")
-  end
-
-  after do
-    browser.alert.ok if browser.alert.exists?
-  end
-
-  context 'alert' do
-    describe '#text' do
-      it 'returns text of alert' do
-        browser.button(id: 'alert').click
-        expect(browser.alert.text).to include('ok')
-      end
+not_compliant_on :headless do
+  describe 'Alert API' do
+    before do
+      browser.goto WatirSpec.url_for("alerts.html")
     end
 
-    describe '#exists?' do
-      it 'returns false if alert is not present' do
-        expect(browser.alert).to_not exist
-      end
+    after do
+      browser.alert.ok if browser.alert.exists?
+    end
 
-      bug "Alert exception not thrown, so Browser#inspect hangs", :safari do
-        it 'returns true if alert is present' do
+    context 'alert' do
+      describe '#text' do
+        it 'returns text of alert' do
           browser.button(id: 'alert').click
-          browser.wait_until(timeout: 10) { browser.alert.exists? }
+          expect(browser.alert.text).to include('ok')
         end
       end
-    end
 
-    describe '#ok' do
-      not_compliant_on :safari do
-        it 'closes alert' do
-          browser.button(id: 'alert').click
-          browser.alert.ok
+      describe '#exists?' do
+        it 'returns false if alert is not present' do
           expect(browser.alert).to_not exist
         end
-      end
-    end
 
-    bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
-      not_compliant_on :safari do
-        describe '#close' do
+        bug "Alert exception not thrown, so Browser#inspect hangs", :safari do
+          it 'returns true if alert is present' do
+            browser.button(id: 'alert').click
+            browser.wait_until(timeout: 10) { browser.alert.exists? }
+          end
+        end
+      end
+
+      describe '#ok' do
+        not_compliant_on :safari do
           it 'closes alert' do
             browser.button(id: 'alert').click
-            browser.alert.close
+            browser.alert.ok
             expect(browser.alert).to_not exist
           end
         end
       end
-    end
 
-    not_compliant_on :relaxed_locate do
-      describe 'wait_until_present' do
-        it 'waits until alert is present and goes on' do
-          browser.button(id: 'timeout-alert').click
-          browser.alert.wait_until_present.ok
-
-          expect(browser.alert).to_not exist
+      bug "https://code.google.com/p/chromedriver/issues/detail?id=26", [:chrome, :macosx] do
+        not_compliant_on :safari do
+          describe '#close' do
+            it 'closes alert' do
+              browser.button(id: 'alert').click
+              browser.alert.close
+              expect(browser.alert).to_not exist
+            end
+          end
         end
+      end
 
-        it 'raises error if alert is not present after timeout' do
-          begin
-            Watir.default_timeout = 2
-            expect {
-              browser.alert.wait_until_present.ok
-            }.to raise_error(Watir::Wait::TimeoutError)
-          ensure
-            Watir.default_timeout = 30
+      not_compliant_on :relaxed_locate do
+        describe 'wait_until_present' do
+          it 'waits until alert is present and goes on' do
+            browser.button(id: 'timeout-alert').click
+            browser.alert.wait_until_present.ok
+
+            expect(browser.alert).to_not exist
+          end
+
+          it 'raises error if alert is not present after timeout' do
+            begin
+              Watir.default_timeout = 2
+              expect {
+                browser.alert.wait_until_present.ok
+              }.to raise_error(Watir::Wait::TimeoutError)
+            ensure
+              Watir.default_timeout = 30
+            end
           end
         end
       end
     end
-  end
 
-  context 'confirm' do
-    describe '#ok' do
-      it 'accepts confirm' do
-        browser.button(id: 'confirm').click
-        browser.alert.ok
-        expect(browser.button(id: 'confirm').value).to eq "true"
-      end
-    end
-
-    describe '#close' do
-      it 'cancels confirm' do
-        browser.button(id: 'confirm').click
-        browser.alert.close
-        expect(browser.button(id: 'confirm').value).to eq "false"
-      end
-    end
-  end
-
-  context 'prompt' do
-    describe '#set' do
-      bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
-        it 'enters text to prompt' do
-          browser.button(id: 'prompt').click
-          browser.alert.set 'My Name'
+    context 'confirm' do
+      describe '#ok' do
+        it 'accepts confirm' do
+          browser.button(id: 'confirm').click
           browser.alert.ok
-          expect(browser.button(id: 'prompt').value).to eq 'My Name'
+          expect(browser.button(id: 'confirm').value).to eq "true"
+        end
+      end
+
+      describe '#close' do
+        it 'cancels confirm' do
+          browser.button(id: 'confirm').click
+          browser.alert.close
+          expect(browser.button(id: 'confirm').value).to eq "false"
+        end
+      end
+    end
+
+    context 'prompt' do
+      describe '#set' do
+        bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255906", :firefox do
+          it 'enters text to prompt' do
+            browser.button(id: 'prompt').click
+            browser.alert.set 'My Name'
+            browser.alert.ok
+            expect(browser.button(id: 'prompt').value).to eq 'My Name'
+          end
         end
       end
     end

--- a/spec/watirspec/browser_spec.rb
+++ b/spec/watirspec/browser_spec.rb
@@ -14,14 +14,16 @@ describe "Browser" do
     end
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do
-      it "returns false if window is closed" do
-        browser.goto WatirSpec.url_for("window_switching.html")
-        browser.a(id: "open").click
-        Watir::Wait.until { browser.windows.size == 2 }
-        browser.window(title: "closeable window").use
-        browser.a(id: "close").click
-        Watir::Wait.until { browser.windows.size == 1 }
-        expect(browser.exists?).to be false
+      not_compliant_on :headless do
+        it "returns false if window is closed" do
+          browser.goto WatirSpec.url_for("window_switching.html")
+          browser.a(id: "open").click
+          Watir::Wait.until { browser.windows.size == 2 }
+          browser.window(title: "closeable window").use
+          browser.a(id: "close").click
+          Watir::Wait.until { browser.windows.size == 1 }
+          expect(browser.exists?).to be false
+        end
       end
     end
 
@@ -183,14 +185,16 @@ describe "Browser" do
     end
   end
 
-  describe "#refresh" do
-    it "refreshes the page" do
-      browser.goto(WatirSpec.url_for("non_control_elements.html"))
-      browser.span(class: 'footer').click
-      expect(browser.span(class: 'footer').text).to include('Javascript')
-      browser.refresh
-      browser.span(class: 'footer').wait_until_present
-      expect(browser.span(class: 'footer').text).to_not include('Javascript')
+  not_compliant_on :headless do
+    describe "#refresh" do
+      it "refreshes the page" do
+        browser.goto(WatirSpec.url_for("non_control_elements.html"))
+        browser.span(class: 'footer').click
+        expect(browser.span(class: 'footer').text).to include('Javascript')
+        browser.refresh
+        browser.span(class: 'footer').wait_until_present
+        expect(browser.span(class: 'footer').text).to_not include('Javascript')
+      end
     end
   end
 

--- a/spec/watirspec/drag_and_drop_spec.rb
+++ b/spec/watirspec/drag_and_drop_spec.rb
@@ -15,14 +15,16 @@ describe "Element" do
           expect(droppable.text).to eq 'Dropped!'
         end
 
-        it "can drag and drop an element onto another when draggable is out of viewport" do
-          reposition "draggable"
-          perform_drag_and_drop_on_droppable
-        end
+        not_compliant_on :headless do
+          it "can drag and drop an element onto another when draggable is out of viewport" do
+            reposition "draggable"
+            perform_drag_and_drop_on_droppable
+          end
 
-        it "can drag and drop an element onto another when droppable is out of viewport" do
-          reposition "droppable"
-          perform_drag_and_drop_on_droppable
+          it "can drag and drop an element onto another when droppable is out of viewport" do
+            reposition "droppable"
+            perform_drag_and_drop_on_droppable
+          end
         end
 
         it "can drag an element by the given offset" do

--- a/spec/watirspec/elements/del_spec.rb
+++ b/spec/watirspec/elements/del_spec.rb
@@ -113,16 +113,18 @@ describe "Del" do
   end
 
   # Other
-  describe "#click" do
-    it "fires events" do
-      expect(browser.del(class: 'footer').text).to_not include('Javascript')
-      browser.del(class: 'footer').click
-      expect(browser.del(class: 'footer').text).to include('Javascript')
-    end
+  not_compliant_on :headless do
+    describe "#click" do
+      it "fires events" do
+        expect(browser.del(class: 'footer').text).to_not include('Javascript')
+        browser.del(class: 'footer').click
+        expect(browser.del(class: 'footer').text).to include('Javascript')
+      end
 
-    it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: "no_such_id").click }.to raise_unknown_object_exception
-      expect { browser.del(title: "no_such_title").click }.to raise_unknown_object_exception
+      it "raises UnknownObjectException if the del doesn't exist" do
+        expect { browser.del(id: "no_such_id").click }.to raise_unknown_object_exception
+        expect { browser.del(title: "no_such_title").click }.to raise_unknown_object_exception
+      end
     end
   end
 end

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -138,18 +138,20 @@ describe "Div" do
   end
 
   # Manipulation methods
-  describe "#click" do
-    it "fires events when clicked" do
-      expect(browser.div(id: 'best_language').text).to_not eq 'Ruby!'
-      browser.div(id: 'best_language').click
-      expect(browser.div(id: 'best_language').text).to eq 'Ruby!'
-    end
+  not_compliant_on :headless do
+    describe "#click" do
+      it "fires events when clicked" do
+        expect(browser.div(id: 'best_language').text).to_not eq 'Ruby!'
+        browser.div(id: 'best_language').click
+        expect(browser.div(id: 'best_language').text).to eq 'Ruby!'
+      end
 
-    it "raises UnknownObjectException if the element does not exist" do
-      expect { browser.div(id: "no_such_id").click }.to raise_unknown_object_exception
-      expect { browser.div(title: "no_such_title").click }.to raise_unknown_object_exception
-      expect { browser.div(index: 1337).click }.to raise_unknown_object_exception
-      expect { browser.div(xpath: "//div[@id='no_such_id']").click }.to raise_unknown_object_exception
+      it "raises UnknownObjectException if the element does not exist" do
+        expect { browser.div(id: "no_such_id").click }.to raise_unknown_object_exception
+        expect { browser.div(title: "no_such_title").click }.to raise_unknown_object_exception
+        expect { browser.div(index: 1337).click }.to raise_unknown_object_exception
+        expect { browser.div(xpath: "//div[@id='no_such_id']").click }.to raise_unknown_object_exception
+      end
     end
   end
 

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -116,6 +116,11 @@ describe "IFrame" do
     end
   end
 
+  it 'switches when the frame is created by subtype' do
+    subtype = browser.iframe.to_subtype
+    expect { subtype.iframe.exist? }.to_not raise_exception
+  end
+
   it 'switches back to top level browsing context' do
     # Point driver to browsing context of first iframe
     browser.iframes.first.ps.locate

--- a/spec/watirspec/elements/ins_spec.rb
+++ b/spec/watirspec/elements/ins_spec.rb
@@ -113,16 +113,18 @@ describe "Ins" do
   end
 
   # Other
-  describe "#click" do
-    it "fires events" do
-      expect(browser.ins(class: 'footer').text).to_not include('Javascript')
-      browser.ins(class: 'footer').click
-      expect(browser.ins(class: 'footer').text).to include('Javascript')
-    end
+  not_compliant_on :headless do
+    describe "#click" do
+      it "fires events" do
+        expect(browser.ins(class: 'footer').text).to_not include('Javascript')
+        browser.ins(class: 'footer').click
+        expect(browser.ins(class: 'footer').text).to include('Javascript')
+      end
 
-    it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: "no_such_id").click }.to raise_unknown_object_exception
-      expect { browser.ins(title: "no_such_title").click }.to raise_unknown_object_exception
+      it "raises UnknownObjectException if the ins doesn't exist" do
+        expect { browser.ins(id: "no_such_id").click }.to raise_unknown_object_exception
+        expect { browser.ins(title: "no_such_title").click }.to raise_unknown_object_exception
+      end
     end
   end
 

--- a/spec/watirspec/elements/span_spec.rb
+++ b/spec/watirspec/elements/span_spec.rb
@@ -113,16 +113,18 @@ describe "Span" do
   end
 
   # Other
-  describe "#click" do
-    it "fires events" do
-      expect(browser.span(class: 'footer').text).to_not include('Javascript')
-      browser.span(class: 'footer').click
-      expect(browser.span(class: 'footer').text).to include('Javascript')
-    end
+    not_compliant_on :headless do
+    describe "#click" do
+      it "fires events" do
+        expect(browser.span(class: 'footer').text).to_not include('Javascript')
+        browser.span(class: 'footer').click
+        expect(browser.span(class: 'footer').text).to include('Javascript')
+      end
 
-    it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: "no_such_id").click }.to raise_unknown_object_exception
-      expect { browser.span(title: "no_such_title").click }.to raise_unknown_object_exception
+      it "raises UnknownObjectException if the span doesn't exist" do
+        expect { browser.span(id: "no_such_id").click }.to raise_unknown_object_exception
+        expect { browser.span(title: "no_such_title").click }.to raise_unknown_object_exception
+      end
     end
   end
 

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -60,6 +60,9 @@ class LocalConfig
     matching_guards << [browser, Selenium::WebDriver::Platform.os]
     matching_guards << :relaxed_locate if Watir.relaxed_locate?
     matching_guards << :not_relaxed_locate unless Watir.relaxed_locate?
+    if @imp.browser_args.last[:headless]
+      matching_guards << :headless
+    end
 
     if !Selenium::WebDriver::Platform.linux? || ENV['DESKTOP_SESSION']
       # some specs (i.e. Window#maximize) needs a window manager on linux
@@ -78,6 +81,7 @@ class LocalConfig
 
   def chrome_args
     opts = {args: ["--disable-translate"]}
+    opts[:headless] = true if ENV['HEADLESS'] == 'true'
     opts[:options] = {binary: ENV['CHROME_BINARY']} if ENV['CHROME_BINARY']
     opts
   end

--- a/support/doctest_helper.rb
+++ b/support/doctest_helper.rb
@@ -74,7 +74,7 @@ YARD::Doctest.configure do |doctest|
   end
 
   doctest.after('Watir::Logger') do
-    Watir.logger.level = :info
+    Watir.logger.level = :warn
   end
 
   doctest.after('Watir::AfterHooks') do


### PR DESCRIPTION
Not sure we *need to run headless tests on Travis, but it is interesting to see what is/isn't supported so far. (pretty much alert/window handling and javascript clicks)

`Watir::Browser.new :chrome, headless: true`
or
`Watir::Browser.new :chrome, headless: true, url: "#{remote_server}/wd/hub"`