### PR TITLE
Reference constant correctly

### DIFF
--- a/lib/watir/capabilities.rb
+++ b/lib/watir/capabilities.rb
@@ -99,7 +99,7 @@ module Watir
         end
         if @browser == :firefox && @options.delete(:headless)
           args = @options.delete(:args) || @options.delete(:switches) || []
-          @options[Selenium::WebDriver::Firefox::Options.KEY] = {'args' => args + ['--headless']}
+          @options[Selenium::WebDriver::Firefox::Options::KEY] = {'args' => args + ['--headless']}
         end
         if @browser == :safari && @options.delete(:technology_preview)
           @options["safari.options"] = {'technologyPreview' => true}


### PR DESCRIPTION
@titusfortner @jarib we were encountering a `NoMethodError: undefined method `KEY' for Selenium::WebDriver::Firefox::Options:Class` when using remote firefox like so. This fixes that error.
```
Watir::Browser.new :firefox, {headless: true, timeout: 120, url: Rails.application.secrets[:chargeback][:url]}
```