### PR TITLE
Remove remaining textarea code from TextField

### DIFF
--- a/lib/watir/elements/text_field.rb
+++ b/lib/watir/elements/text_field.rb
@@ -4,15 +4,12 @@ module Watir
 
     NON_TEXT_TYPES = %w[file radio checkbox submit reset image button hidden range color]
 
-    inherit_attributes_from Watir::TextArea
-    remove_method :type # we want Input#type here, which was overriden by TextArea's attributes
-
     protected
 
     def selector_string
       selector = @selector.dup
       selector[:type] = '(any text type)'
-      selector[:tag_name] = "input or textarea"
+      selector[:tag_name] = "input"
 
       if @query_scope.is_a?(Browser) || @query_scope.is_a?(IFrame)
         super


### PR DESCRIPTION
Locating `textarea` by `#text_field` was removed in 6.0.0. This pull request removes some lingering code in `TextField`.