### PR TITLE
Support switching back to Original Window without using a block

### DIFF
--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -9,7 +9,7 @@ module Watir
     include HasWindow
     include Waitable
 
-    attr_writer :default_context
+    attr_writer :default_context, :original_window
     attr_reader :driver
     attr_reader :after_hooks
     alias_method :wd, :driver # ensures duck typing with Watir::Element

--- a/lib/watir/has_window.rb
+++ b/lib/watir/has_window.rb
@@ -11,7 +11,7 @@ module Watir
     #
 
     def windows(*args)
-      all = @driver.window_handles.map { |handle| Window.new(@driver, handle: handle) }
+      all = @driver.window_handles.map { |handle| Window.new(self, handle: handle) }
 
       if args.empty?
         all
@@ -30,11 +30,26 @@ module Watir
     #
 
     def window(*args, &blk)
-      win = Window.new @driver, extract_selector(args)
+      win = Window.new self, extract_selector(args)
 
       win.use(&blk) if block_given?
 
       win
+    end
+
+    #
+    # Returns original window if defined, current window if not
+    # See Window#use
+    #
+    # @example
+    #   browser.window(title: 'closeable window').use
+    #   browser.original_window.use
+    #
+    # @return [Window]
+    #
+
+    def original_window
+      @original_window ||= window
     end
 
     private

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -3,8 +3,9 @@ module Watir
     include EventuallyPresent
     include Waitable
 
-    def initialize(driver, selector)
-      @driver = driver
+    def initialize(browser, selector)
+      @browser = browser
+      @driver = browser.driver
       @selector = selector
 
       if selector.empty?
@@ -151,6 +152,7 @@ module Watir
     #
 
     def close
+      @browser.original_window = nil if self == @browser.original_window
       use { @driver.close }
     end
 
@@ -190,6 +192,7 @@ module Watir
     #
 
     def use(&blk)
+      @browser.original_window ||= current_window
       wait_for_exists
       @driver.switch_to.window(handle, &blk)
       self

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -38,7 +38,7 @@ describe "Browser::AfterHooks" do
 
   describe "#run" do
     after(:each) do
-      browser.window(index: 0).use
+      browser.original_window.use
       browser.after_hooks.delete @page_after_hook
     end
 
@@ -178,7 +178,7 @@ describe "Browser::AfterHooks" do
           window = browser.window(title: "closeable window")
           window.use
           expect { browser.a(id: "close").click }.to_not raise_error
-          browser.window(index: 0).use
+          browser.original_window.use
         end
       end
     end

--- a/spec/watirspec/browser_spec.rb
+++ b/spec/watirspec/browser_spec.rb
@@ -4,8 +4,8 @@ describe "Browser" do
 
   describe "#exists?" do
     after do
-      browser.window(index: 0).use
-      browser.windows[1..-1].each(&:close)
+      browser.original_window.use
+      browser.windows.reject(&:current?).each(&:close)
     end
 
     it "returns true if we are at a page" do

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -9,8 +9,8 @@ describe "Browser" do
   end
 
   after do
-    browser.window(index: 0).use
-    browser.windows[1..-1].each(&:close)
+    browser.original_window.use
+    browser.windows.reject(&:current?).each(&:close)
   end
 
   describe "#windows" do
@@ -104,8 +104,8 @@ describe "Window" do
     end
 
     after do
-      browser.window(index: 0).use
-      browser.windows[1..-1].each(&:close)
+      browser.original_window.use
+      browser.windows.reject(&:current?).each(&:close)
     end
 
     not_compliant_on :safari, %i(firefox linux) do
@@ -206,8 +206,8 @@ describe "Window" do
     end
 
     after do
-      browser.window(index: 0).use
-      browser.windows[1..-1].each(&:close)
+      browser.original_window.use
+      browser.windows.reject(&:current?).each(&:close)
     end
 
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1223277", :firefox do


### PR DESCRIPTION
implements #550 

This gives more flexibility if you want to be in a different context than a single block to return to the original window (which is most use cases when dealing with multiple windows.

Allows this:
```ruby
browser.window(title: "foo").use
do_stuff
browser.reset_window!
```
instead of this:
```ruby
browser.window(title: "foo").use do
  do_stuff
end
```
or this:
```ruby
original_window = browser.window
browser.window(title: 'foo').use
do_stuff
original_window.use
```
