### PR TITLE
changes label_from_text to use :visible_text instead of :text

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -186,7 +186,7 @@ module Watir
         def label_from_text(label_exp)
           # TODO: this won't work correctly if @wd is a sub-element
           locate_elements(:tag_name, 'label').find do |el|
-            matches_selector?(el, text: label_exp)
+            matches_selector?(el, visible_text: label_exp)
           end
         end
 

--- a/spec/watirspec/elements/text_field_spec.rb
+++ b/spec/watirspec/elements/text_field_spec.rb
@@ -25,6 +25,8 @@ describe "TextField" do
       expect(browser.text_field(label: /(Last|First) name/)).to exist
       expect(browser.text_field(label: 'Without for')).to exist
       expect(browser.text_field(label: /Without for/)).to exist
+      expect(browser.text_field(label: 'With hidden text')).to exist
+      expect(browser.text_field(label: /With hidden text/)).not_to exist
     end
 
     it "returns the first text field if given no args" do

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -39,6 +39,7 @@
             <label for="new_user_occupation">Occupation</label>
             <input type="text" name="new_user_occupation" id="new_user_occupation" value="Developer" onfocus="document.getElementById('onfocus_test').innerHTML = 'changed by onfocus event'"/> <br />
             <label>Without for <input /></label>
+            <label>With<span style="display:none;"> hidden</span> text<input /></label>
             <label for="new_user_species">Species</label>
             <input type="text" name="new_user_species" id="new_user_species" value="Homo sapiens sapiens" disabled="disabled" /> <br />
             <label for="new_user_code">Personal code</label>


### PR DESCRIPTION
Using `b.text_field(label: /some text/)` threw a deprecation warning about using `:text` instead of `:visible_text`.  Updating the `label_from_text` function to use `:visible_text` fixes this issue.