### PR TITLE
Reduce `enabled` Wire Calls

### DIFF
--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -20,13 +20,12 @@ describe Watir::Element do
     end
 
     it "returns false if the element is stale" do
-      wd_element = browser.div(id: "foo").wd
+      element = browser.div(id: "foo").tap(&:exists?)
 
-      # simulate element going stale during lookup
-      allow(browser.driver).to receive(:find_element).with(:id, 'foo') { wd_element }
       browser.refresh
 
-      expect(browser.div(:id, 'foo')).to_not be_present
+      expect(element).to be_stale
+      expect(element).to_not be_present
     end
 
   end
@@ -54,13 +53,13 @@ describe Watir::Element do
       browser.goto WatirSpec.url_for('removed_element.html')
     end
 
-    it "relocates element from a collection when it becomes stale" do
-      watir_element = browser.divs(id: "text").first
-      expect(watir_element).to exist
+    it "element from a collection returns false when it becomes stale" do
+      element = browser.divs(id: "text").first.tap(&:exists?)
 
       browser.refresh
 
-      expect(watir_element).to exist
+      expect(element).to be_stale
+      expect(element).to_not exist
     end
 
     it "returns false when tag name does not match id" do
@@ -71,22 +70,15 @@ describe Watir::Element do
 
   describe "#element_call" do
 
-    it 'handles exceptions when taking an action on an element that goes stale during execution' do
+    it 'handles exceptions when taking an action on a stale element' do
       browser.goto WatirSpec.url_for('removed_element.html')
 
-      watir_element = browser.div(id: "text")
+      element = browser.div(id: "text").tap(&:exists?)
 
-      # simulate element going stale after assert_exists and before action taken, but not when block retried
-      allow(watir_element).to receive(:text) do
-        watir_element.send(:element_call) do
-          @already_stale ||= false
-          browser.refresh unless @already_stale
-          @already_stale = true
-          watir_element.instance_variable_get('@element').text
-        end
-      end
+      browser.refresh
 
-      expect { watir_element.text }.to_not raise_error
+      expect(element).to be_stale
+      expect { element.text }.to_not raise_error
     end
 
   end

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -199,15 +199,12 @@ describe "Element" do
     end
 
     it "raises UnknownObjectException exception if the element is stale" do
-      wd_element = browser.text_field(id: "new_user_email").wd
+      element = browser.text_field(id: "new_user_email").tap(&:exists?)
 
-      # simulate element going stale during lookup
-      allow(browser.driver).to receive(:find_element).with(:css, '#new_user_email') { wd_element }
-      allow(browser.driver).to receive(:find_elements).with(:css, '#new_user_email') { [wd_element] }
-      allow(browser.driver).to receive(:find_elements).with(:tag_name, 'iframe') { [] }
       browser.refresh
 
-      expect { browser.text_field(css: '#new_user_email').visible? }.to raise_unknown_object_exception
+      expect(element).to be_stale
+      expect { element.visible? }.to raise_unknown_object_exception
     end
 
     it "returns true if the element has style='visibility: visible' even if parent has style='visibility: hidden'" do

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -247,10 +247,9 @@ describe Watir::Element do
     end
 
     it "does not error when element goes stale" do
-      element = browser.div(id: 'foo')
+      element = browser.div(id: 'foo').tap(&:exists?)
 
       allow(element).to receive(:stale?).and_return(false, true)
-      allow(element.wd).to receive(:displayed?).and_raise(Selenium::WebDriver::Error::StaleElementReferenceError)
 
       browser.a(id: 'hide_foo').click
       expect { element.wait_while_present(timeout: 1) }.to_not raise_exception


### PR DESCRIPTION
I believe this addresses #718.

There is a fundamental difference between locating elements from the context of `#element_call`, i.e. to *do something with the element, and locating from the context of a predicate call (e.g. `#exists?` or `#enabled?`, etc). Behaviors applicable for one do not always apply to the other. This PR attempts to do a better job distinguishing them and using the correct logic in the correct locations.

We have been using `#enabled?` to represent a generic wire call to ensure that an element is not stale before using it. The obvious extension of what I did in Watir 6.4 (the big performance release last summer) is to not make this check every time we go to use an element, but to follow the same pattern of trying to use it and dealing with the unknown object error.

Our Element related watir specs see about a 60% drop in usage of this wire call (approx 3700 to 1350) with this PR code. This could be pretty significant when running remotely.

This code will also return `false` for `#stale?` when the element is still in the DOM but the driver is pointing to a different browsing context (nested iframe, etc). This isn't a backward compatible change, but I think it has been the intended behavior and just overlooked. I don't expect people are using a staleness check to ensure they've switched to a different frame.

Also, we don't have to contort ourselves to emulate staleness in the specs any more. We have a predicate `#stale?` that does not change regardless of how often it is called, and every place that can result in a staleness exception is now being rescued and handled, so there is no longer any need  need to fake it out with mocked Selenium calls.