### PR TITLE
allow location of elements using custom attributes

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -587,9 +587,9 @@ module Watir
 
       element_validator = element_validator_class.new
       selector_builder = selector_builder_class.new(@query_scope, @selector.dup, self.class.attribute_list)
-      locator = locator_class.new(@query_scope, @selector.dup, selector_builder, element_validator)
+      @locator = locator_class.new(@query_scope, @selector.dup, selector_builder, element_validator)
 
-      @element = locator.locate
+      @element = @locator.locate
     end
 
     def selector_string
@@ -657,7 +657,9 @@ module Watir
         yield
       rescue unknown_exception => ex
         msg = ex.message
-        msg += ". Maybe look in an iframe?" if @query_scope.iframes.count > 0
+        msg += "; Maybe look in an iframe?" if @query_scope.iframes.count > 0
+        custom_attributes = @locator.selector_builder.custom_attributes
+        msg += "; Watir treated #{custom_attributes} as a non-HTML compliant attribute, ensure that was intended" unless custom_attributes.empty?
         raise unknown_exception, msg
       rescue Selenium::WebDriver::Error::StaleElementReferenceError
         retry

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -8,9 +8,9 @@ module Watir
       selector = @selector.merge(tag_name: frame_tag)
       element_validator = element_validator_class.new
       selector_builder = selector_builder_class.new(@query_scope, selector, self.class.attribute_list)
-      locator = locator_class.new(@query_scope, selector, selector_builder, element_validator)
+      @locator = locator_class.new(@query_scope, selector, selector_builder, element_validator)
 
-      element = locator.locate
+      element = @locator.locate
       element or raise unknown_exception, "unable to locate #{@selector[:tag_name]} using #{selector_string}"
 
       @element = FramedDriver.new(element, browser)

--- a/lib/watir/exception.rb
+++ b/lib/watir/exception.rb
@@ -7,7 +7,6 @@ module Watir
     class ObjectDisabledException < Error; end
     class ObjectReadOnlyException < Error; end
     class NoValueFoundException < Error; end
-    class MissingWayOfFindingObjectException < Error; end
     class UnknownCellException < Error; end
     class NoMatchingWindowFoundException < Error; end
     class UnknownFrameException < Error; end

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -2,6 +2,8 @@ module Watir
   module Locators
     class Element
       class SelectorBuilder
+        attr_reader :custom_attributes
+
         VALID_WHATS = [Array, String, Regexp, TrueClass, FalseClass, ::Symbol].freeze
         WILDCARD_ATTRIBUTE = /^(aria|data)_(.+)$/
 
@@ -9,6 +11,7 @@ module Watir
           @query_scope = query_scope # either element or browser
           @selector = selector
           @valid_attributes = valid_attributes
+          @custom_attributes = []
         end
 
         def normalized_selector
@@ -75,14 +78,14 @@ module Watir
           when :caption
             [:text, what]
           else
-            assert_valid_as_attribute how
+            check_custom_attribute how
             [how, what]
           end
         end
 
-        def assert_valid_as_attribute(attribute)
+        def check_custom_attribute(attribute)
           return if valid_attribute?(attribute) || attribute.to_s =~ WILDCARD_ATTRIBUTE
