### PR TITLE
implement RadioSet

### DIFF
--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -148,6 +148,8 @@ require 'watir/elements/table_row'
 require 'watir/elements/table_section'
 require 'watir/elements/text_area'
 require 'watir/elements/text_field'
+require 'watir/elements/input'
+require 'watir/radio_set'
 
 require 'watir/locators'
 require 'watir/aliases'

--- a/lib/watir/adjacent.rb
+++ b/lib/watir/adjacent.rb
@@ -111,7 +111,7 @@ module Watir
       plural = opt.delete(:plural)
       opt[:index] ||= 0 unless plural || opt.values.any? { |e| e.is_a? Regexp }
       klass = if !plural && opt[:tag_name]
-                self.send(opt[:tag_name]).class
+                Watir.tag_to_class[opt[:tag_name].to_sym]
               elsif !plural
                 HTMLElement
               elsif opt[:tag_name]

--- a/lib/watir/elements/input.rb
+++ b/lib/watir/elements/input.rb
@@ -1,0 +1,15 @@
+module Watir
+  class Input < HTMLElement
+
+    #
+    # Returns applicable label.
+    # Is not lazy loaded.
+    #
+
+    def label
+      el = parent(tag_name: 'form').label(for: id)
+      return el if el.exist?
+    end
+
+  end # Input
+end # Watir

--- a/lib/watir/elements/input.rb
+++ b/lib/watir/elements/input.rb
@@ -7,8 +7,7 @@ module Watir
     #
 
     def label
-      el = parent(tag_name: 'form').label(for: id)
-      return el if el.exist?
+      parent(tag_name: 'form').label(for: id)
     end
 
   end # Input

--- a/lib/watir/elements/input.rb
+++ b/lib/watir/elements/input.rb
@@ -2,8 +2,9 @@ module Watir
   class Input < HTMLElement
 
     #
-    # Returns applicable label.
-    # Is not lazy loaded.
+    # Returns label element associated with Input element.
+    #
+    # @return [Watir::Label]
     #
 
     def label

--- a/lib/watir/elements/radio.rb
+++ b/lib/watir/elements/radio.rb
@@ -1,6 +1,11 @@
 module Watir
   class Radio < Input
 
+    def initialize(query_scope, selector)
+      super
+      @selector[:label] = @selector.delete(:text) if @selector.key?(:text)
+    end
+
     #
     # Selects this radio button.
     #
@@ -20,6 +25,18 @@ module Watir
       element_call { @element.selected? }
     end
     alias_method :selected?, :set?
+
+    #
+    # Returns the text of the associated label.
+    # Returns empty string if no label is found.
+    #
+    # @return [String]
+    #
+
+    def text
+      l = label()
+      l ? l.text : ''
+    end
 
   end # Radio
 

--- a/lib/watir/elements/radio.rb
+++ b/lib/watir/elements/radio.rb
@@ -35,7 +35,7 @@ module Watir
 
     def text
       l = label()
-      l ? l.text : ''
+      l.exist? ? l.text : ''
     end
 
   end # Radio

--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -119,6 +119,7 @@ module Watir
 
         def find_all_by_one
           how, what = @selector.to_a.first
+          return [what] if how == :element
           selector_builder.check_type how, what
 
           if WD_FINDERS.include?(how)

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -47,18 +47,31 @@ module Watir
     # @return Watir::Radio
     #
 
-    def radio(opt)
-      name_opt = name.empty? ? {} : {name: name}
-      frame.radio(opt.merge name_opt)
+    def radio(opt = {})
+      n = name
+      if !n.empty? && (!opt[:name] || opt[:name] == n)
+        frame.radio(opt.merge name: n)
+      elsif n.empty?
+        return source
+      else
+        raise Watir::Exception::UnknownObjectException, "#{opt[:name]} does not match name of RadioSet: #{n}"
+      end
+
     end
 
     #
     # @return Watir::RadioCollection
     #
 
