### PR TITLE
Simplify element locator

### DIFF
--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -304,7 +304,7 @@ describe Watir::Locators::Element::Locator do
         div_elements = [element(tag_name: "div")]
 
         expect_all(:tag_name, "label").ordered.and_return(label_elements)
-        expect_all(:xpath, ".//div[@id='baz']").ordered.and_return(div_elements)
+        expect_one(:xpath, ".//div[@id='baz']").ordered.and_return(div_elements.first)
 
         allow(browser).to receive(:ensure_context).and_return(nil)
         allow(browser).to receive(:execute_script).and_return('foo', 'foob')

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -298,6 +298,22 @@ describe "Element" do
       end
     end
 
+    context ":index locator" do
+      before { browser.goto WatirSpec.url_for("data_attributes.html") }
+
+      it "finds the first element by index: 0" do
+        expect(browser.element(index: 0).tag_name).to eq "html"
+      end
+
+      it "finds the second element by index: 1" do
+        expect(browser.element(index: 1).tag_name).to eq "head"
+      end
+
+      it "finds the last element by index: -1" do
+        expect(browser.element(index: -1).tag_name).to eq "p"
+      end
+    end
+
     it "doesn't raise when called on nested elements" do
       expect(browser.div(id: 'no_such_div').link(id: 'no_such_id')).to_not exist
     end


### PR DESCRIPTION
@titusfortner, these are the changes I have for simplifying the locator code.

The idea is:

1. Separate locators that can be included in the XPath from those that require filtering (inspecting the element).
2. Build the XPath
3. Apply filters

To avoid changing too much, the changes are isolated to the Element::Locator class. At some point, some of the logic could be moved to the selector builder (eg adding of Regexps predicates). 

Some random notes:
* For the specs, the get_element_tag_name wire calls dropped by 76% (from 11,656 to 2,772). 
* When locating an element by index and filtering is required, lazy evaluation is used to avoid inspecting elements that are not needed. This should help address the [performance issue raised on Watir General](https://groups.google.com/d/msg/watir-general/vKqwbPyxgTc/JjOs4MuXCAAJ).
