### PR TITLE
Support multiple parameters in UserEditable#set!

### DIFF
--- a/lib/watir/user_editable.rb
+++ b/lib/watir/user_editable.rb
@@ -22,7 +22,9 @@ module Watir
     # @param [String] input_value
     #
 
-    def set!(input_value)
+    def set!(*args)
+      raise ArgumentError, "#set! does not support special keys, use #set instead" if args.any? { |v| v.kind_of?(::Symbol) }
+      input_value = args.join
       set input_value[0]
       element_call { execute_js(:setValue, @element, input_value[0..-2]) }
       append(input_value[-1])

--- a/spec/watirspec/elements/text_field_spec.rb
+++ b/spec/watirspec/elements/text_field_spec.rb
@@ -297,6 +297,16 @@ describe "TextField" do
       expect(browser.text_field(name: "new_user_occupation").value).to eq "ĳĳ"
     end
 
+    it "sets the value to a concatenation of multiple arguments" do
+      browser.text_field(id: 'new_user_email').set('Bye', 'Cruel', 'World')
+      expect(browser.text_field(id: "new_user_email").value).to eq 'ByeCruelWorld'
+    end
+
+    it "sets the value to blank when no arguments are provided" do
+      browser.text_field(id: 'new_user_email').set
+      expect(browser.text_field(id: "new_user_email").value).to eq ''
+    end
+
     it "raises UnknownObjectException if the text field doesn't exist" do
       expect { browser.text_field(id: "no_such_id").set('secret') }.to raise_unknown_object_exception
     end
@@ -331,6 +341,20 @@ describe "TextField" do
     it "is able to set multi-byte characters" do
       browser.text_field(name: "new_user_occupation").set!("ĳĳ")
       expect(browser.text_field(name: "new_user_occupation").value).to eq "ĳĳ"
+    end
+
+    it "sets the value to a concatenation of multiple arguments" do
+      browser.text_field(id: 'new_user_email').set!('Bye', 'Cruel', 'World')
+      expect(browser.text_field(id: "new_user_email").value).to eq 'ByeCruelWorld'
+    end
+
+    it "sets the value to blank when no arguments are provided" do
+      browser.text_field(id: 'new_user_email').set!
+      expect(browser.text_field(id: "new_user_email").value).to eq ''
+    end
+
+    it "raises ArgumentError for special keys" do
+      expect { browser.text_field(id: 'new_user_email').set!('a', :tab) }.to raise_error(ArgumentError)
     end
 
     it "raises UnknownObjectException if the text field doesn't exist" do


### PR DESCRIPTION
Depending on your expectations, fixes or partially fixes, #651.

The changes:
* Allow `#set!` to accept multiple parameters.
* Raises an exception if one of the parameters is a `Symbol` (ie special key). While the example in #651 included `:tab`, I am not convinced that `#set!` should support it. 