### PR TITLE
implement extra methods and add aliases from page object gem

### DIFF
--- a/lib/watir/attribute_helper.rb
+++ b/lib/watir/attribute_helper.rb
@@ -38,6 +38,10 @@ module Watir
     #  @return [$1] value of $3 property
     #
     def attribute(type, method, attr)
+      if %i(size selected? clear style width height).include? method
+        Watir.logger.debug "#{self}##{method} will use direct Element method not #attribute_value by default"
+        return
+      end
       typed_attributes[type] << [method, attr]
       define_attribute(type, method, attr)
     end

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -112,7 +112,17 @@ module Watir
             end
           end
     end
-    alias_method :locate, :to_a
+
+    #
+    # Locate all elements and return self.
+    #
+    # @return ElementCollection
+    #
+
+    def locate
+      to_a
+      self
+    end
 
     #
     # Returns true if two element collections are equal.

--- a/lib/watir/elements/checkbox.rb
+++ b/lib/watir/elements/checkbox.rb
@@ -18,6 +18,7 @@ module Watir
     def set(bool = true)
       set? == bool ? assert_enabled : click
     end
+    alias_method :check, :set
 
     #
     # Returns true if the element is checked
@@ -27,6 +28,7 @@ module Watir
     def set?
       element_call { @element.selected? }
     end
+    alias_method :checked?, :set?
 
     #
     # Unsets checkbox.
@@ -35,6 +37,7 @@ module Watir
     def clear
       set false
     end
+    alias_method :uncheck, :clear
 
   end # CheckBox
 

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -269,6 +269,7 @@ module Watir
     def attribute_value(attribute_name)
       element_call { @element.attribute attribute_name }
     end
+    alias_method :attribute, :attribute_value
 
     #
     # Returns outer (inner + element itself) HTML code of element.
@@ -351,6 +352,87 @@ module Watir
 
       element_call { execute_atom :fireEvent, @element, event_name }
     end
+
+    #
+    # Scroll until the element is in the view screen
+    #
+    # @example
+    #   browser.button(name: "new_user_button").scroll_into_view
+    #
+    # @return [Selenium::WebDriver::Point]
+    #
+
+    def scroll_into_view
+      element_call { @element.location_once_scrolled_into_view }
+    end
+
+    #
+    # location of element (x, y)
+    #
+    # @example
+    #   browser.button(name: "new_user_button").location
+    #
+    # @return [Selenium::WebDriver::Point]
+    #
+
+    def location
+      element_call { @element.location }
+    end
+
+    #
+    # size of element (width, height)
+    #
+    # @example
+    #   browser.button(name: "new_user_button").size
+    #
+    # @return [Selenium::WebDriver::Dimension]
+    #
+
+    def size
+      element_call { @element.size }
+    end
+
+    #
+    # Get height of element
+    #
+    # @example
+    #   browser.button(name: "new_user_button").height
+    #
+    # @return [Selenium::WebDriver::Dimension]
+    #
+
+    def height
+      size['height']
+    end
+
+    #
+    # Get width of element
+    #
+    # @example
+    #   browser.button(name: "new_user_button").width
+    #
+    # @return [Selenium::WebDriver::Dimension]
+    #
+
+    def width
+      size['width']
+    end
+
+    #
+    # Get centre coordinates of element
+    #
+    # @example
+    #   browser.button(name: "new_user_button").centre
+    #
+    # @return [Selenium::WebDriver::Point]
+    #
+
+    def center
+      location = location()
+      Selenium::WebDriver::Point.new(location.x + (height/2),
+                                     location.y + (width/2))
+    end
+    alias_method :centre, :center
 
     #
     # @api private

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -14,6 +14,7 @@ module Watir
     include Adjacent
 
     attr_accessor :keyword
+    attr_reader :selector
 
     #
     # temporarily add :id and :class_name manually since they're no longer specified in the HTML spec.

--- a/lib/watir/elements/font.rb
+++ b/lib/watir/elements/font.rb
@@ -1,4 +1,18 @@
 module Watir
