### PR TITLE
Demo update to use watir.com instead of google.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Watir Powered By Selenium!
 require 'watir'
 
 browser = Watir::Browser.new
-browser.goto 'google.com'
-browser.text_field(title: 'Search').set 'Hello World!'
-browser.button(type: 'submit').click
+
+browser.goto 'watir.com'
+browser.link(text: 'Documentation').click
 
 puts browser.title
-# => 'Hello World! - Google Search'
+# => 'Documentation – Watir Project...'
 browser.close
 ```
 


### PR DESCRIPTION
Google recently changed their search page, and the existing demo no longer works correctly. This update isn't as involved as the existing one, but it utilizes watir.com, thus removing the demo's dependency on Google.

Opening a similar PR on watir/watir.github.io changing the main demo there, too!