### PR TITLE
Support selecting a list of options

### DIFF
--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -41,8 +41,9 @@ module Watir
     # @return [String] The text of the option selected. If multiple options match, returns the first match.
     #
 
-    def select(str_or_rx)
-      select_by str_or_rx
+    def select(*str_or_rx)
+      results = str_or_rx.flatten.map { |v| select_by v}
+      results.first
     end
 
     #
@@ -53,8 +54,9 @@ module Watir
     # @return [String] The text of the first option selected.
     #
 
-    def select_all(str_or_rx)
-      select_all_by str_or_rx
+    def select_all(*str_or_rx)
+      results = str_or_rx.flatten.map { |v| select_all_by v }
+      results.first
     end
 
     #
@@ -64,8 +66,9 @@ module Watir
     # @raise [Watir::Exception::NoValueFoundException] if the value does not exist.
     #
 
-    def select!(str_or_rx)
-      select_by!(str_or_rx, :single)
+    def select!(*str_or_rx)
+      results = str_or_rx.flatten.map { |v| select_by!(v, :single) }
+      results.first
     end
 
     #
@@ -75,8 +78,9 @@ module Watir
     # @raise [Watir::Exception::NoValueFoundException] if the value does not exist.
     #
 
-    def select_all!(str_or_rx)
-      select_by!(str_or_rx, :multiple)
+    def select_all!(*str_or_rx)
+      results = str_or_rx.flatten.map { |v| select_by!(v, :multiple) }
+      results.first
     end
 
     #

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -303,6 +303,18 @@ describe "SelectList" do
       expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
     end
 
+    it "selects each item in an Array" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select(["Danish", "Swedish"])
+      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
+    end
+
+    it "selects each item in a parameter list" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select("Danish", "Swedish")
+      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
+    end
+
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
       it "selects empty options" do
         browser.select_list(id: "delete_user_username").select("")
@@ -364,7 +376,7 @@ describe "SelectList" do
     end
 
     it "raises a TypeError if argument is not a String, Regexp or Numeric" do
-      expect { browser.select_list(id: "new_user_languages").select([]) }.to raise_error(TypeError)
+      expect { browser.select_list(id: "new_user_languages").select({}) }.to raise_error(TypeError)
     end
   end
 
@@ -416,6 +428,18 @@ describe "SelectList" do
       expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
     end
 
+    it "selects each item in an Array" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select!(["Danish", "Swedish"])
+      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
+    end
+
+    it "selects each item in a parameter list" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select!("Danish", "Swedish")
+      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "Swedish"]
+    end
+
     bug "https://bugzilla.mozilla.org/show_bug.cgi?id=1255957", :firefox do
       it "selects empty options" do
         browser.select_list(id: "delete_user_username").select!("")
@@ -452,7 +476,7 @@ describe "SelectList" do
 
     it "raises a TypeError if argument is not a String, Regexp or Numeric" do
       browser.select_list(id: "new_user_languages").clear
-      expect { browser.select_list(id: "new_user_languages").select!([]) }.to raise_error(TypeError)
+      expect { browser.select_list(id: "new_user_languages").select!({}) }.to raise_error(TypeError)
     end
   end
 
@@ -467,6 +491,18 @@ describe "SelectList" do
       browser.select_list(name: "new_user_languages").clear
       browser.select_list(name: "new_user_languages").select_all(/NO|EN/)
       expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["EN", "NO"]
+    end
+
+    it "selects all options in an Array" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select_all([/ish/, /Latin/])
+      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "EN", "Swedish", "Azeri - Latin", "Latin"]
+    end
+
+    it "selects all options in a parameter list" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select_all(/ish/, /Latin/)
+      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "EN", "Swedish", "Azeri - Latin", "Latin"]
     end
 
     it "returns the first matching value if there are multiple matches" do
@@ -491,6 +527,18 @@ describe "SelectList" do
       browser.select_list(name: "new_user_languages").clear
       browser.select_list(name: "new_user_languages").select_all!(/NO|EN/)
       expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["EN", "NO"]
+    end
+
+    it "selects all options in an Array" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select_all!([/ish/, /Latin/])
+      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "EN", "Swedish", "Azeri - Latin", "Latin"]
+    end
+
+    it "selects all options in a parameter list" do
+      browser.select_list(name: "new_user_languages").clear
+      browser.select_list(name: "new_user_languages").select_all!(/ish/, /Latin/)
+      expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq ["Danish", "EN", "Swedish", "Azeri - Latin", "Latin"]
     end
 
     it "returns the first matching value if there are multiple matches" do


### PR DESCRIPTION
To select multiple options in a multi-select lists, currently requires calling `#select` multiple times:

~~~~~~~~ruby
s = browser.select_list(id: 'has_multiple')
s.select('first')
s.select('second')
~~~~~~~~

This pull request adds support for selecting multiple options at once:

~~~~~~~~ruby
s = browser.select_list(id: 'has_multiple')

# via array
s.select(['first', 'second'])

# via multiple parameters
s.select('first', 'second')
~~~~~~~~

Not only does this make the Watir syntax nicer for multi-selects, it should help page object designs that use a populate page type method.