### PR TITLE
handle adjacent location in selector builder

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -64,7 +64,7 @@ module Watir
         def by_id
           selector = @selector.dup
           id = selector.delete(:id)
-          return unless id.is_a? String
+          return if !id.is_a?(String) || selector[:adjacent]
 
           tag_name = selector.delete(:tag_name)
           return unless selector.empty? # multiple attributes
@@ -89,7 +89,7 @@ module Watir
         def find_first_by_multiple
           selector = selector_builder.normalized_selector
 
-          idx = selector.delete(:index)
+          idx = selector.delete(:index) unless selector[:adjacent]
           visible = selector.delete(:visible)
 
           how, what = selector_builder.build(selector)

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -2,7 +2,7 @@ module Watir
   module Locators
     class Element
       class SelectorBuilder
-        VALID_WHATS = [Array, String, Regexp, TrueClass, FalseClass].freeze
+        VALID_WHATS = [Array, String, Regexp, TrueClass, FalseClass, ::Symbol].freeze
         WILDCARD_ATTRIBUTE = /^(aria|data)_(.+)$/
 
         def initialize(query_scope, selector, valid_attributes)
@@ -35,8 +35,11 @@ module Watir
               raise TypeError, "expected TrueClass or FalseClass, got #{what.inspect}:#{what.class}"
             end
           else
-            if what.is_a?(Array) && how != :class
+            if what.is_a?(Array) && how != :class && how != :class_name
               raise TypeError, "Only :class locator can have a value of an Array"
+            end
+            if what.is_a?(Symbol) && how != :adjacent
+              raise TypeError, "Symbol is not a valid value"
             end
             unless VALID_WHATS.any? { |t| what.is_a? t }
               raise TypeError, "expected one of #{VALID_WHATS.inspect}, got #{what.inspect}:#{what.class}"
@@ -63,7 +66,7 @@ module Watir
 
         def normalize_selector(how, what)
           case how
-          when :tag_name, :text, :xpath, :index, :class, :label, :css, :visible
+          when :tag_name, :text, :xpath, :index, :class, :label, :css, :visible, :adjacent
             # include :class since the valid attribute is 'class_name'
             # include :for since the valid attribute is 'html_for'
             [how, what]

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -8,15 +8,19 @@ module Watir
           end
 
           def build(selectors)
-            xpath = ".//"
+            adjacent = selectors.delete :adjacent
+            xpath = adjacent ? process_adjacent(adjacent) : ".//"
+
             xpath << (selectors.delete(:tag_name) || '*').to_s
 
-            selectors.delete :index
+            index = selectors.delete(:index)
 
             # the remaining entries should be attributes
             unless selectors.empty?
               xpath << "[" << attribute_expression(nil, selectors) << "]"
             end
+
+            xpath << "[#{index + 1}]" if adjacent && index
 
             p xpath: xpath, selectors: selectors if $DEBUG
 
@@ -75,6 +79,21 @@ module Watir
           end
 
           private
+
+          def process_adjacent(adjacent)
+            xpath = './'
+            xpath << case adjacent
+                     when :ancestor
+                       "ancestor::"
+                     when :preceding
+                       "preceding-sibling::"
+                     when :following
+                       "following-sibling::"
+                     when :child
+                       ""
+                     end
+            xpath
+          end
 
           def build_class_match(value)
             if value.match(/^!/)

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -303,7 +303,7 @@ describe Watir::Locators::Element::Locator do
       it "raises a TypeError if selector value is not a String, Regexp or Boolean" do
         num_type = RUBY_VERSION[/^\d+\.(\d+)/, 1].to_i >= 4 ? 'Integer' : 'Fixnum'
         expect { locate_one(tag_name: 123) }.to \
