### PR TITLE
Selenium's link_text and partial_link_text locators

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -36,7 +36,7 @@ module Watir
         end
 
         def locate
-          e = by_id and return e # short-circuit if :id is given
+          e = by_se_locator and return e # short-circuit if selenium locator is given
 
           element = if @selector.size == 1
                       find_first_by_one
@@ -61,18 +61,23 @@ module Watir
 
         private
 
-        def by_id
+        def by_se_locator
           selector = @selector.dup
-          id = selector.delete(:id)
-          return if !id.is_a?(String) || selector[:adjacent]
-
+          return if selector[:adjacent]
           tag_name = selector.delete(:tag_name)
-          return unless selector.empty? # multiple attributes
 
-          element = locate_element(:id, id)
-          return if tag_name && !element_validator.validate(element, {tag_name: tag_name})
+          %i[id link_text partial_link_text].each do |sel|
+            value = selector.delete(sel)
+            next unless value
+            return unless value.is_a?(String)
+            return if value && !selector.empty? # multiple attributes
+            @element = locate_element(sel, value)
+            break if @element
+          end
+          return unless @element
+          return if tag_name && !element_validator.validate(@element, {tag_name: tag_name})
 
-          element
+          @element
         end
 
         def find_first_by_one

--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -153,7 +153,7 @@ module Watir
 
         def fetch_value(element, how)
           case how
-          when :text
+          when :text, :link_text, :partial_link_text
             element.text
           when :tag_name
             element.tag_name.downcase
@@ -197,7 +197,7 @@ module Watir
 
           if how == :xpath && can_convert_regexp_to_contains?
             rx_selector.each do |key, value|
-              next if key == :tag_name || key == :text
+              next if %i[tag_name text link_text partial_link_text].include? key
 
               predicates = regexp_selector_to_predicates(key, value)
               what = "(#{what})[#{predicates.join(' and ')}]" unless predicates.empty?

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -35,6 +35,9 @@ module Watir
               raise TypeError, "expected TrueClass or FalseClass, got #{what.inspect}:#{what.class}"
             end
           else
+            if %i[link_text partial_link_text].include?(how) && @selector.key?(:tag_name) && @selector[:tag_name] != 'a'
+              raise TypeError, ":#{how} locator can only be used with link elements"
+            end
             if what.is_a?(Array) && how != :class && how != :class_name
               raise TypeError, "Only :class locator can have a value of an Array"
             end
@@ -66,7 +69,7 @@ module Watir
 
         def normalize_selector(how, what)
           case how
-          when :tag_name, :text, :xpath, :index, :class, :label, :css, :visible, :adjacent
+          when :tag_name, :text, :xpath, :index, :class, :label, :css, :visible, :adjacent, :link_text, :partial_link_text
             # include :class since the valid attribute is 'class_name'
             # include :for since the valid attribute is 'html_for'
             [how, what]

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -313,6 +313,16 @@ describe Watir::Locators::Element::Locator do
     end
 
     describe "errors" do
+      it "raises a TypeError if using link_text with a non-link element" do
+        expect { locate_one(tag_name: "div", link_text: "bar") }.to \
+        raise_error(TypeError, %[:link_text locator can only be used with link elements])
+      end
+
+      it "raises a TypeError if using partial_link_text with a non-link element" do
+        expect { locate_one(tag_name: "div", partial_link_text: "bar") }.to \
+        raise_error(TypeError, %[:partial_link_text locator can only be used with link elements])
+      end
+
       it "raises a TypeError if :index is not a Integer" do
         expect { locate_one(tag_name: "div", index: "bar") }.to \
         raise_error(TypeError, %[expected Integer, got "bar":String])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'webdrivers'
 require 'locator_spec_helper'
 require 'rspec'
 
-SELENIUM_SELECTORS = %i(class class_name css id tag_name xpath)
+SELENIUM_SELECTORS = %i(class class_name css id tag_name xpath link_text partial_link_text)
 
 if ENV['RELAXED_LOCATE'] == "false"
   Watir.relaxed_locate = false

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -18,6 +18,11 @@ describe "Link" do
       not_compliant_on :internet_explorer do
         expect(browser.link(href: 'non_control_elements.html')).to exist
       end
+      expect(browser.link(link_text: "Link 2")).to exist
+      expect(browser.link(link_text: /Link 2/)).to exist
+      expect(browser.link(partial_link_text: "Link")).to exist
+      expect(browser.link(partial_link_text: /Link 2/)).to exist
+
       expect(browser.link(href: /non_control_elements.html/)).to exist
       expect(browser.link(index: 1)).to exist
       expect(browser.link(xpath: "//a[@id='link_2']")).to exist

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -20,8 +20,12 @@ describe "Link" do
       end
       expect(browser.link(link_text: "Link 2")).to exist
       expect(browser.link(link_text: /Link 2/)).to exist
+      expect(browser.link(link_text: "Link 2", class: 'external')).to exist
+      expect(browser.link(link_text: /Link 2/, class: 'external')).to exist
       expect(browser.link(partial_link_text: "Link")).to exist
       expect(browser.link(partial_link_text: /Link 2/)).to exist
+      expect(browser.link(partial_link_text: "Link", class: 'external', index: 1)).to exist
+      expect(browser.link(partial_link_text: /Link 2/), class: 'external').to exist
 
       expect(browser.link(href: /non_control_elements.html/)).to exist
       expect(browser.link(index: 1)).to exist


### PR DESCRIPTION
Based on the conversation in #678 

This allows `link_text` and `partial_link_text` to be used in conjunction with other locators just like all other selenium location methods. `String` and `RegExp` values are supported. It works for `#element` and `#link` types only, and otherwise will throw a `TypeError`.