### PR TITLE
change order of locator class selection

### DIFF
--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -115,6 +115,7 @@ require the watir_css gem - https://github.com/watir/watir_css
   end
 
 end
+require 'watir/locators'
 
 require 'watir/attribute_helper'
 require 'watir/row_container'
@@ -152,7 +153,6 @@ require 'watir/elements/text_field'
 require 'watir/elements/input'
 require 'watir/radio_set'
 
-require 'watir/locators'
 require 'watir/aliases'
 
 Watir.tag_to_class.freeze

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -6,6 +6,7 @@ module Watir
 
   class ElementCollection
     include Enumerable
+    include Locators::ClassHelpers
 
     def initialize(query_scope, selector)
       @query_scope = query_scope
@@ -127,28 +128,6 @@ module Watir
       locator = locator_class.new(@query_scope, @selector, selector_builder, element_validator)
 
       @elements ||= locator.locate_all
-    end
-
-    def locator_class
-      Kernel.const_get("#{Watir.locator_namespace}::#{element_class_name}::Locator")
-    rescue NameError
-      Kernel.const_get("#{Watir.locator_namespace}::Element::Locator")
-    end
-
-    def element_validator_class
-      Kernel.const_get("#{Watir.locator_namespace}::#{element_class_name}::Validator")
-    rescue NameError
-      Kernel.const_get("#{Watir.locator_namespace}::Element::Validator")
-    end
-
-    def selector_builder_class
-      Kernel.const_get("#{Watir.locator_namespace}::#{element_class_name}::SelectorBuilder")
-    rescue NameError
-      Kernel.const_get("#{Watir.locator_namespace}::Element::SelectorBuilder")
-    end
-
-    def element_class_name
-      element_class.to_s.split('::').last
     end
 
     def element_class

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -13,6 +13,7 @@ module Watir
     include Waitable
     include Adjacent
     include JSExecution
+    include Locators::ClassHelpers
 
     attr_accessor :keyword
     attr_reader :selector
@@ -625,26 +626,8 @@ module Watir
       raise unknown_exception, "element located, but timed out after #{Watir.default_timeout} seconds, waiting for #{inspect} to be present"
     end
 
-    def locator_class
-      Kernel.const_get("#{Watir.locator_namespace}::#{element_class_name}::Locator")
-    rescue NameError
-      Kernel.const_get("#{Watir.locator_namespace}::Element::Locator")
-    end
-
-    def element_validator_class
-      Kernel.const_get("#{Watir.locator_namespace}::#{element_class_name}::Validator")
-    rescue NameError
-      Kernel.const_get("#{Watir.locator_namespace}::Element::Validator")
-    end
-
-    def selector_builder_class
-      Kernel.const_get("#{Watir.locator_namespace}::#{element_class_name}::SelectorBuilder")
-    rescue NameError
-      Kernel.const_get("#{Watir.locator_namespace}::Element::SelectorBuilder")
-    end
-
-    def element_class_name
-      self.class.name.split('::').last
+    def element_class
+      self.class
     end
 
     def attribute?(attribute_name)

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -21,3 +21,40 @@ require 'watir/locators/text_field/locator'
 require 'watir/locators/text_field/selector_builder'
 require 'watir/locators/text_field/selector_builder/xpath'
 require 'watir/locators/text_field/validator'
+
+module Watir
+  module Locators
+    module ClassHelpers
+      def locator_class
+        class_from_string("#{Watir.locator_namespace}::#{element_class_name}::Locator") ||
+            class_from_string("Watir::Locators::#{element_class_name}::Locator") ||
+            class_from_string("#{Watir.locator_namespace}::Element::Locator") ||
+            Watir::Locators::Element::Locator
+      end
+
+      def element_validator_class
+        class_from_string("#{Watir.locator_namespace}::#{element_class_name}::Validator") ||
+            class_from_string("Watir::Locators::#{element_class_name}::Validator") ||
+            class_from_string("#{Watir.locator_namespace}::Element::Validator") ||
+            Watir::Locators::Element::Validator
+      end
+
+      def selector_builder_class
+        class_from_string("#{Watir.locator_namespace}::#{element_class_name}::SelectorBuilder") ||
+            class_from_string("Watir::Locators::#{element_class_name}::SelectorBuilder") ||
+            class_from_string("#{Watir.locator_namespace}::Element::SelectorBuilder") ||
+            Watir::Locators::Element::SelectorBuilder
+      end
+
+      def class_from_string(string)
+        Kernel.const_get(string)
+      rescue NameError
+        nil
+      end
+
+      def element_class_name
+        element_class.to_s.split('::').last
+      end
+    end
+  end
+end


### PR DESCRIPTION
This shouldn't affect Watizzle other than allowing you to delete [these lines](https://github.com/p0deje/watizzle/blob/master/lib/watizzle.rb#L14-L18), but I notice you don't use any special processing from Watir's subtyped elements, anyway, is that intentional? 

For WatirAngular it allows getting rid of [these lines](https://github.com/titusfortner/watir_angular/blob/master/lib/watir_angular.rb#L29-L39).

Then again, I'm essentially subclassing each special subtype to get their custom behaviors and including a module of the logic the gem is adding: https://github.com/titusfortner/watir_angular/blob/master/lib/watir_angular/locators/element/selector_builder.rb

Does this fit with what you were considering for this extension approach, or is there a better way I'm not recognizing? 