### PR TITLE
Reset for stale elements

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -405,6 +405,7 @@ module Watir
       assert_exists
       @element.displayed?
     rescue Selenium::WebDriver::Error::StaleElementReferenceError
+      reset!
       raise unknown_exception
     end
 

--- a/spec/watirspec/html/wait.html
+++ b/spec/watirspec/html/wait.html
@@ -54,6 +54,7 @@
     <a id="hide_foo" href="#" onclick="setTimeoutDisplay('foo', 'none', 500);">hide foo</a>
     <a id="remove_foo" href="#" onclick="setTimeoutRemove('foo', 1000);">remove foo</a>
     <a id="add_foobar" href="#" onclick="setTimeoutAddDisplay('foobar', 'bar', 1000);">add foobar</a>
+    <a id="readd_bar" href="#" onclick="setTimeoutRemove('bar', 500); setTimeoutAddDisplay('bar', 'foo', 1000);">re-add bar</a>
     <div id="buttons">
       <button id="btn" type="button" onclick="setDisabled('btn', true, 0)" disabled>Click To Disable!</button>
       <a id="enable_btn" href="#" onclick="setDisabled('btn', false, 500);">enable btn</a>

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -204,6 +204,11 @@ describe Watir::Element do
       expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
     end
 
+    it "waits until the element re-appears" do
+      browser.link(id: 'readd_bar').click
+      expect { browser.div(id: 'bar').wait_until_present }.to_not raise_exception
+    end
+
     it "times out if the element doesn't appear" do
       inspected = '#<Watir::Div: located: false; {:id=>"bar", :tag_name=>"div"}>'
       error = Watir::Wait::TimeoutError
@@ -259,7 +264,6 @@ describe Watir::Element do
       Watir.default_timeout = 1
       element = browser.link(name: 'add_select').wait_until(&:exists?)
       begin
-        start_time = ::Time.now
         browser.link(id: 'change_select').click
         expect { element.wait_while_present }.not_to raise_error
       ensure


### PR DESCRIPTION
I figured out #730 came from not properly replicating this line in the new code:
https://github.com/watir/watir/commit/ca377c3d0041edae59bd8ce7bb7390571ac4a471#diff-a0982f69261cbd95246962ebecdabf3cL571

What I don't like about this code is that it means that calling `#present?` twice returns different results. So, I'd like to deprecate that behavior. `#stale?` will always return result of Staleness no matter how many times it is called. But `#present?` will treat an element like a Watir element, not a Selenium element and say that if an element is at that address it is present, even if it isn't the same Selenium element, and will return true or false based on current status.

This will also deprecate `#visible?` which we've discussed previously.