### PR TITLE
implement TableCell#column_header method

### DIFF
--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -112,7 +112,17 @@ module Watir
             end
           end
     end
-    alias_method :locate, :to_a
+
+    #
+    # Locate all elements and return self.
+    #
+    # @return ElementCollection
+    #
+
+    def locate
+      to_a
+      self
+    end
 
     #
     # Returns true if two element collections are equal.

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -14,6 +14,7 @@ module Watir
     include Adjacent
 
     attr_accessor :keyword
+    attr_reader :selector
 
     #
     # temporarily add :id and :class_name manually since they're no longer specified in the HTML spec.

--- a/lib/watir/elements/row.rb
+++ b/lib/watir/elements/row.rb
@@ -11,7 +11,7 @@ module Watir
     def to_a
       # we do this craziness since the xpath used will find direct child rows
       # before any rows inside thead/tbody/tfoot...
-      super.sort_by { |e| e.attribute_value(:rowIndex).to_i }
+      @to_a ||= super.sort_by { |e| e.attribute_value(:rowIndex).to_i }
     end
   end
 end # Watir

--- a/lib/watir/elements/table_cell.rb
+++ b/lib/watir/elements/table_cell.rb
@@ -2,5 +2,16 @@ module Watir
   class TableCell < HTMLElement
     alias_method :colspan, :col_span
     alias_method :rowspan, :row_span
+
+    def column_header
+      table = parent(tag_name: 'table')
+      header_row = table.tr
+      current_row = parent(tag_name: 'tr')
+
+      table.cell_size_check(header_row, current_row)
+
+      header_type = header_row.th.exist? ? 'th' : 'td'
+      Watir.tag_to_class[header_type.to_sym].new(header_row, tag_name: header_type, index: previous_siblings.size)
+    end
   end # TableCell
 end # Watir

--- a/spec/watirspec/elements/collections_spec.rb
+++ b/spec/watirspec/elements/collections_spec.rb
@@ -47,6 +47,6 @@ describe "Collections" do
     browser.goto(WatirSpec.url_for("collections.html"))
     spans = browser.span(id: "a_span").spans
     expect(spans).to receive(:elements).and_return([])
-    spans.locate
+    expect(spans.locate).to be_a Watir::SpanCollection
   end
 end

--- a/spec/watirspec/elements/table_spec.rb
+++ b/spec/watirspec/elements/table_spec.rb
@@ -75,7 +75,7 @@ describe "Table" do
 
       expect {
         browser.table.hashes
-      }.to raise_error("row at index 0 has 2 cells, expected 3")
+      }.to raise_error("row at index 0 has 2 cells, while header row has 3")
     end
   end
 

--- a/spec/watirspec/elements/td_spec.rb
+++ b/spec/watirspec/elements/td_spec.rb
@@ -70,4 +70,11 @@ describe "TableCell" do
     end
   end
 
+  describe "#column_header" do
+    it "returns the corresponding column header" do
+      td = browser.td(text: '1 331').column_header
+      expect(td.text).to eq 'Income tax'
+    end
+  end
+
 end


### PR DESCRIPTION
Based on a feature conversation in Slack channel.
This is easy to implement now that we have adjacent calls.
This assumes that the `th` elements are in the first `tr` which I think is required.

Not sure if there are other similar convenience methods we want to do?
`TableDataCell#row_value(index)` with `td.previous_sibling(index: index)` ?