### PR TITLE
Select exact matches when using Select#select_by! with String

### DIFF
--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -162,7 +162,7 @@ module Watir
     def select_by!(str_or_rx, number)
       js_rx = case str_or_rx
               when String
-                str_or_rx
+                "^#{str_or_rx}$"
               when Regexp
                 str_or_rx.inspect.sub('\\A', '^').sub('\\Z', '$').sub('\\z', '$').sub(/^\//, '').sub(/\/[a-z]*$/, '')
                     .gsub(/\(\?#.+\)/, '').gsub(/\(\?-\w+:/, '(')

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -432,6 +432,14 @@ describe "SelectList" do
       browser.select_list(id: 'single-quote').select!("'foo'")
     end
 
+    it "selects exact matches when using String" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select!("Latin")
+      selected_options = browser.select_list(name: "new_user_languages").selected_options.map(&:text)
+      expect(selected_options).not_to include("Azeri - Latin")
+      expect(selected_options).to include("Latin")
+    end
+
     it "raises NoValueFoundException if the option doesn't exist" do
       expect { browser.select_list(id: "new_user_country").select!("missing_option") }.to raise_no_value_found_exception
       expect { browser.select_list(id: "new_user_country").select!(/missing_option/) }.to raise_no_value_found_exception

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -53,6 +53,8 @@
                 <option selected="selected" value="3" label="NO">Norwegian</option>
                 <option value="4" disabled>Russian</option>
                 <option>Swedish</option>
+                <option>Azeri - Latin</option>
+                <option>Latin</option>
             </select> <br />
             <label for="new_user_portrait">Portrait</label>
             <input type="file" name="new_user_portrait" id="new_user_portrait" class="portrait" title="Smile!" onchange="WatirSpec.addMessage(this.value)" /> <br />


### PR DESCRIPTION
When using `#Select#select!` and `#Select#select_all!` with a `String` parameter, options are selected by partial matches. They should be selected by exact matches.

For example, in:
~~~~~~~~html
<select id="mySelect" size="4" multiple="multiple">
  <option value="a">Apple</option>
  <option value="p">Pear</option>
  <option value="b">Banana</option>
  <option value="o">Orange</option>
</select>
~~~~~~~~

Multiple get selected when only one matches the specified value:

~~~~~~~~ruby
b.select.select!('a')
#=> "Apple"

b.select.selected_options.map(&:text)
["Apple", "Pear"]
~~~~~~~~