### PR TITLE
support for finding multiple classes with regular expressions

### DIFF
--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -105,7 +105,9 @@ module Watir
         end
 
         def build_wd_selector(selectors)
-          return if selectors.values.any? { |e| e.is_a? Regexp }
+          return if selectors.values.any? do |e|
+            e.is_a?(Array) ? e.any? { |c| c.is_a?(Regexp) } : e.is_a?(Regexp)
+          end
           build_xpath(selectors)
         end
 

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -77,7 +77,7 @@ module Watir
           private
 
           def build_class_match(value)
-            if value.match(/^!/)
+            if value.to_s.include?('!')
               klass = XpathSupport.escape " #{value[1..-1]} "
               "not(contains(concat(' ', @class, ' '), #{klass}))"
             else

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -272,6 +272,23 @@ describe "Element" do
           expect(e).to exist
           expect(e.class_name).to eq "a b"
         end
+
+        it "matches one with regular expressions" do
+          e = browser.div(class: [/a/, /b/], index: 2)
+          expect(e).to exist
+          expect(e.class_name).to eq "abc"
+        end
+
+        it "matches one with mix of string and regular expressions" do
+          e = browser.div(class: ['a', /b/], index: 1)
+          expect(e).to exist
+          expect(e.class_name).to eq "a b"
+        end
+
+        it "matches multiple with regular expressions" do
+          es = browser.divs(class: [/a/, /b/])
+          expect(es.size).to eq 3
+        end
       end
     end
 


### PR DESCRIPTION
This code is kind of ugly. Do we even care about this feature? Someone pinged me on Slack saying they thought they needed to convert everything to an Array, and their single regex broke. I had him remove the array and he was cool with it. But thought it would be interesting to get it to work.

I'm ok with not doing this if we don't care about the support for it.

@chrismcmahon, would you use it?