### PR TITLE
element and #elements support the new :class locators

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -79,7 +79,7 @@ module Watir
           how, what = @selector.to_a.first
           selector_builder.check_type(how, what)
 
-          if WD_FINDERS.include?(how)
+          if wd_supported?(how, what)
             wd_find_first_by(how, what)
           else
             find_first_by_multiple
@@ -118,7 +118,7 @@ module Watir
           return [what] if how == :element
           selector_builder.check_type how, what
 
-          if WD_FINDERS.include?(how)
+          if wd_supported?(how, what)
             wd_find_all_by(how, what)
           else
             find_all_by_multiple
@@ -270,6 +270,12 @@ module Watir
           scope.find_elements(how, what)
         end
 
+        def wd_supported?(how, what)
+          return false unless WD_FINDERS.include?(how)
+          return false unless what.kind_of?(String) || what.kind_of?(Regexp)
+          return false if [:class, :class_name].include?(how) && what.kind_of?(String) && what.include?(' ')
+          true
+        end
       end
     end
   end

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -59,6 +59,24 @@ describe Watir::Locators::Element::Locator do
 
         locate_one [:data_view, false]
       end
+
+      it "handles selector with class attribute presence" do
+        expect_one :xpath, ".//*[@class]"
+
+        locate_one class: true
+      end
+
+      it "handles selector with multiple classes in array" do
+        expect_one :xpath, ".//*[(contains(concat(' ', @class, ' '), ' a ') and contains(concat(' ', @class, ' '), ' b '))]"
+
+        locate_one class: ["a", "b"]
+      end
+
+      it "handles selector with multiple classes in string" do
+        expect_one :xpath, ".//*[contains(concat(' ', @class, ' '), ' a b ')]"
+
+        locate_one class: "a b"
+      end
     end
 
     describe "with special cased selectors" do
@@ -345,6 +363,24 @@ describe Watir::Locators::Element::Locator do
         locate_all [:tag_name, "div",
                     :dir     , "foo",
                     :title   , 'bar']
+      end
+
+      it "handles selector with class attribute presence" do
+        expect_all :xpath, ".//*[@class]"
+
+        locate_all class: true
+      end
+
+      it "handles selector with multiple classes in array" do
+        expect_all :xpath, ".//*[(contains(concat(' ', @class, ' '), ' a ') and contains(concat(' ', @class, ' '), ' b '))]"
+
+        locate_all class: ["a", "b"]
+      end
+
+      it "handles selector with multiple classes in string" do
+        expect_all :xpath, ".//*[contains(concat(' ', @class, ' '), ' a b ')]"
+
+        locate_all class: "a b"
       end
     end
 

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -308,6 +308,11 @@ describe "Element" do
     it "raises ArgumentError error if selector hash with :css has multiple entries" do
       expect { browser.div(css: "div", class: "foo").exists? }.to raise_error(ArgumentError)
     end
+
+    it "finds element by Selenium name locator" do
+      expect(browser.element(name: "new_user_first_name")).to exist
+      expect(browser.element(name: /new_user_first_name/)).to exist
+    end
   end
 
   describe '#send_keys' do


### PR DESCRIPTION
Fixes Issue #658.

Note that in terms of the `Locator#wd_supported?`, I left Regexp values as being treated as supported by webdriver. I originally thought I could remove the `Locator#all_elements` calls and just fall back to the find by multiple methods. While it worked in most cases, it failed when using `name: /regexp/` (due to invalid attribute).