### PR TITLE
Fix IFrame#present?

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -424,7 +424,7 @@ module Watir
 
     def present?
       visible?
-    rescue UnknownObjectException
+    rescue UnknownObjectException, UnknownFrameException
       false
     end
 

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -49,7 +49,7 @@ module Watir
     def exists?
       assert_exists
       true
-    rescue UnknownObjectException, UnknownFrameException
+    rescue unknown_exception
       false
     end
     alias_method :exist?, :exists?
@@ -424,7 +424,7 @@ module Watir
 
     def present?
       visible?
-    rescue UnknownObjectException, UnknownFrameException
+    rescue unknown_exception
       false
     end
 

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -103,6 +103,16 @@ describe "IFrame" do
     expect(browser.iframe(index: 0).div(id: 'invalid')).to_not exist
   end
 
+  describe "#present?" do
+    it "returns true if the iframe present" do
+      expect(browser.iframe(id: "iframe_1")).to be_present
+    end
+    
+    it "returns false if the iframe is not present" do
+      expect(browser.iframe(id: "no_such_id")).not_to be_present
+    end
+  end
+
   it 'switches between iframe and parent when needed' do
     browser.iframe(id: "iframe_1").elements.each do |element|
       element.text


### PR DESCRIPTION
As mentioned in #697, `IFrame` does not check presence very well:

~~~~~~~~ruby
browser.iframe(id: 'does_not_exist').present?
#=> Watir::Exception::UnknownFrameException: unable to locate iframe using {:id=>"does_not_exist", :tag_name=>"iframe"}
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/elements/element.rb:663:in `rescue in element_call'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/elements/element.rb:679:in `element_call'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/elements/element.rb:403:in `visible?'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/elements/element.rb:426:in `present?'
#=>         from (irb):4
#=>         from C:/Ruby24/bin/irb.cmd:19:in `<main>'

browser.iframe(id: 'does_not_exist').wait_until_present
#=> Watir::Exception::UnknownFrameException: unable to locate iframe using {:id=>"does_not_exist", :tag_name=>"iframe"}
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/elements/element.rb:663:in `rescue in element_call'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/elements/element.rb:679:in `element_call'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/elements/element.rb:403:in `visible?'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/elements/element.rb:426:in `present?'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait.rb:46:in `block in until'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait.rb:89:in `block in run_with_timer'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait/timer.rb:20:in `block in wait'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait/timer.rb:19:in `loop'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait/timer.rb:19:in `wait'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait.rb:88:in `run_with_timer'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait.rb:45:in `until'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait.rb:125:in `wait_until'
#=>         from C:/Ruby24/lib/ruby/gems/2.4.0/gems/watir-6.10.0/lib/watir/wait.rb:173:in `wait_until_present'
#=>         from (irb):5
#=>         from C:/Ruby24/bin/irb.cmd:19:in `<main>'
~~~~~~~~

This pull request updates `#present?` to also rescue the `UnknownFrameException`.