-    def radios
-      opt = name ? {name: name} : {}
-      element_call(:wait_for_present) { frame.radios(opt) }
+    def radios(opt = {})
+      n = name
+      if !n.empty? && (!opt[:name] || opt[:name] == n)
+        element_call(:wait_for_present) { frame.radios(opt.merge name: n) }
+      elsif n.empty?
+        Watir::RadioCollection.new(frame, element: source.wd)
+      else
+        raise Watir::Exception::UnknownObjectException, "#{opt[:name]} does not match name of RadioSet: #{n}"
+      end
     end
 
     #

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -1,0 +1,218 @@
+module Watir
+  class RadioSet
+    extend Forwardable
+    include Watir::Exception
+    include Enumerable
+
+    delegate [:exists?, :present?, :visible?, :browser] => :source
+
+    attr_reader :source, :frame
+
+    def initialize(query_scope, selector)
+      unless selector.kind_of? Hash
+        raise ArgumentError, "invalid argument: #{selector.inspect}"
+      end
+
+      @source = Radio.new(query_scope, selector)
+      @frame = @source.parent(tag_name: :form)
+    end
+
+    #
+    # Yields each TableCell associated with this row.
+    #
+    # @example
+    #   radio_set = browser.radio_set
+    #   radio_set.each do |radio|
+    #     puts radio.text
+    #   end
+    #
+    # @yieldparam [Watir::RadioSet] element iterate through the radio buttons.
+    #
+
+    def each(&block)
+      radios.each(&block)
+    end
+
+    #
+    # Get the n'th radio button in this set
+    #
+    # @return Watir::Radio
+    #
+
+    def [](idx)
+      radios[idx]
+    end
+
+    #
+    # @return Watir::Radio
+    #
+
+    def radio(opt)
+      name_opt = name.empty? ? {} : {name: name}
+      frame.radio(opt.merge name_opt)
+    end
+
+    #
+    # @return Watir::RadioCollection
+    #
+
+    def radios
+      opt = name ? {name: name} : {}
+      element_call(:wait_for_present) { frame.radios(opt) }
+    end
+
+    #
+    # Returns true if any radio buttons in the set are enabled.
+    #
+    # @return [Boolean]
+    #
+
+    def enabled?
+      any?(&:enabled?)
+    end
+
+    #
+    # Returns true if all radio buttons in the set are disabled.
+    #
+    # @return [Boolean]
+    #
+
+    def disabled?
+      !enabled?
+    end
+
+    #
+    # Returns true if all radio buttons in the set are disabled.
+    #
+    # @return [String]
+    #
+
+    def name
+      @name ||= source.name
+    end
+
+    #
+    # If RadioSet exists, this always returns 'radio'.
+    #
+    # @return [String]
+    #
+
+    def type
+      source.send :assert_exists
+      'radio'
+    end
+
+    #
+    # Returns true if the radio set has one or more radio buttons where label matches the given value.
+    #
+    # @param [String, Regexp] str_or_rx
+    # @return [Boolean]
+    #
+
+    def include?(str_or_rx)
+      radio(label: str_or_rx).exist?
+    end
+
+    #
+    # Select the radio button whose value or label matches the given string.
+    #
+    # @param [String, Regexp] str_or_rx
+    # @raise [Watir::Exception::UnknownObjectException] if the Radio does not exist.
+    # @return [String] The value or text of the radio selected.
+    #
+
+    def select(str_or_rx)
+      found_by_value = radio(value: str_or_rx)
+      found_by_text = radio(label: str_or_rx)
+
+      if found_by_value.exist?
+        found_by_value.click unless found_by_value.selected?
+        return found_by_value.value
+      elsif found_by_text.exist?
+        found_by_text.click unless found_by_text.selected?
+        return found_by_text.text
+      else
+        raise UnknownObjectException, "Unable to locate radio matching #{str_or_rx.inspect}"
+      end
+    end
+
+    #
+    # Returns true if any of the radio button label matches the given value.
+    #
+    # @param [String, Regexp] str_or_rx
+    # @raise [Watir::Exception::UnknownObjectException] if the options do not exist
+    # @return [Boolean]
+    #
+
+    def selected?(str_or_rx)
+      found = frame.radio(label: str_or_rx)
+
+      return found.selected? if found.exist?
+      raise UnknownObjectException, "Unable to locate radio matching #{str_or_rx.inspect}"
+    end
+
+    #
+    # Returns the value of the selected radio button in the set.
+    # Returns nil if no radio is selected.
+    #
+    # @return [String, nil]
+    #
+
+    def value
+      sel = selected
+      sel && sel.value
+    end
+
+    #
+    # Returns the text of the selected radio button in the set.
+    # Returns nil if no option is selected.
+    #
+    # @return [String, nil]
+    #
+
+    def text
+      sel = selected
+      sel && sel.text
+    end
+
+    #
+    # Returns the selected Radio element.
+    # Returns nil if no radio button is selected.
+    #
+    # @return [Watir::Radio, nil]
+    #
+
+    def selected
+      find(&:selected?)
+    end
+
+    #
+    # Returns true if two elements are equal.
+    #
+    # @example
+    #   browser.radio_set(id: 'new_user_newsletter_yes') == browser.radio_set(id: 'new_user_newsletter_no')
+    #   #=> true
+    #
+
+    def ==(other)
+      return false unless other.kind_of?(self.class)
+      frame == other.frame
+    end
+    alias_method :eql?, :==
+
+    private
+
+    def element_call(*args, &blk)
+      source.send :element_call, *args, &blk
+    end
+  end # RadioSet
+
+  module Container
+    def radio_set(*args)
+      RadioSet.new(self, extract_selector(args).merge(tag_name: "input", type: "radio"))
+    end
+
+    Watir.tag_to_class[:radio_set] = RadioSet
+  end # Container
+
+end # Watir

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -18,7 +18,7 @@ module Watir
     end
 
     #
