### PR TITLE
Allow user-specified :type when locating input buttons

### DIFF
--- a/lib/watir/locators/button/selector_builder.rb
+++ b/lib/watir/locators/button/selector_builder.rb
@@ -8,15 +8,18 @@ module Watir
           selectors.delete(:tag_name) || raise("internal error: no tag_name?!")
 
           button_attr_exp = xpath_builder.attribute_expression(:button, selectors)
-
-          selectors[:type] = Watir::Button::VALID_TYPES
-          input_attr_exp = xpath_builder.attribute_expression(:input, selectors)
-
+          
           xpath = ".//button"
           xpath << "[#{button_attr_exp}]" unless button_attr_exp.empty?
-          xpath << " | .//input"
-          xpath << "[#{input_attr_exp}]"
-
+          
+          unless selectors[:type] == false
+            selectors[:type] = Watir::Button::VALID_TYPES if [nil, true].include?(selectors[:type])
+            input_attr_exp = xpath_builder.attribute_expression(:input, selectors)
+            
+            xpath << " | .//input"
+            xpath << "[#{input_attr_exp}]"
+          end
+          
           p build_wd_selector: xpath if $DEBUG
 
           [:xpath, xpath]

--- a/spec/watirspec/elements/button_spec.rb
+++ b/spec/watirspec/elements/button_spec.rb
@@ -75,6 +75,23 @@ describe "Button" do
       expect(browser.button(xpath: "//input[@type='button']")).to exist
     end
 
+    it "matches the specific type when locating by type" do
+      aggregate_failures do
+        expect(browser.button(type: "button").type).to eq "button"
+        expect(browser.button(type: "reset").type).to eq "reset"
+        expect(browser.button(type: "submit").type).to eq "submit"
+        expect(browser.button(type: "image").type).to eq "image"
+      end
+    end
+    
+    it "matches valid input types when type is boolean" do
+      aggregate_failures do
+        expect(browser.buttons(type: false).map(&:tag_name)).to all eq("button")
+        
+        input_buttons = browser.buttons(type: true).select { |e| e.tag_name == "input" }
+        expect(input_buttons.map(&:type).uniq).to match_array(Watir::Button::VALID_TYPES)
+      end
+    end
 
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.button(id: 3.14).exists? }.to raise_error(TypeError)


### PR DESCRIPTION
When locating input buttons, the user-specified :type is ignored. For example, in the page:

~~~~~~~~html
<input type="reset">
<input type="submit">
~~~~~~~~

You get the wrong element if you locate by type:

~~~~~~~~ruby
browser.button(type: "submit").html
#=> "<input type="reset">"

browser.button(type: false).html
#=> "<input type="reset">"
~~~~~~~~

With these changes:

1. Match the user-specified type when specified
2.  Ignore input tags when {type: false} (since that would mean they are text fields)
3. Continue to select only valid button types when {type: true} or not specified