### PR TITLE
Se locators

### DIFF
--- a/lib/watir/locators/button/locator.rb
+++ b/lib/watir/locators/button/locator.rb
@@ -2,19 +2,12 @@ module Watir
   module Locators
     class Button
       class Locator < Element::Locator
-        def locate_all
-          find_all_by_multiple
-        end
+
 
         private
 
-        def wd_find_first_by(how, what)
-          if how == :tag_name
-            how  = :xpath
-            what = ".//button | .//input[#{selector_builder.xpath_builder.attribute_expression(:input, type: Watir::Button::VALID_TYPES)}]"
-          end
-
-          super
+        def using_selenium(*)
+          # force watir usage
         end
 
         def can_convert_regexp_to_contains?

--- a/lib/watir/locators/button/validator.rb
+++ b/lib/watir/locators/button/validator.rb
@@ -2,7 +2,7 @@ module Watir
   module Locators
     class Button
       class Validator < Element::Validator
-        def validate(element, selector)
+        def validate(element, _selector)
           return unless %w[input button].include?(element.tag_name.downcase)
           # TODO - Verify this is desired behavior based on https://bugzilla.mozilla.org/show_bug.cgi?id=1290963
           return if element.tag_name.downcase == "input" && !Watir::Button::VALID_TYPES.include?(element.attribute(:type).downcase)

--- a/lib/watir/locators/cell/locator.rb
+++ b/lib/watir/locators/cell/locator.rb
@@ -2,15 +2,13 @@ module Watir
   module Locators
     class Cell
       class Locator < Element::Locator
-        def locate_all
-          find_all_by_multiple
-        end
 
         private
 
-        def by_id
-          nil
+        def using_selenium(*)
+          # force watir usage
         end
+
       end
     end
   end

--- a/lib/watir/locators/row/locator.rb
+++ b/lib/watir/locators/row/locator.rb
@@ -2,15 +2,13 @@ module Watir
   module Locators
     class Row
       class Locator < Element::Locator
-        def locate_all
-          find_all_by_multiple
-        end
 
         private
 
-        def by_id
-          nil # avoid this
+        def using_selenium(*)
+          # force Watir usage
         end
+
       end
     end
   end

--- a/lib/watir/locators/text_field/locator.rb
+++ b/lib/watir/locators/text_field/locator.rb
@@ -2,15 +2,11 @@ module Watir
   module Locators
     class TextField
       class Locator < Element::Locator
-        def locate_all
-          find_all_by_multiple
-        end
 
         private
 
-        def wd_find_first_by(how, what)
-          how, what = selector_builder.build_wd_selector(how => what) if how == :tag_name
-          super
+        def using_selenium(*)
+          # force Watir usage
         end
 
         def matches_selector?(element, rx_selector)
@@ -28,13 +24,6 @@ module Watir
           super
         end
 
-        def by_id
-          element = super
-
-          if element && !Watir::TextField::NON_TEXT_TYPES.include?(element.attribute(:type))
-            element
-          end
-        end
       end
     end
   end

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -77,6 +77,24 @@ describe Watir::Locators::Element::Locator do
 
         locate_one class: "a b"
       end
+
+      it "handles selector with tag_name and xpath" do
+          elements = [
+              element(tag_name: "div", attributes: { class: "foo" }),
+              element(tag_name: "span", attributes: { class: "foo" }),
+              element(tag_name: "div", attributes: { class: "foo" })
+          ]
+
+          expect_one(:xpath, './/*[@class="foo"]').and_return(elements.first)
+          expect_all(:xpath, './/*[@class="foo"]').and_return(elements)
+
+          selector = {
+              xpath: './/*[@class="foo"]',
+              tag_name: 'span'
+          }
+
+          expect(locate_one(selector).tag_name).to eq 'span'
+      end
     end
 
     describe "with special cased selectors" do
@@ -91,13 +109,6 @@ describe Watir::Locators::Element::Locator do
 
         locate_one tag_name: "div",
                    caption: "foo"
