### PR TITLE
Set flash default timeout to 0.01

### DIFF
--- a/lib/watir/js_execution.rb
+++ b/lib/watir/js_execution.rb
@@ -45,8 +45,6 @@ module Watir
 
     def flash(color: 'red', flashes: 5, delay: 0.1)
       background_color = style("backgroundColor")
-      background_color = 'white' if background_color.empty?
-      element_color = element_call { execute_js(:backgroundColor, @element) }.strip
 
       (flashes * 2).times do |n|
         nextcolor = n.even? ? color : background_color
@@ -54,7 +52,7 @@ module Watir
         sleep(delay)
       end
 
-      element_call { execute_js(:backgroundColor, @element, element_color) }
+      element_call { execute_js(:backgroundColor, @element, background_color) }
 
       self
     end

--- a/lib/watir/js_execution.rb
+++ b/lib/watir/js_execution.rb
@@ -43,11 +43,10 @@ module Watir
     # @return [Watir::Element]
     #
 
-    def flash(color: 'red', flashes: 5, delay: 0.01)
+    def flash(color: 'red', flashes: 5, delay: 0.1)
       background_color = style("backgroundColor")
       background_color = 'white' if background_color.empty?
       element_color = element_call { execute_js(:backgroundColor, @element) }.strip
-      element_color = 'white' if element_color.empty?
 
       (flashes * 2).times do |n|
         nextcolor = n.even? ? color : background_color

--- a/lib/watir/js_execution.rb
+++ b/lib/watir/js_execution.rb
@@ -43,7 +43,7 @@ module Watir
     # @return [Watir::Element]
     #
 
-    def flash(color: 'red', flashes: 5, delay: 0.2)
+    def flash(color: 'red', flashes: 5, delay: 0.01)
       background_color = style("backgroundColor")
       background_color = 'white' if background_color.empty?
       element_color = element_call { execute_js(:backgroundColor, @element) }.strip


### PR DESCRIPTION
Reduced the default flash time from 2 seconds to 0.1 second.
Because `.flash` is mostly used to present the automation product to a potential client, 2 seconds delay to flash an element will make the solution look slow. Tested on Firefox 57.