### PR TITLE
get specs passing for chromedriver 2.32

### DIFF
--- a/spec/watirspec/elements/filefield_spec.rb
+++ b/spec/watirspec/elements/filefield_spec.rb
@@ -148,24 +148,12 @@ describe "FileField" do
       end
 
       not_compliant_on :internet_explorer do
-        bug "Raises File not found error - File Bug Report", :firefox do
-          it "does not raise an error if the file does not exist" do
-            path = File.join(Dir.tmpdir, 'unlikely-to-exist')
-            browser.file_field.value = path
-
-            expected = path
-            expected.gsub!("/", "\\") if Selenium::WebDriver::Platform.windows?
-
-            expect(browser.file_field.value).to include(File.basename(expected)) # only some browser will return the full path
-          end
-        end
-
         not_compliant_on %i(chrome windows) do
-          bug "Raises File not found error - File Bug Report", :firefox do
+          bug "Raises InvalidArgumentError: File not found", :firefox do
             it "does not alter its argument" do
-              value = '/foo/bar'
+              value = File.expand_path 'support/travis.sh'
               browser.file_field.value = value
-              expect(value).to eq '/foo/bar'
+              expect(value).to match /support\/travis\.sh$/
             end
           end
         end


### PR DESCRIPTION
Is this actually desired behavior? "does not raise an error if the file does not exist"
w3c doesn't say anything about it one way or another.

Alternative is to specify that this spec is not compliant on Chrome instead of deleting it.