### PR TITLE
make text location equivalent between String and RegExp values

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -154,7 +154,7 @@ module Watir
         def fetch_value(element, how)
           case how
           when :text
-            element.text
+            Watir::Element.new(@query_scope, element: element).send(:execute_js, :getTextContent, element).strip
           when :tag_name
             element.tag_name.downcase
           when :href

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -274,6 +274,10 @@ describe Watir::Locators::Element::Locator do
 
         expect_all(:tag_name, "label").ordered.and_return(label_elements)
         expect_all(:xpath, ".//div[@id='baz']").ordered.and_return(div_elements)
+
+        allow(browser).to receive(:ensure_context).and_return(nil)
+        allow(browser).to receive(:execute_script).and_return('foo', 'foob')
+
         expect(locate_one(tag_name: "div", label: /oob/)).to eq div_elements.first
       end
 

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -37,7 +37,7 @@ module LocatorSpecHelper
     attrs.each do |key, value|
       allow(el).to receive(:attribute).with(key).and_return(value)
     end if attrs
-
+    allow(el).to receive(:enabled?).and_return true
     el
   end
 

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -13,8 +13,8 @@ describe "Div" do
       expect(browser.div(id: /header/)).to exist
       expect(browser.div(title: "Header and primary navigation")).to exist
       expect(browser.div(title: /Header and primary navigation/)).to exist
-      expect(browser.div(text: "This is a footer.")).to exist
-      expect(browser.div(text: /This is a footer\./)).to exist
+      expect(browser.div(text: "Not shownNot hidden")).to exist
+      expect(browser.div(text: /Not shownNot hidden/)).to exist
       expect(browser.div(class: "profile")).to exist
       expect(browser.div(class: /profile/)).to exist
       expect(browser.div(index: 0)).to exist


### PR DESCRIPTION
At the Hackathon in Toronto we (@bret, @tk8817, @jkotests & others) discussed at length the proper way of addressing #342.  This was not the solution I proposed, but I was persuaded that it makes the most sense for consistency and backward compatibility based on the unique considerations of text nodes.

I'm not sure this is the best implementation of our idea, so any feedback on it would be appreciated.