-      end
-
-      it "translates :class_name to :class" do
-        expect_one :xpath, ".//div[contains(concat(' ', @class, ' '), ' foo ')]"
-
-        locate_one tag_name: "div",
-                   class_name: "foo"
       end
 
       it "handles data-* attributes" do
@@ -307,6 +318,7 @@ describe Watir::Locators::Element::Locator do
 
     it "returns nil if found element didn't match the selector tag_name" do
       expect_one(:xpath, "//div").and_return(element(tag_name: "div"))
+      expect_all(:xpath, "//div").and_return([element(tag_name: "div")])
 
       selector = {
         tag_name: "input",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'webdrivers'
 require 'locator_spec_helper'
 require 'rspec'
 
-SELENIUM_SELECTORS = %i(class class_name css id tag_name xpath)
+SELENIUM_SELECTORS = %i(class class_name css id tag_name xpath link_text partial_link_text link)
 
 if ENV['RELAXED_LOCATE'] == "false"
   Watir.relaxed_locate = false

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -82,6 +82,11 @@ describe "Div" do
       browser.goto WatirSpec.url_for "multiple_ids.html"
       expect(browser.div(id: "multiple", class: "bar").class_name).to eq "bar"
     end
+
+    it "should find the id with the correct tag name" do
+      browser.goto WatirSpec.url_for "multiple_ids.html"
+      expect(browser.span(id: "multiple").class_name).to eq "foobar"
+    end
   end
 
   describe "#style" do

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -202,10 +202,12 @@ describe "Element" do
       wd_element = browser.text_field(id: "new_user_email").wd
 
       # simulate element going stale during lookup
-      allow(browser.driver).to receive(:find_element).with(:id, 'new_user_email') { wd_element }
+      allow(browser.driver).to receive(:find_element).with(:css, '#new_user_email') { wd_element }
+      allow(browser.driver).to receive(:find_elements).with(:css, '#new_user_email') { [wd_element] }
+      allow(browser.driver).to receive(:find_elements).with(:tag_name, 'iframe') { [] }
       browser.refresh
 
-      expect { browser.text_field(id: 'new_user_email').visible? }.to raise_unknown_object_exception
+      expect { browser.text_field(css: '#new_user_email').visible? }.to raise_unknown_object_exception
     end
 
     it "returns true if the element has style='visibility: visible' even if parent has style='visibility: hidden'" do

--- a/spec/watirspec/html/multiple_ids.html
+++ b/spec/watirspec/html/multiple_ids.html
@@ -8,6 +8,7 @@
 
 <body>
   <div id="multiple" class="foo"></div>
+  <span id="multiple" class="foobar"></span>
   <div id="multiple" class="bar"></div>
   
 </body>


### PR DESCRIPTION
I find this code overall much more straightforward than what was there, but let me know what doesn't make sense in this re-write.

1. gets rid of `#find_*_by_one` methods since those were only useful for selenium selectors and it made for weird naming conventions, as well as duplicating some code with `#by_id`

2. Removes code duplication between `#find_first_by_multiple` and `#find_all_by_multiple`

2. It treats all selenium selectors like we were treating `:id` with `#by_id`

3. Supports using selenium selectors for `#locate_all` as well `#locate`

4. Finding a single element with `:tag_name` + `:css` or `:xpath` no longer just validates the tag name of the first element found, it checks if the first found matches the tag name in `#using_selenium`, but then will go into `#using_watir` to filter `find_elements` with the `:tag_name` to pull out what matches.

5.  `Element::Locator` subclasses have different things to override. `#wd_find_first_by` and `#by_id` were often just duplicating code from `Element::SelectorBuilder` subclasses, now it is just necessary to force `#using_watir` and it all just works

6. `:link_text`, `:partial_link_text` and `:link` do not fit in with the rest of the Watir locating system. You can't currently mix them with other locators and you can't pass in regular expressions. So I want to deprecate them in favor of the code that @jkotests just wrote with `:visible_text` which does support all of those things. I say we support them until Watir 7 when we have **the great deprecation purge of 2018**.