-        raise_error(TypeError, %[expected one of [Array, String, Regexp, TrueClass, FalseClass], got 123:#{num_type}])
+        raise_error(TypeError, %[expected one of [Array, String, Regexp, TrueClass, FalseClass, Symbol], got 123:#{num_type}])
       end
 
       it "raises a MissingWayOfFindingObjectException if the attribute is not valid" do

--- a/spec/watirspec/adjacent_spec.rb
+++ b/spec/watirspec/adjacent_spec.rb
@@ -21,6 +21,10 @@ describe "Adjacent Elements" do
       expect(browser.div(id: "first_sibling").parent(tag_name: :div)).to be_a Watir::Div
     end
 
+    it "accepts class_name argument" do
+      expect(browser.div(id: "first_sibling").parent(class_name: 'parent').id).to eq 'parent_span'
+    end
+
     it "accepts index and tag_name arguments" do
       expect(browser.div(id: "first_sibling").parent(tag_name: :div, index: 1).id).to eq 'grandparent'
       expect(browser.div(id: "first_sibling").parent(tag_name: :div, index: 1)).to be_a Watir::Div
@@ -51,9 +55,21 @@ describe "Adjacent Elements" do
       expect(browser.div(id: "first_sibling").following_sibling(tag_name: :div)).to be_a Watir::Div
     end
 
+    it "accepts class_name argument" do
+      expect(browser.div(id: "first_sibling").following_sibling(class_name: 'b').id).to eq 'second_sibling'
+    end
+
     it "accepts index and tag_name arguments" do
       expect(browser.div(id: "first_sibling").following_sibling(tag_name: :div, index: 1).id).to eq 'third_sibling'
       expect(browser.div(id: "first_sibling").following_sibling(tag_name: :div, index: 1)).to be_a Watir::Div
+    end
+
+    it "accepts text as Regexp" do
+      expect(browser.div(id: "first_sibling").following_sibling(text: /t/).id).to eq 'third_sibling'
+    end
+
+    it "accepts text as String" do
+      expect(browser.div(id: "first_sibling").following_sibling(text: 'text').id).to eq 'third_sibling'
     end
 
     it "does not error when no next sibling of an index exists" do
@@ -75,6 +91,16 @@ describe "Adjacent Elements" do
       expect(browser.div(id: "second_sibling").following_siblings(tag_name: :div).size).to eq 1
       expect(browser.div(id: "second_sibling").following_siblings(tag_name: :div).first).to be_a Watir::Div
     end
+
+    it "accepts class_name argument" do
+      expect(browser.div(id: "second_sibling").following_siblings(class_name: 'b').size).to eq 1
+      expect(browser.div(id: "second_sibling").following_siblings(class_name: 'b').first).to be_a Watir::Div
+    end
+
+    it "accepts class_name argument for multiple classes" do
+      expect(browser.div(id: "second_sibling").following_siblings(class_name: ['a','b']).size).to eq 1
+      expect(browser.div(id: "second_sibling").following_siblings(class_name: ['a', 'b']).first).to be_a Watir::Div
+    end
   end
 
   describe "#previous_sibling" do
@@ -91,6 +117,10 @@ describe "Adjacent Elements" do
     it "accepts tag_name argument" do
       expect(browser.div(id: "third_sibling").previous_sibling(tag_name: :div).id).to eq 'second_sibling'
       expect(browser.div(id: "third_sibling").previous_sibling(tag_name: :div)).to be_a Watir::Div
+    end
+
+    it "accepts class_name argument" do
+      expect(browser.div(id: "third_sibling").previous_sibling(class_name: 'a').id).to eq 'between_siblings2'
     end
 
     it "accepts index and tag_name arguments" do
@@ -117,6 +147,11 @@ describe "Adjacent Elements" do
       expect(browser.div(id: "second_sibling").previous_siblings(tag_name: :div).size).to eq 1
       expect(browser.div(id: "second_sibling").previous_siblings(tag_name: :div).first).to be_a Watir::Div
     end
+
+    it "accepts class_name argument" do
+      expect(browser.div(id: "second_sibling").previous_siblings(class_name: 'a').size).to eq 1
+      expect(browser.div(id: "second_sibling").previous_siblings(class_name: 'a').first.id).to eq 'between_siblings1'
+    end
   end
 
   describe "#child" do
@@ -133,6 +168,10 @@ describe "Adjacent Elements" do
     it "accepts tag_name argument" do
       expect(browser.div(id: "parent").child(tag_name: :span).id).to eq 'between_siblings1'
       expect(browser.div(id: "parent").child(tag_name: :span)).to be_a Watir::Span
+    end
+
+    it "accepts class_name argument" do
+      expect(browser.div(id: "parent").child(class_name: 'b').id).to eq 'second_sibling'
     end
 
     it "accepts index and tag_name arguments" do
@@ -158,6 +197,12 @@ describe "Adjacent Elements" do
     it "accepts tag_name argument" do
       children = browser.div(id: "parent").children(tag_name: :div)
       expect(children.size).to eq 3
+      expect(children.all? { |child| child.is_a? Watir::Div }).to eq true
+    end
+
+    it "accepts a class_name argument" do
+      children = browser.div(id: "parent").children(class_name: 'b')
+      expect(children.size).to eq 2
       expect(children.all? { |child| child.is_a? Watir::Div }).to eq true
     end
   end

--- a/spec/watirspec/html/nested_elements.html
+++ b/spec/watirspec/html/nested_elements.html
@@ -8,7 +8,7 @@
 <body>
 <span id="grandparent_span">
         <div id="grandparent">
-            <span id="parent_span">
+            <span class="parent" id="parent_span">
                 <div id="parent">
                     <div id="first_sibling">
                         <span id="child_span">
@@ -22,10 +22,10 @@
                             <div id="youngest_child"></div>
                         </span>
                     </div>
-                    <span id="between_siblings1"></span>
-                    <div id="second_sibling"></div>
-                    <span id="between_siblings2"></span>
-                    <div id="third_sibling"></div>
+                    <span class="a" id="between_siblings1"></span>
+                    <div class="b" id="second_sibling"></div>
+                    <span class="a" id="between_siblings2"></span>
+                    <div class="a b" id="third_sibling">text</div>
                 </div>
             </span>
         </div>


### PR DESCRIPTION
This addresses #551, as well as supporting *all location types!

While an end user *could use the new locator directly, I'm only going to document it through the methods in the Adjacent module. Not sure if we want to try to enforce this more actively.