### PR TITLE
don't run after hooks when alert is present

### DIFF
--- a/lib/watir/after_hooks.rb
+++ b/lib/watir/after_hooks.rb
@@ -66,7 +66,7 @@ module Watir
     #
 
     def run
-      if @after_hooks.any? && @browser.window.present?
+      if @after_hooks.any? && @browser.window.present? && !@browser.alert.exists?
         each { |after_hook| after_hook.call(@browser) }
       end
     end

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -125,21 +125,17 @@ describe "Browser::AfterHooks" do
     end
 
     not_compliant_on :safari, :headless do
-      it "raises UnhandledAlertError error when running error checks with alert present" do
-        url = WatirSpec.url_for("alerts.html")
-        @page_after_hook = Proc.new { browser.url }
+      it "does not run error checks with alert present" do
+        browser.goto WatirSpec.url_for("alerts.html")
+
+        @page_after_hook = Proc.new { @yield = browser.title == "Alerts" }
         browser.after_hooks.add @page_after_hook
-        browser.goto url
 
-        not_compliant_on :firefox do
-          expect { browser.button(id: "alert").click }.to raise_error(Selenium::WebDriver::Error::UnhandledAlertError)
-        end
-
-        deviates_on :firefox do
-          expect { browser.button(id: "alert").click }.to raise_error(Selenium::WebDriver::Error::UnexpectedAlertOpenError)
-        end
+        browser.button(id: "alert").click
+        expect(@yield).to be_nil
 
         browser.alert.ok
+        expect(@yield).to eq true
       end
     end
 


### PR DESCRIPTION
Geckodriver has changed the default Firefox implementation.
Calling `browser.window.present?` no longer closes an alert if present, which was the problem when we discussed error checkers back in #283 

If we are ok actually deprecating Legacy Firefox support with AfterHooks, this will make a lot of things significantly easier.