+  class Font < HTMLElement
+
+    #
+    # size of font
+    #
+    # @return [Integer]
+    #
+
+    def size
+      attribute_value(:size)
+    end
+
+  end # Font
+
   module Container
     def font(*args)
       Font.new(self, extract_selector(args).merge(tag_name: "font"))

--- a/lib/watir/elements/hidden.rb
+++ b/lib/watir/elements/hidden.rb
@@ -3,6 +3,11 @@ module Watir
     def visible?
       false
     end
+
+    def click
+      raise Watir::Exception::ObjectDisabledException, "click is not available on the hidden field element"
+    end
+
   end
 
   module Container

--- a/lib/watir/elements/image.rb
+++ b/lib/watir/elements/image.rb
@@ -16,18 +16,6 @@ module Watir
       )
     end
 
-    #
-    # Returns the image's width in pixels.
-    #
-    # @return [Integer] width
-    #
-
-    def width
-      element_call do
-        driver.execute_script "return arguments[0].width", @element
-      end
-    end
-
   end # Image
 
   module Container

--- a/lib/watir/elements/radio.rb
+++ b/lib/watir/elements/radio.rb
@@ -8,6 +8,7 @@ module Watir
     def set
       click unless set?
     end
+    alias_method :select, :set
 
     #
     # Is this radio set?
@@ -18,6 +19,7 @@ module Watir
     def set?
       element_call { @element.selected? }
     end
+    alias_method :selected?, :set?
 
   end # Radio
 

--- a/lib/watir/elements/row.rb
+++ b/lib/watir/elements/row.rb
@@ -11,7 +11,7 @@ module Watir
     def to_a
       # we do this craziness since the xpath used will find direct child rows
       # before any rows inside thead/tbody/tfoot...
-      super.sort_by { |e| e.attribute_value(:rowIndex).to_i }
+      @to_a ||= super.sort_by { |e| e.attribute_value(:rowIndex).to_i }
     end
   end
 end # Watir

--- a/lib/watir/elements/table_cell.rb
+++ b/lib/watir/elements/table_cell.rb
@@ -2,5 +2,16 @@ module Watir
   class TableCell < HTMLElement
     alias_method :colspan, :col_span
     alias_method :rowspan, :row_span
+
+    def column_header
+      table = parent(tag_name: 'table')
+      header_row = table.tr
+      current_row = parent(tag_name: 'tr')
+
+      table.cell_size_check(header_row, current_row)
+
+      header_type = header_row.th.exist? ? 'th' : 'td'
+      Watir.tag_to_class[header_type.to_sym].new(header_row, tag_name: header_type, index: previous_siblings.size)
+    end
   end # TableCell
 end # Watir

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -32,7 +32,7 @@ module LocatorSpecHelper
 
   def element(opts = {})
     attrs = opts.delete(:attributes)
-    el = double(Watir::Element, opts)
+    el = double(Watir::HTMLElement, opts)
 
     attrs.each do |key, value|
       allow(el).to receive(:attribute).with(key).and_return(value)

--- a/spec/watirspec/elements/collections_spec.rb
+++ b/spec/watirspec/elements/collections_spec.rb
@@ -47,6 +47,6 @@ describe "Collections" do
     browser.goto(WatirSpec.url_for("collections.html"))
     spans = browser.span(id: "a_span").spans
     expect(spans).to receive(:elements).and_return([])
-    spans.locate
+    expect(spans.locate).to be_a Watir::SpanCollection
   end
 end

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -381,4 +381,88 @@ describe "Element" do
       expect(div.outer_html).to eq('<div id="foo"><a href="#">hello</a></div>')
     end
   end