-    # Yields each TableCell associated with this row.
+    # Yields each Radio associated with this set.
     #
     # @example
     #   radio_set = browser.radio_set
@@ -95,7 +95,7 @@ module Watir
     end
 
     #
-    # Returns true if all radio buttons in the set are disabled.
+    # Returns the name attribute for the set.
     #
     # @return [String]
     #
@@ -209,7 +209,7 @@ module Watir
 
     def ==(other)
       return false unless other.kind_of?(self.class)
-      frame == other.frame
+      radios == other.radios
     end
     alias_method :eql?, :==
 

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -99,7 +99,7 @@ describe "Element" do
     end
 
     it "finds finds several elements by arbitrary attribute" do
-      expect(browser.elements(id: /^new_user/).length).to eq 32
+      expect(browser.elements(id: /^new_user/).length).to eq 33
     end
 
     it "finds an element from an element's subtree" do

--- a/spec/watirspec/elements/labels_spec.rb
+++ b/spec/watirspec/elements/labels_spec.rb
@@ -14,7 +14,7 @@ describe "Labels" do
 
   describe "#length" do
     it "returns the number of labels" do
-      expect(browser.labels.length).to eq 39
+      expect(browser.labels.length).to eq 40
     end
   end
 

--- a/spec/watirspec/elements/radio_spec.rb
+++ b/spec/watirspec/elements/radio_spec.rb
@@ -115,6 +115,21 @@ describe "Radio" do
     end
   end
 
+  describe "#text" do
+    it "returns the text if the radio exists" do
+      expect(browser.radio(id: 'new_user_newsletter_yes').text).to eq "Yes"
+    end
+
+    it "raises UnknownObjectException if the radio doesn't exist" do
+      expect { browser.radio(index: 1337).text }.to raise_unknown_object_exception
+    end
+
+    it "returns empty string when there is no label" do
+      form = browser.form(id: "new_user")
+      expect(form.radio(index: 2).text).to eq ''
+    end
+  end
+
   describe "#title" do
     it "returns the title attribute if the radio exists" do
       expect(browser.radio(id: "new_user_newsletter_no").title).to eq "Traitor!"

--- a/spec/watirspec/elements/radio_spec.rb
+++ b/spec/watirspec/elements/radio_spec.rb
@@ -15,9 +15,8 @@ describe "Radio" do
       expect(browser.radio(name: /new_user_newsletter/)).to exist
       expect(browser.radio(value: "yes")).to exist
       expect(browser.radio(value: /yes/)).to exist
-      # TODO: figure out what :text means for a radio button
-      # browser.radio(text: "yes").to exist
-      # browser.radio(text: /yes/).to exist
+      expect(browser.radio(text: "Yes")).to exist
+      expect(browser.radio(text: /Yes/)).to exist
       expect(browser.radio(class: "huge")).to exist
       expect(browser.radio(class: /huge/)).to exist
       expect(browser.radio(index: 0)).to exist

--- a/spec/watirspec/elements/radios_spec.rb
+++ b/spec/watirspec/elements/radios_spec.rb
@@ -14,7 +14,7 @@ describe "Radios" do
 
   describe "#length" do
     it "returns the number of radios" do
-      expect(browser.radios.length).to eq 6
+      expect(browser.radios.length).to eq 7
     end
   end
 

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -115,6 +115,8 @@
             <label for="new_user_newsletter_probably">Probably</label>
             <input type="radio" name="new_user_newsletter" id="new_user_newsletter_nah" value="nah" disabled="disabled" />
             <label for="new_user_newsletter_nah">Nah</label>
+            <input type="radio" id="new_user_newsletter_none" value="none" disabled="disabled" />
+            <label for="new_user_newsletter_none">None</label>
         </fieldset>
         <fieldset>
             <legend>Actions</legend>

--- a/spec/watirspec/radio_set_spec.rb
+++ b/spec/watirspec/radio_set_spec.rb
@@ -213,7 +213,6 @@ describe "RadioSet" do
     end
   end
 
-
   describe "#selected" do
     it "should raise UnknownObjectException if the radio set doesn't exist" do
       expect { browser.radio_set(name: 'no_such_name').selected }.to raise_unknown_object_exception
@@ -305,18 +304,18 @@ describe "RadioSet" do
     end
   end
 
-  describe "eql?" do
+  describe "#eql?" do
     it 'returns true when located by any radio button' do
       rs = browser.radio_set(id: "new_user_newsletter_yes")