-          raise Exception::MissingWayOfFindingObjectException, "invalid attribute: #{attribute.inspect}"
+          @custom_attributes << attribute.to_s
         end
 
         def given_xpath_or_css(selector)

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -327,14 +327,6 @@ describe Watir::Locators::Element::Locator do
         expect { locate_one(tag_name: 123) }.to \
         raise_error(TypeError, %[expected one of [Array, String, Regexp, TrueClass, FalseClass, Symbol], got 123:#{num_type}])
       end
-
-      it "raises a MissingWayOfFindingObjectException if the attribute is not valid" do
-        bad_selector = {tag_name: "input", href: "foo"}
-        valid_attributes = Watir::Input.attributes
-
-        expect { locate_one(bad_selector, valid_attributes) }.to \
-        raise_error(Watir::Exception::MissingWayOfFindingObjectException, "invalid attribute: :href")
-      end
     end
   end
 

--- a/spec/watirspec/elements/area_spec.rb
+++ b/spec/watirspec/elements/area_spec.rb
@@ -44,10 +44,6 @@ describe "Area" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.area(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.area(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/button_spec.rb
+++ b/spec/watirspec/elements/button_spec.rb
@@ -92,10 +92,6 @@ describe "Button" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.button(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.button(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/checkbox_spec.rb
+++ b/spec/watirspec/elements/checkbox_spec.rb
@@ -68,10 +68,6 @@ describe "CheckBox" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.checkbox(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.checkbox(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/dd_spec.rb
+++ b/spec/watirspec/elements/dd_spec.rb
@@ -26,10 +26,6 @@ describe "Dd" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.dd(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.dd(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/del_spec.rb
+++ b/spec/watirspec/elements/del_spec.rb
@@ -37,10 +37,6 @@ describe "Del" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.del(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.del(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -19,6 +19,8 @@ describe "Div" do
       expect(browser.div(class: /profile/)).to exist
       expect(browser.div(index: 0)).to exist
       expect(browser.div(xpath: "//div[@id='header']")).to exist
+      expect(browser.div(custom_attribute: "custom")).to exist
+      expect(browser.div(custom_attribute: /custom/)).to exist
     end
 
     it "returns the first div if given no args" do
@@ -41,11 +43,6 @@ describe "Div" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.div(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.div(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
-
   end
 
   # Attribute methods
@@ -151,6 +148,11 @@ describe "Div" do
         expect { browser.div(title: "no_such_title").click }.to raise_unknown_object_exception
         expect { browser.div(index: 1337).click }.to raise_unknown_object_exception
         expect { browser.div(xpath: "//div[@id='no_such_id']").click }.to raise_unknown_object_exception
+      end
+
+      it "includes custom message if element with a custom attribute does not exist" do
+        message = "Watir treated [\"custom_attribute\"] as a non-HTML compliant attribute, ensure that was intended"
+        expect { browser.div(custom_attribute: "not_there").click }.to raise_unknown_object_exception(message)
       end
     end
 

--- a/spec/watirspec/elements/divs_spec.rb
+++ b/spec/watirspec/elements/divs_spec.rb
@@ -14,7 +14,7 @@ describe "Divs" do
 
   describe "#length" do
     it "returns the number of divs" do
-      expect(browser.divs.length).to eq 14
+      expect(browser.divs.length).to eq 15
     end
   end
 

--- a/spec/watirspec/elements/dl_spec.rb
+++ b/spec/watirspec/elements/dl_spec.rb
@@ -26,10 +26,6 @@ describe "Dl" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.dl(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.dl(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/dt_spec.rb
+++ b/spec/watirspec/elements/dt_spec.rb
@@ -26,10 +26,6 @@ describe "Dt" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.dt(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.dt(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -84,16 +84,6 @@ describe "Element" do
       expect(browser.element(title: "no title")).to exist
     end
 
-    it "raises MissingWayOfFindingObjectException if the attribute is invalid for the element type" do
-      expect {
-        browser.element(for: "no title").exists?
-      }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-
-      expect {
-        browser.element(value: //).exists?
-      }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
-
     it "finds several elements by xpath" do
       expect(browser.elements(xpath: "//a").length).to eq 1
     end

--- a/spec/watirspec/elements/em_spec.rb
+++ b/spec/watirspec/elements/em_spec.rb
@@ -26,10 +26,6 @@ describe "Em" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.em(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.em(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/filefield_spec.rb
+++ b/spec/watirspec/elements/filefield_spec.rb
@@ -40,10 +40,6 @@ describe "FileField" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.file_field(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.file_field(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/form_spec.rb
+++ b/spec/watirspec/elements/form_spec.rb
@@ -43,10 +43,6 @@ describe "Form" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.form(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.form(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   describe "#submit" do

--- a/spec/watirspec/elements/frame_spec.rb
+++ b/spec/watirspec/elements/frame_spec.rb
@@ -67,10 +67,6 @@ describe "Frame" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.frame(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.frame(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   it "raises UnknownFrameException when accessing elements inside non-existing frame" do

--- a/spec/watirspec/elements/hidden_spec.rb
+++ b/spec/watirspec/elements/hidden_spec.rb
@@ -43,10 +43,6 @@ describe "Hidden" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.hidden(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.hidden(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/hn_spec.rb
+++ b/spec/watirspec/elements/hn_spec.rb
@@ -34,10 +34,6 @@ describe ["H1", "H2", "H3", "H4", "H5", "H6"] do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.h1(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.h1(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -97,10 +97,6 @@ describe "IFrame" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.iframe(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.iframe(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   it 'handles all locators for element which do not exist' do

--- a/spec/watirspec/elements/image_spec.rb
+++ b/spec/watirspec/elements/image_spec.rb
@@ -36,10 +36,6 @@ describe "Image" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.image(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.image(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/ins_spec.rb
+++ b/spec/watirspec/elements/ins_spec.rb
@@ -37,10 +37,6 @@ describe "Ins" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.ins(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.ins(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/label_spec.rb
+++ b/spec/watirspec/elements/label_spec.rb
@@ -35,10 +35,6 @@ describe "Label" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.label(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.label(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   describe "click" do

--- a/spec/watirspec/elements/li_spec.rb
+++ b/spec/watirspec/elements/li_spec.rb
@@ -37,10 +37,6 @@ describe "Li" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.li(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.li(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -47,10 +47,6 @@ describe "Link" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.link(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.link(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/map_spec.rb
+++ b/spec/watirspec/elements/map_spec.rb
@@ -33,10 +33,6 @@ describe "Map" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.map(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.map(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/ol_spec.rb
+++ b/spec/watirspec/elements/ol_spec.rb
@@ -44,10 +44,6 @@ describe "Ol" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.ol(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.ol(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/option_spec.rb
+++ b/spec/watirspec/elements/option_spec.rb
@@ -64,11 +64,6 @@ describe "Option" do
       expect { browser.option(id: 3.14).exists? }.to raise_error(TypeError)
       expect { browser.select_list(name: "new_user_country").option(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.option(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-      expect { browser.select_list(name: "new_user_country").option(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   describe "#select" do
@@ -102,14 +97,6 @@ describe "Option" do
     it "raises UnknownObjectException if the option does not exist (select_list context)" do
       expect { browser.select_list(name: "new_user_country").option(text: "no_such_text").select }.to raise_unknown_object_exception
       expect { browser.select_list(name: "new_user_country").option(text: /missing/).select }.to raise_unknown_object_exception
-    end
-
-    it "raises MissingWayOfFindingObjectException when given a bad 'how' (page context)" do
-      expect { browser.option(missing: "Denmark").select }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
-
-    it "raises MissingWayOfFindingObjectException when given a bad 'how' (select_list context)" do
-      expect { browser.select_list(name: "new_user_country").option(missing: "Denmark").select }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
     end
   end
 

--- a/spec/watirspec/elements/p_spec.rb
+++ b/spec/watirspec/elements/p_spec.rb
@@ -37,10 +37,6 @@ describe "P" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.p(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.p(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/pre_spec.rb
+++ b/spec/watirspec/elements/pre_spec.rb
@@ -37,10 +37,6 @@ describe "Pre" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.pre(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.pre(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/radio_spec.rb
+++ b/spec/watirspec/elements/radio_spec.rb
@@ -66,10 +66,6 @@ describe "Radio" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.radio(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.radio(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -41,10 +41,6 @@ describe "SelectList" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.select_list(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.select_list(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/span_spec.rb
+++ b/spec/watirspec/elements/span_spec.rb
@@ -37,10 +37,6 @@ describe "Span" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.span(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.span(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/strong_spec.rb
+++ b/spec/watirspec/elements/strong_spec.rb
@@ -37,10 +37,6 @@ describe "Strong" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.strong(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.strong(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/table_spec.rb
+++ b/spec/watirspec/elements/table_spec.rb
@@ -34,10 +34,6 @@ describe "Table" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.table(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.table(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Other

--- a/spec/watirspec/elements/tbody_spec.rb
+++ b/spec/watirspec/elements/tbody_spec.rb
@@ -43,11 +43,6 @@ describe "TableBody" do
       expect { browser.tbody(id: 3.14).exists? }.to raise_error(TypeError)
       expect { browser.table(index: 0).tbody(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.tbody(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-      expect { browser.table(index: 0).tbody(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   bug "Safari does not strip text", :safari do

--- a/spec/watirspec/elements/td_spec.rb
+++ b/spec/watirspec/elements/td_spec.rb
@@ -33,10 +33,6 @@ describe "TableCell" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.td(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.td(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   describe "#click" do

--- a/spec/watirspec/elements/text_field_spec.rb
+++ b/spec/watirspec/elements/text_field_spec.rb
@@ -74,10 +74,6 @@ describe "TextField" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.text_field(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.text_field(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/elements/tfoot_spec.rb
+++ b/spec/watirspec/elements/tfoot_spec.rb
@@ -42,11 +42,6 @@ describe "TableFooter" do
       expect { browser.tfoot(id: 3.14).exists? }.to raise_error(TypeError)
       expect { browser.table(index: 0).tfoot(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.tfoot(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-      expect { browser.table(index: 0).tfoot(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   describe "#[]" do

--- a/spec/watirspec/elements/thead_spec.rb
+++ b/spec/watirspec/elements/thead_spec.rb
@@ -43,11 +43,6 @@ describe "TableHeader" do
       expect { browser.thead(id: 3.14).exists? }.to raise_error(TypeError)
       expect { browser.table(index: 0).thead(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.thead(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-      expect { browser.table(index: 0).thead(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   describe "#[]" do

--- a/spec/watirspec/elements/tr_spec.rb
+++ b/spec/watirspec/elements/tr_spec.rb
@@ -28,10 +28,6 @@ describe "TableRow" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.tr(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.tr(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   describe "#click" do

--- a/spec/watirspec/elements/ul_spec.rb
+++ b/spec/watirspec/elements/ul_spec.rb
@@ -33,10 +33,6 @@ describe "Ul" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.ul(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.ul(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods

--- a/spec/watirspec/html/non_control_elements.html
+++ b/spec/watirspec/html/non_control_elements.html
@@ -130,6 +130,6 @@
       <del></del>
       <del class="footer" onclick="this.innerHTML = 'This is a del with text set by Javascript.'">This is a del.</del>
     </div>
-
+    <div custom-attribute=custom>Custom</div>
   </body>
 </html>

--- a/spec/watirspec/radio_set_spec.rb
+++ b/spec/watirspec/radio_set_spec.rb
@@ -43,10 +43,6 @@ describe "RadioSet" do
     it "raises TypeError when 'what' argument is invalid" do
       expect { browser.radio_set(id: 3.14).exists? }.to raise_error(TypeError)
     end
-
-    it "raises MissingWayOfFindingObjectException when 'how' argument is invalid" do
-      expect { browser.radio_set(no_such_how: 'some_value').exists? }.to raise_error(Watir::Exception::MissingWayOfFindingObjectException)
-    end
   end
 
   # Attribute methods


### PR DESCRIPTION
This is an example of how #681 can be addressed

Ideally people use HTML 5 compliant attributes, but I'm not sure there's a good reason to enforce that. This code would just record the presence of non compliant attributes and make note of it in the error message if it isn't found.

Creating methods is different. If they want to get the value of a non-compliant attribute, then they can do: `my_element.attribute_value('custom_attribute')` without providing support for `my_element.custom_attribute`.