+
+  not_compliant_on %i(remote firefox) do
+    describe '#scroll_into_view' do
+      it 'scrolls element into view' do
+        el = browser.button(name: 'new_user_image')
+        element_center = el.center['y']
+
+        bottom_viewport_script = 'return window.pageYOffset + window.innerHeight'
+        expect(browser.execute_script bottom_viewport_script).to be < element_center
+
+        expect(el.scroll_into_view).to be_a Selenium::WebDriver::Point
+
+        expect(browser.execute_script bottom_viewport_script).to be > element_center
+      end
+    end
+  end
+
+  describe '#location' do
+    it 'returns coordinates for element location' do
+      location = browser.button(name: 'new_user_image').location
+
+      expect(location).to be_a Selenium::WebDriver::Point
+      expect(location['y']).to be > 0
+      expect(location['x']).to be > 0
+
+      not_compliant_on :remote do
+        expect(location['y']).to be_a Float
+        expect(location['x']).to be_a Float
+      end
+
+      deviates_on :remote do
+        expect(location['y']).to be_a Integer
+        expect(location['x']).to be_a Integer
+      end
+    end
+  end
+
+  describe '#size' do
+    it 'returns size of element' do
+      size = browser.button(name: 'new_user_image').size
+
+      expect(size).to be_a Selenium::WebDriver::Dimension
+      expect(size['width']).to eq 104.0
+      expect(size['height']).to eq 70.0
+    end
+  end
+
+  describe '#height' do
+    it 'returns height of element' do
+      height = browser.button(name: 'new_user_image').height
+
+      expect(height).to eq 70.0
+    end
+  end
+
+  describe '#width' do
+    it 'returns width of element' do
+      width = browser.button(name: 'new_user_image').width
+
+      expect(width).to eq 104.0
+    end
+
+  end
+
+  describe '#center' do
+    it 'returns center of element' do
+      center = browser.button(name: 'new_user_image').center
+
+      expect(center).to be_a Selenium::WebDriver::Point
+      expect(center['y']).to be > 0.0
+      expect(center['x']).to be > 0.0
+
+      not_compliant_on :remote do
+        expect(center['y']).to be_a Float
+        expect(center['x']).to be_a Float
+      end
+
+      deviates_on :remote do
+        expect(center['y']).to be_a Integer
+        expect(center['x']).to be_a Integer
+      end
+    end
+  end
+
 end

--- a/spec/watirspec/elements/hidden_spec.rb
+++ b/spec/watirspec/elements/hidden_spec.rb
@@ -90,6 +90,12 @@ describe "Hidden" do
     end
   end
 
+  describe "#click" do
+    it "raises ObjectDisabledException when attempting to click" do
+      expect { browser.hidden(index: 1337).click }.to raise_object_disabled_exception
+    end
+  end
+
   describe "#respond_to?" do
     it "returns true for all attribute methods" do
       expect(browser.hidden(index: 1)).to respond_to(:id)

--- a/spec/watirspec/elements/table_spec.rb
+++ b/spec/watirspec/elements/table_spec.rb
@@ -75,7 +75,7 @@ describe "Table" do
 
       expect {
         browser.table.hashes
-      }.to raise_error("row at index 0 has 2 cells, expected 3")
+      }.to raise_error("row at index 0 has 2 cells, while header row has 3")
     end
   end
 

--- a/spec/watirspec/elements/td_spec.rb
+++ b/spec/watirspec/elements/td_spec.rb
@@ -70,4 +70,11 @@ describe "TableCell" do
     end
   end
 
+  describe "#column_header" do
+    it "returns the corresponding column header" do
+      td = browser.td(text: '1 331').column_header
+      expect(td.text).to eq 'Income tax'
+    end
+  end
+
 end


### PR DESCRIPTION
Now that Page Object gem is entirely implemented by Watir, I think we should be moving some of the things that are implemented there that aren't technically related to Page Objects into Watir directly. Many of these things should already have been done in Watir and I just didn't think to implement them.

1. Several obvious aliases
2. For attributes that have Watir method equivalents, the default behavior should be the method, not the attribute. We can put these into a constant if that makes more sense. (except `Font#size` which overrides the superclass method because it is different)
3. `html_element.rb` file to load after all `#attribute` calls are made to alias `#attribute` to `#attribute_value`. The alternative is to rename `#attribute` in the helper file to `#set_attribute` which I might actually prefer, but thought I'd get feedback on it before changing it.
4. Six new element methods with documentation & tests
5. Not sure that's the right error to throw when trying to click a hidden element. thoughts?

I'm still digging into the Page Object code, so there will likely be more things, but these are the ones that I got in the first pass.

@AlexisKAndersen or @cheezy let me know if you have any input on this as well.