-      expect(browser.radio_set(id: /new_user_newsletter_yes/)).to eql rs
-      expect(browser.radio_set(name: "new_user_newsletter")).to eql rs
+      expect(browser.radio_set(id: /new_user_newsletter_no/)).to eql rs
+      expect(browser.radio_set(name: "new_user_newsletter", index: 2)).to eql rs
       expect(browser.radio_set(name: /new_user_newsletter/)).to eql rs
       expect(browser.radio_set(value: "yes")).to eql rs
       expect(browser.radio_set(value: /yes/)).to eql rs
       expect(browser.radio_set(class: "huge")).to eql rs
       expect(browser.radio_set(class: /huge/)).to eql rs
       expect(browser.radio_set(index: 0)).to eql rs
-      expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_yes']")).to eql rs
+      expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_probably']")).to eql rs
     end
   end
 

--- a/spec/watirspec/radio_set_spec.rb
+++ b/spec/watirspec/radio_set_spec.rb
@@ -1,0 +1,284 @@
+require "watirspec_helper"
+
+describe "RadioSet" do
+
+  before :each do
+    browser.goto(WatirSpec.url_for("forms_with_input_elements.html"))
+  end
+
+  # Exists method
+  describe "#exists?" do
+    it "returns true if matches any particular radio_set button" do
+      expect(browser.radio_set(id: "new_user_newsletter_yes")).to exist
+      expect(browser.radio_set(id: /new_user_newsletter_yes/)).to exist
+      expect(browser.radio_set(name: "new_user_newsletter")).to exist
+      expect(browser.radio_set(name: /new_user_newsletter/)).to exist
+      expect(browser.radio_set(value: "yes")).to exist
+      expect(browser.radio_set(value: /yes/)).to exist
+      expect(browser.radio_set(class: "huge")).to exist
+      expect(browser.radio_set(class: /huge/)).to exist
+      expect(browser.radio_set(index: 0)).to exist
+      expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_yes']")).to exist
+    end
+
+    it "returns the first radio set if given no args" do
+      expect(browser.radio_set).to exist
+    end
+
+    it "returns false if no radio button exists" do
+      expect(browser.radio_set(id: "no_such_id")).to_not exist
+      expect(browser.radio_set(id: /no_such_id/)).to_not exist
+      expect(browser.radio_set(name: "no_such_name")).to_not exist
+      expect(browser.radio_set(name: /no_such_name/)).to_not exist
+      expect(browser.radio_set(value: "no_such_value")).to_not exist
+      expect(browser.radio_set(value: /no_such_value/)).to_not exist
+      expect(browser.radio_set(text: "no_such_text")).to_not exist
+      expect(browser.radio_set(text: /no_such_text/)).to_not exist
+      expect(browser.radio_set(class: "no_such_class")).to_not exist
+      expect(browser.radio_set(class: /no_such_class/)).to_not exist
+      expect(browser.radio_set(index: 1337)).to_not exist
+      expect(browser.radio_set(xpath: "input[@id='no_such_id']")).to_not exist
+    end
+
+    it "raises TypeError when 'what' argument is invalid" do
+      expect {browser.radio_set(id: 3.14).exists?}.to raise_error(TypeError)
+    end
+
+    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
+      expect {browser.radio_set(no_such_how: 'some_value').exists?}.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
+    end
+  end
+
+  # Attribute methods
+  describe "#name" do
+    it "returns the name attribute if the radio exists" do
+      expect(browser.radio_set(id: 'new_user_newsletter_yes').name).to eq "new_user_newsletter"
+    end
+
+    it "returns an empty string if the radio exists and the attribute doesn't" do
+      expect(browser.radio_set(id: 'new_user_newsletter_absolutely').name).to eq ""
+    end
+
+    it "raises UnknownObjectException if the radio doesn't exist" do
+      expect {browser.radio_set(index: 1337).name}.to raise_unknown_object_exception
+    end
+  end
+
+  describe "#type" do
+    it "returns the type attribute if the radio set exists" do
+      expect(browser.radio_set.type).to eq "radio"
+    end
+
+    it "raises UnknownObjectException if the radio doesn't exist" do
+      expect {browser.radio_set(index: 1337).type}.to raise_unknown_object_exception
+    end
+  end
+
+  describe "#value" do
+    it "returns the value attributes of the selected radio button" do
+      expect(browser.radio_set(id: 'new_user_newsletter_yes').value).to eq 'yes'
+    end
+
+    it "raises UnknownObjectException if the radio doesn't exist" do
+      expect {browser.radio_set(index: 1337).value}.to raise_unknown_object_exception
+    end
+  end
+
+  describe "#text" do
+    it "returns the text of the selected radio button" do
+      expect(browser.radio_set(id: 'new_user_newsletter_yes').text).to eq 'Yes'
+    end
+
+    it "raises UnknownObjectException if the radio set doesn't exist" do
+      expect {browser.radio_set(index: 1337).text}.to raise_unknown_object_exception
+    end
+  end
+
+  describe "#respond_to?" do
+    it "returns true for all attribute methods" do
+      expect(browser.radio_set(index: 0)).to_not respond_to(:class_name)
+      expect(browser.radio_set(index: 0)).to_not respond_to(:id)
+      expect(browser.radio_set(index: 0)).to respond_to(:name)
+      expect(browser.radio_set(index: 0)).to_not respond_to(:title)
+      expect(browser.radio_set(index: 0)).to respond_to(:type)
+      expect(browser.radio_set(index: 0)).to respond_to(:value)
+      expect(browser.radio_set(index: 0)).to respond_to(:text)
+      expect(browser.radio_set(index: 0)).to_not respond_to(:clear)
+    end
+  end
+
+  # Access methods
+  describe "#enabled?" do
+    it "returns true if any radio button in the set is enabled" do
+      expect(browser.radio_set(id: "new_user_newsletter_nah")).to be_enabled
+      expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_nah']")).to be_enabled
+    end
+
+    it "returns false if all radio buttons are disabled" do
+      expect(browser.radio_set(id: "new_user_newsletter_none")).to_not be_enabled
+      expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_none']")).to_not be_enabled
+    end
+
+    it "raises UnknownObjectException if the radio button doesn't exist" do
+      expect {browser.radio_set(id: "no_such_id").enabled?}.to raise_unknown_object_exception
+      expect {browser.radio_set(xpath: "//input[@id='no_such_id']").enabled?}.to raise_unknown_object_exception
+    end
+  end
+
+  describe "#disabled?" do
+    it "returns false if the any radio button in the set is enabled" do
+      expect(browser.radio_set(id: "new_user_newsletter_nah")).to_not be_disabled
+      expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_nah']")).to_not be_disabled
+    end
+
+    it "returns true if all radio buttons are disabled" do
+      expect(browser.radio_set(id: "new_user_newsletter_none")).to be_disabled
+      expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_none']")).to be_disabled
+    end
+
+    it "should raise UnknownObjectException when the radio set does not exist" do
+      expect {browser.radio_set(index: 1337).disabled?}.to raise_unknown_object_exception
+    end
+  end
+
+  # Other
+  describe "#radio" do
+    it "returns an instance of Radio" do
+      radio = browser.radio_set(id: 'new_user_newsletter_yes').radio(id: 'new_user_newsletter_no')
+      expect(radio).to be_instance_of(Watir::Radio)
+      expect(radio.value).to eq "no"
+    end
+  end
+
+  describe "#radios" do
+    it "returns collection of all radios in the set" do
+      radios = browser.radio_set(id: 'new_user_newsletter_yes').radios
+      values = %w[yes no certainly nah nah]
+      expect(radios.map(&:value)).to match_array values
+    end
+  end
+
+  describe "#selected" do
+    it "should raise UnknownObjectException if the radio set doesn't exist" do
+      expect {browser.radio_set(name: 'no_such_name').selected}.to raise_unknown_object_exception
+    end
+
+    it "gets the currently selected radio" do
+      expect(browser.radio_set(id: 'new_user_newsletter_no').selected.text).to eq 'Yes'
+      expect(browser.radio_set(id: 'new_user_newsletter_no').selected.value).to eq 'yes'
+    end
+  end
+
+  describe "#include?" do
+    it "returns true if the given radio exists by text" do
+      expect(browser.radio_set(id: 'new_user_newsletter_no')).to include('Yes')
+    end
+
+    it "returns false if the given option doesn't exist" do
+      expect(browser.radio_set(id: 'new_user_newsletter_no')).to_not include('Mother')
+    end
+  end
+
+  describe "#selected?" do
+    it "returns true if the given option is selected by text" do
+      browser.radio_set(id: 'new_user_newsletter_yes').select('No')
+      expect(browser.radio_set(id: 'new_user_newsletter_yes')).to be_selected('No')
+    end
+
+    it "returns false if the given option is not selected by text" do
+      expect(browser.radio_set(id: 'new_user_newsletter_yes')).to_not be_selected('Probably')
+    end
+
+    it "raises UnknownObjectException if the radio button doesn't exist" do
+      expect {browser.radio_set(id: 'new_user_newsletter_yes').selected?('missing_option')}.to raise_unknown_object_exception
+    end
+  end
+
+  describe "#select" do
+    context "when interacting with radios" do
+      it "selects radio text by String" do
+        browser.radio_set(id: 'new_user_newsletter_yes').select("Probably")
+        expect(browser.radio_set(id: 'new_user_newsletter_yes').selected.text).to eq 'Probably'
+      end
+
+      it "selects radio text by Regexp" do
+        browser.radio_set(id: 'new_user_newsletter_yes').select(/Prob/)
+        expect(browser.radio_set(id: 'new_user_newsletter_yes').selected.text).to eq 'Probably'
+      end
+
+      it "selects the radio text when given an Xpath" do
+        browser.radio_set(xpath: "//input[@id='new_user_newsletter_no']").select("Probably")
+        expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_no']").selected.text).to eq 'Probably'
+      end
+
+      it "selects radio value by string" do
+        browser.radio_set(id: 'new_user_newsletter_yes').select("no")
+        expect(browser.radio_set(id: 'new_user_newsletter_yes').selected.text).to eq 'No'
+      end
+
+      it "selects radio value by regexp" do
+        browser.radio_set(id: 'new_user_newsletter_yes').select(/nah/)
+        expect(browser.radio_set(id: 'new_user_newsletter_yes').selected.text).to eq 'Probably'
+      end
+    end
+
+    it "returns the value selected" do
+      expect(browser.radio_set(id: 'new_user_newsletter_yes').select("no")).to eq "no"
+    end
+
+    it "fires onchange event when selecting a radio" do
+      browser.radio_set(id: 'new_user_newsletter_yes').radio(value: 'certainly').set
+      expect(messages).to eq ["changed: new_user_newsletter"]
+
+      browser.radio_set(id: 'new_user_newsletter_yes').radio(value: 'certainly').set
+      expect(messages).to eq ["changed: new_user_newsletter"] # no event fired here - didn't change
+
+      browser.radio_set(id: 'new_user_newsletter_yes').radio(value: 'yes').set
+      browser.radio_set(id: 'new_user_newsletter_yes').radio(value: 'certainly').set
+      expect(messages).to eq ["changed: new_user_newsletter", "clicked: new_user_newsletter_yes", "changed: new_user_newsletter"]
+    end
+
+    it "doesn't fire onchange event when selecting an already selected radio" do
+      browser.radio_set(id: 'new_user_newsletter_yes').radio(value: 'no').set
+
+      browser.radio_set(id: 'new_user_newsletter_yes').radio(value: 'no').set
+      expect(messages.size).to eq 1
+
+      browser.radio_set(id: 'new_user_newsletter_yes').radio(value: 'no').set
+      expect(messages.size).to eq 1
+    end
+  end
+
+  describe "eql?" do
+    it 'returns true when located by any radio button' do
+      rs = browser.radio_set(id: "new_user_newsletter_yes")
+      expect(browser.radio_set(id: /new_user_newsletter_yes/)).to eql rs
+      expect(browser.radio_set(name: "new_user_newsletter")).to eql rs
+      expect(browser.radio_set(name: /new_user_newsletter/)).to eql rs
+      expect(browser.radio_set(value: "yes")).to eql rs
+      expect(browser.radio_set(value: /yes/)).to eql rs
+      expect(browser.radio_set(class: "huge")).to eql rs
+      expect(browser.radio_set(class: /huge/)).to eql rs
+      expect(browser.radio_set(index: 0)).to eql rs
+      expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_yes']")).to eql rs
+    end
+  end
+
+  it "returns the text of the selected radio" do
+    expect(browser.radio_set(id: 'new_user_newsletter_yes').select("No")).to eq "No"
+  end
+
+  it "raises UnknownObjectException if the radio doesn't exist" do
+    expect {browser.radio_set(id: 'new_user_newsletter_yes').select("missing_option")}.to raise_unknown_object_exception
+    expect {browser.radio_set(id: 'new_user_newsletter_yes').select(/missing_option/)}.to raise_unknown_object_exception
+  end
+
+  it "raises ObjectDisabledException if the option is disabled" do
+    expect {browser.radio_set(id: 'new_user_newsletter_none').select("None")}.to raise_object_disabled_exception
+  end
+
+  it "raises a TypeError if argument is not a String, Regexp or Numeric" do
+    expect {browser.radio_set(id: 'new_user_newsletter_yes').select([])}.to raise_error(TypeError)
+  end
+
+end

