### PR TITLE
Locate elements by visible text

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -91,22 +91,23 @@ module Watir
 
           idx = selector.delete(:index) unless selector[:adjacent]
           visible = selector.delete(:visible)
+          visible_text = selector.delete(:visible_text)
 
           how, what = selector_builder.build(selector)
 
           if how
             # could build xpath/css for selector
-            if idx && idx != 0 || !visible.nil?
+            if idx && idx != 0 || !visible.nil? || !visible_text.nil?
               elements = locate_elements(how, what)
-              filter_elements elements, visible, idx, :single
+              filter_elements elements, visible, visible_text, idx, :single
             else
               locate_element(how, what)
             end
           else
             # can't use xpath, probably a regexp in there
-            if idx && idx != 0 || !visible.nil?
+            if idx && idx != 0 || !visible.nil? || !visible_text.nil?
               elements = wd_find_by_regexp_selector(selector, :select)
-              filter_elements elements, visible, idx, :single
+              filter_elements elements, visible, visible_text, idx, :single
             else
               wd_find_by_regexp_selector(selector, :find)
             end
@@ -128,6 +129,7 @@ module Watir
         def find_all_by_multiple
           selector = selector_builder.normalized_selector
           visible = selector.delete(:visible)
+          visible_text = selector.delete(:visible_text)
 
           if selector.key? :index
             raise ArgumentError, "can't locate all elements by :index"
@@ -140,7 +142,7 @@ module Watir
                     wd_find_by_regexp_selector(selector, :select)
                   end
           return [] if found.nil?
-          filter_elements found, visible, nil, :multiple
+          filter_elements found, visible, visible_text, nil, :multiple
         end
 
         def wd_find_all_by(how, what)
@@ -154,6 +156,8 @@ module Watir
         def fetch_value(element, how)
           case how
           when :text
+            element.text
+          when :visible_text
             element.text
           when :tag_name
             element.tag_name.downcase
@@ -208,8 +212,9 @@ module Watir
           filter_elements_by_regex(elements, rx_selector, method)
         end
 
-        def filter_elements elements, visible, idx, number
+        def filter_elements elements, visible, visible_text, idx, number
           elements.select! { |el| visible == el.displayed? } unless visible.nil?
+          elements.select! { |el| visible_text === el.text } unless visible_text.nil?
           number == :single ? elements[idx || 0] : elements
         end
 

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -34,6 +34,10 @@ module Watir
             unless what.is_a?(TrueClass) || what.is_a?(FalseClass)
               raise TypeError, "expected TrueClass or FalseClass, got #{what.inspect}:#{what.class}"
             end
+          when :visible_text
+            unless what.is_a?(String) || what.is_a?(Regexp)
+              raise TypeError, "expected String or Regexp, got #{what.inspect}:#{what.class}"
+            end
           else
             if what.is_a?(Array) && how != :class && how != :class_name
               raise TypeError, "Only :class locator can have a value of an Array"
@@ -66,7 +70,7 @@ module Watir
 
         def normalize_selector(how, what)
           case how
-          when :tag_name, :text, :xpath, :index, :class, :label, :css, :visible, :adjacent
+          when :tag_name, :text, :xpath, :index, :class, :label, :css, :visible, :visible_text, :adjacent
             # include :class since the valid attribute is 'class_name'
             # include :for since the valid attribute is 'html_for'
             [how, what]

--- a/spec/watirspec/elements/divs_spec.rb
+++ b/spec/watirspec/elements/divs_spec.rb
@@ -14,7 +14,7 @@ describe "Divs" do
 
   describe "#length" do
     it "returns the number of divs" do
-      expect(browser.divs.length).to eq 14
+      expect(browser.divs.length).to eq 15
     end
   end
 

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -71,6 +71,27 @@ describe "Element" do
     end
   end
 
+  describe "visible text" do
+    it "finds elements by visible text" do
+      browser.goto WatirSpec.url_for('non_control_elements.html')
+
+      expect(browser.link(visible_text: "all visible")).to exist
+      expect(browser.link(visible_text: /all visible/)).to exist
+      expect(browser.link(visible_text: "some visible")).to exist
+      expect(browser.link(visible_text: /some visible/)).to exist
+      expect(browser.link(visible_text: "none visible")).not_to exist
+      expect(browser.link(visible_text: /none visible/)).not_to exist
+
+      expect(browser.link(visible_text: "Link 2", class: "external")).to exist
+      expect(browser.link(visible_text: /Link 2/, class: "external")).to exist
+
+      expect(browser.element(visible_text: "all visible")).to exist
+      expect(browser.element(visible_text: /all visible/)).to exist
+      expect(browser.element(visible_text: "some visible")).to exist
+      expect(browser.element(visible_text: /some visible/)).to exist
+    end
+  end
+
   describe "finding with unknown tag name" do
     it "finds an element without arguments" do
       expect(browser.element).to exist

--- a/spec/watirspec/elements/elements_spec.rb
+++ b/spec/watirspec/elements/elements_spec.rb
@@ -33,4 +33,15 @@ describe "Elements" do
     end
   end
 
+  describe "visible text" do
+    it 'finds elements by visible text' do
+      browser.goto WatirSpec.url_for('non_control_elements.html')
+      expect(browser.links(visible_text: 'all visible').count).to eq(1)
+      expect(browser.links(visible_text: /all visible/).count).to eq(1)
+      expect(browser.links(visible_text: 'some visible').count).to eq(1)
+      expect(browser.links(visible_text: /some visible/).count).to eq(1)
+      expect(browser.links(visible_text: 'none visible').count).to eq(0)
+      expect(browser.links(visible_text: /none visible/).count).to eq(0)
+    end
+  end
 end

--- a/spec/watirspec/elements/links_spec.rb
+++ b/spec/watirspec/elements/links_spec.rb
@@ -14,7 +14,7 @@ describe "Links" do
 
   describe "#length" do
     it "returns the number of links" do
-      expect(browser.links.length).to eq 4
+      expect(browser.links.length).to eq 7
     end
   end
 

--- a/spec/watirspec/elements/spans_spec.rb
+++ b/spec/watirspec/elements/spans_spec.rb
@@ -14,7 +14,7 @@ describe "Spans" do
 
   describe "#length" do
     it "returns the number of spans" do
-      expect(browser.spans.length).to eq 6
+      expect(browser.spans.length).to eq 7
     end
   end
 

--- a/spec/watirspec/html/non_control_elements.html
+++ b/spec/watirspec/html/non_control_elements.html
@@ -131,5 +131,10 @@
       <del class="footer" onclick="this.innerHTML = 'This is a del with text set by Javascript.'">This is a del.</del>
     </div>
 
+		<div id="visible_text">
+			<a id="all_visible_text">all visible</a>
+			<a id="some_visible_text">some visible<span style="display:none;"> some hidden</span></a>
+			<a id="no_visible_text" style="display:none;">none visible</a>
+		</div>
   </body>
 </html>


### PR DESCRIPTION
Based on the conversation in #678.

This adds a generic :visible_text locator for the purpose of supporting the use case provided by Selenium's built-in :link_text and :partial_link_text locators. This adds support across all element types - `#element`, `#link`, `#div`, etc. String and RegExp values are supported. 

Performance will be better for links if the :visible_text locator directly uses Selenium's :link_text and :partial_link_text. I haven't added the short-circuit yet. I figured we should agree on the generic approach before adding performance optimizations.