### PR TITLE
implement TableCell#sibling_from_header

### DIFF
--- a/lib/watir/elements/table_cell.rb
+++ b/lib/watir/elements/table_cell.rb
@@ -4,14 +4,30 @@ module Watir
     alias_method :rowspan, :row_span
 
     def column_header
-      table = parent(tag_name: 'table')
-      header_row = table.tr
       current_row = parent(tag_name: 'tr')
+      header_row(current_row, index: previous_siblings.size)
+    end
+
+    def sibling_from_header(opt)
+      current_row = parent(tag_name: 'tr')
+      header = header_row(current_row, opt)
+      index = header.previous_siblings.size
+
+      self.class.new(current_row, tag_name: 'td', index: index)
+    end
+
+    private
+
+    def header_row(current_row, opt)
+      table = self.parent(tag_name: 'table')
+      header_row = table.tr
 
       table.cell_size_check(header_row, current_row)
 
-      header_type = header_row.th.exist? ? 'th' : 'td'
-      Watir.tag_to_class[header_type.to_sym].new(header_row, tag_name: header_type, index: previous_siblings.size)
+      header_type = table.th.exist? ? 'th' : 'tr'
+      opt.merge!(tag_name: header_type)
+
+      Watir.tag_to_class[header_type.to_sym].new(header_row, opt)
     end
   end # TableCell
 end # Watir

--- a/spec/watirspec/elements/td_spec.rb
+++ b/spec/watirspec/elements/td_spec.rb
@@ -77,4 +77,20 @@ describe "TableCell" do
     end
   end
 
+  describe "#sibling_from_header" do
+    it "returns the corresponding sibling cell by text" do
+      local_td = browser.td(text: '1 331')
+
+      td = local_td.sibling_from_header(text: 'After income tax')
+      expect(td.text).to eq '4 532'
+    end
+
+    it "returns the corresponding sibling cell by index" do
+      local_td = browser.td(text: '1 331')
+
+      td = local_td.sibling_from_header(text: /tax/, index: 2)
+      expect(td.text).to eq '4 532'
+    end
+
+  end
 end


### PR DESCRIPTION
An example use case for this is being able to locate a specific cell in a table (e.g. by text) and wanting to check a checkbox in an adjacent cell. This would allow:

```
browser.td(text: 'Jason Smith').sibling_from_header(text: "Opted In").checkbox.check
```
Can also use index, but not sure if it makes more sense than what is available now.

Now:
```
browser.td(text: 'Jason Smith').parent(tag_name: 'tr').td(index: -1).checkbox.check
```
PR:
```
browser.td(text: 'Jason Smith').sibling_from_header(index: -1).checkbox.check
```

It's the most descriptive name I could come up with. Alternate naming options welcomed. :)