### PR TITLE
Only make one wire call for Element#center

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -368,9 +368,10 @@ module Watir
     #
 
     def center
-      location = location()
-      Selenium::WebDriver::Point.new(location.x + (width/2),
-                                     location.y + (height/2))
+      point = location
+      dimensions = size
+      Selenium::WebDriver::Point.new(point.x + (dimensions['width']/2),
+                                     point.y + (dimensions['height']/2))
     end
     alias_method :centre, :center
 


### PR DESCRIPTION
Currently, it's calling `#size` twice. Once to get width and once to get height