### PR TITLE
fix bug of not waiting for Select List

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -593,7 +593,7 @@ module Watir
       return if present?
 
       begin
-        @query_scope.wait_for_present
+        @query_scope.wait_for_present unless @query_scope.is_a? Browser
         wait_until_present
       rescue Watir::Wait::TimeoutError
         msg = "element located, but timed out after #{Watir.default_timeout} seconds, waiting for #{inspect} to be present"


### PR DESCRIPTION
Even more tweaking the select list code...

Mostly timing related...
`#options` needs to go though an `#element_call` to get the specified waiting behavior 

I'm also removing the waits for the options, since they didn't respect the `#relaxed_locate` setting and I'm not sure how to check both text and labels without it causing problems somewhere. I think we're ok to assume that if the select list is present that the options should be ready to go right away. Maybe I'll have a better thought on this after I sleep more, but this should be good.