--- a/spec/watirspec/radio_set_spec.rb
+++ b/spec/watirspec/radio_set_spec.rb
@@ -8,7 +8,7 @@ describe "RadioSet" do
 
   # Exists method
   describe "#exists?" do
-    it "returns true if matches any particular radio_set button" do
+    it "returns true if matches any radio_set button" do
       expect(browser.radio_set(id: "new_user_newsletter_yes")).to exist
       expect(browser.radio_set(id: /new_user_newsletter_yes/)).to exist
       expect(browser.radio_set(name: "new_user_newsletter")).to exist
@@ -19,10 +19,6 @@ describe "RadioSet" do
       expect(browser.radio_set(class: /huge/)).to exist
       expect(browser.radio_set(index: 0)).to exist
       expect(browser.radio_set(xpath: "//input[@id='new_user_newsletter_yes']")).to exist
-    end
-
-    it "returns the first radio set if given no args" do
-      expect(browser.radio_set).to exist
     end
 
     it "returns false if no radio button exists" do
@@ -40,12 +36,16 @@ describe "RadioSet" do
       expect(browser.radio_set(xpath: "input[@id='no_such_id']")).to_not exist
     end
 
+    it "returns the first radio set if given no args" do
+      expect(browser.radio_set).to exist
+    end
+
     it "raises TypeError when 'what' argument is invalid" do
-      expect {browser.radio_set(id: 3.14).exists?}.to raise_error(TypeError)
+      expect { browser.radio_set(id: 3.14).exists? }.to raise_error(TypeError)
     end
 
     it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect {browser.radio_set(no_such_how: 'some_value').exists?}.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
+      expect { browser.radio_set(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
     end
   end
 
@@ -55,12 +55,20 @@ describe "RadioSet" do
       expect(browser.radio_set(id: 'new_user_newsletter_yes').name).to eq "new_user_newsletter"
     end
 
-    it "returns an empty string if the radio exists and the attribute doesn't" do
+    it "returns an empty string if the radio exists and there is not name" do
       expect(browser.radio_set(id: 'new_user_newsletter_absolutely').name).to eq ""
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect {browser.radio_set(index: 1337).name}.to raise_unknown_object_exception
+      expect { browser.radio_set(index: 1337).name }.to raise_unknown_object_exception
+    end
+  end
+
+  context "without name specified" do
+    it "Finds specified radio" do
+      expect(browser.radio_set(id: 'new_user_newsletter_absolutely').count).to eq 1
+      expect(browser.radio_set(id: 'new_user_newsletter_absolutely').radios.size).to eq 1
+      expect(browser.radio_set(id: 'new_user_newsletter_absolutely').radio(value: 'absolutely').exist?).to be true
     end
   end
 
@@ -70,7 +78,7 @@ describe "RadioSet" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect {browser.radio_set(index: 1337).type}.to raise_unknown_object_exception
+      expect { browser.radio_set(index: 1337).type }.to raise_unknown_object_exception
     end
   end
 
@@ -80,7 +88,7 @@ describe "RadioSet" do
     end
 
     it "raises UnknownObjectException if the radio doesn't exist" do
-      expect {browser.radio_set(index: 1337).value}.to raise_unknown_object_exception
+      expect { browser.radio_set(index: 1337).value }.to raise_unknown_object_exception
     end
   end
 
@@ -90,7 +98,7 @@ describe "RadioSet" do
     end
 
     it "raises UnknownObjectException if the radio set doesn't exist" do
-      expect {browser.radio_set(index: 1337).text}.to raise_unknown_object_exception
+      expect { browser.radio_set(index: 1337).text }.to raise_unknown_object_exception
     end
   end
 
@@ -120,8 +128,8 @@ describe "RadioSet" do
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      expect {browser.radio_set(id: "no_such_id").enabled?}.to raise_unknown_object_exception
-      expect {browser.radio_set(xpath: "//input[@id='no_such_id']").enabled?}.to raise_unknown_object_exception
+      expect { browser.radio_set(id: "no_such_id").enabled? }.to raise_unknown_object_exception
+      expect { browser.radio_set(xpath: "//input[@id='no_such_id']").enabled? }.to raise_unknown_object_exception
     end
   end
 
@@ -137,30 +145,78 @@ describe "RadioSet" do
     end
 
     it "should raise UnknownObjectException when the radio set does not exist" do
-      expect {browser.radio_set(index: 1337).disabled?}.to raise_unknown_object_exception
+      expect { browser.radio_set(index: 1337).disabled? }.to raise_unknown_object_exception
     end
   end
 
   # Other
   describe "#radio" do
-    it "returns an instance of Radio" do
+    it "returns first instance of Radio if no arguments specified" do
+      radio = browser.radio_set(id: 'new_user_newsletter_yes').radio
+      expect(radio).to be_instance_of(Watir::Radio)
+      expect(radio.value).to eq "yes"
+    end
+
+    it "returns provided instance of Radio if element has no name" do
+      radio = browser.radio_set(id: 'new_user_newsletter_absolutely').radio
+      expect(radio).to be_instance_of(Watir::Radio)
+      expect(radio.value).to eq "absolutely"
+    end
+
+    it "returns an instance of Radio matching the provided value" do
       radio = browser.radio_set(id: 'new_user_newsletter_yes').radio(id: 'new_user_newsletter_no')
       expect(radio).to be_instance_of(Watir::Radio)
       expect(radio.value).to eq "no"
     end
-  end
 
-  describe "#radios" do
-    it "returns collection of all radios in the set" do
-      radios = browser.radio_set(id: 'new_user_newsletter_yes').radios
-      values = %w[yes no certainly nah nah]
-      expect(radios.map(&:value)).to match_array values
+    it "does not exist when using bad locator" do
+      radio = browser.radio_set(id: 'new_user_newsletter_yes').radio(id: 'new_user_newsletter_not_there')
+      expect(radio).to_not exist
+    end
+
+    it "raises Unknown Object Exception if it specifies the wrong name" do
+      radio_set = browser.radio_set(id: 'new_user_newsletter_yes')
+      expect { radio_set.radio(name: '') }.to raise_unknown_object_exception
+      expect { radio_set.radio(name: 'foo') }.to raise_unknown_object_exception
     end
   end
 
+  describe "#radios" do
+    it "returns array of all radios in the set if no arguments specified" do
+      radios = browser.radio_set(id: 'new_user_newsletter_yes').radios
+      expect(radios).to be_instance_of(Watir::RadioCollection)
+      values = %w[yes no certainly nah nah]
+      expect(radios.map(&:value)).to match_array values
+    end
+
+    it "returns RadioCollection matching the provided value" do
+      radios = browser.radio_set(id: 'new_user_newsletter_yes').radios(id: /new_user_newsletter_n/)
+      expect(radios).to be_instance_of(Watir::RadioCollection)
+      expect(radios.map(&:value)).to eq %w[no nah]
+    end
+
+    it "returns provided instance of Radio if element has no name" do
+      radios = browser.radio_set(id: 'new_user_newsletter_absolutely').radios
+      expect(radios).to be_instance_of(Watir::RadioCollection)
+      expect(radios.size).to eq 1
+      expect(radios.first.value).to eq "absolutely"
+    end
+
+    it "returns empty collection if specified radio does not exist" do
+      radios = browser.radio_set(id: 'new_user_newsletter_yes').radios(id: 'new_user_newsletter_not_there')
+      expect(radios).to be_empty
+    end
+
+    it "raises empty collection if it specifies the wrong name" do
+      radio_set = browser.radio_set(id: 'new_user_newsletter_yes')
+      expect { radio_set.radios(name: '') }.to raise_unknown_object_exception
+    end
+  end
+
+
   describe "#selected" do
     it "should raise UnknownObjectException if the radio set doesn't exist" do
-      expect {browser.radio_set(name: 'no_such_name').selected}.to raise_unknown_object_exception
+      expect { browser.radio_set(name: 'no_such_name').selected }.to raise_unknown_object_exception
     end
 
     it "gets the currently selected radio" do
@@ -190,7 +246,7 @@ describe "RadioSet" do
     end
 
     it "raises UnknownObjectException if the radio button doesn't exist" do
-      expect {browser.radio_set(id: 'new_user_newsletter_yes').selected?('missing_option')}.to raise_unknown_object_exception
+      expect { browser.radio_set(id: 'new_user_newsletter_yes').selected?('missing_option') }.to raise_unknown_object_exception
     end
   end
 
@@ -269,16 +325,16 @@ describe "RadioSet" do
   end
 
   it "raises UnknownObjectException if the radio doesn't exist" do
-    expect {browser.radio_set(id: 'new_user_newsletter_yes').select("missing_option")}.to raise_unknown_object_exception
-    expect {browser.radio_set(id: 'new_user_newsletter_yes').select(/missing_option/)}.to raise_unknown_object_exception
+    expect { browser.radio_set(id: 'new_user_newsletter_yes').select("missing_option") }.to raise_unknown_object_exception
+    expect { browser.radio_set(id: 'new_user_newsletter_yes').select(/missing_option/) }.to raise_unknown_object_exception
   end
 
   it "raises ObjectDisabledException if the option is disabled" do
-    expect {browser.radio_set(id: 'new_user_newsletter_none').select("None")}.to raise_object_disabled_exception
+    expect { browser.radio_set(id: 'new_user_newsletter_none').select("None") }.to raise_object_disabled_exception
   end
 
   it "raises a TypeError if argument is not a String, Regexp or Numeric" do
-    expect {browser.radio_set(id: 'new_user_newsletter_yes').select([])}.to raise_error(TypeError)
+    expect { browser.radio_set(id: 'new_user_newsletter_yes').select([]) }.to raise_error(TypeError)
   end
 
 end


### PR DESCRIPTION
This still needs all of documentation in the class itself, but I wanted to run the code by people before I started tidying it up.

Radio buttons with the same name are not independent because only one can be selected at a time. Ideally a user would be able to treat it just like a Select List and choose amongst the options available. I literally took the `select_list_spec.rb` file to create the `radio_set_spec.rb` file and tweaked it based on what makes sense for radio buttons vs options. There are probably a bunch more specs I'm missing since `RadioSet` doesn't inherit from anything.

This should probably include Enumerable for iteration... Yeah, this needs more work.

Also, this addresses the age old question of what `Radio#text` should return. :)