### PR TITLE
Only deprecate text and regexp when text content will change behaviour

### DIFF
--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -14,8 +14,7 @@ describe "Div" do
       expect(browser.div(title: "Header and primary navigation")).to exist
       expect(browser.div(title: /Header and primary navigation/)).to exist
       expect(browser.div(text: "Not shownNot hidden")).to exist
-      msg =  /text locator with RegExp values to find elements based on only visible text is deprecated\. Use :visible_text instead/
-      expect { expect(browser.div(text: /Not hidden/)).to exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.div(text: /Not hidden/)).to exist
       expect(browser.div(class: "profile")).to exist
       expect(browser.div(class: /profile/)).to exist
       expect(browser.div(index: 0)).to exist
@@ -34,8 +33,7 @@ describe "Div" do
       expect(browser.div(title: "no_such_title")).to_not exist
       expect(browser.div(title: /no_such_title/)).to_not exist
       expect(browser.div(text: "no_such_text")).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated\. Use :visible_text instead/
-      expect { expect(browser.div(text: /no_such_text/)).to_not exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.div(text: /no_such_text/)).to_not exist
       expect(browser.div(class: "no_such_class")).to_not exist
       expect(browser.div(class: /no_such_class/)).to_not exist
       expect(browser.div(index: 1337)).to_not exist
@@ -148,9 +146,24 @@ describe "Div" do
   end
 
   describe "Deprecation Warnings" do
-    it "throws deprecation when for text and RegExp" do
-      msg =  /text locator with RegExp values to find elements based on only visible text is deprecated\. Use :visible_text instead/
-      expect { browser.div(text: /Not hidden/).exists? }.to output(msg).to_stdout_from_any_process
+    describe "text locator with RegExp values" do
+      it "does not throw deprecation when still matched by text content" do
+        expect { browser.div(text: /some visible/).exists? }.not_to output.to_stdout_from_any_process
+      end
+
+      it "throws deprecation when no longer matched by text content" do
+        msg = Regexp.new(Regexp.escape(":text locator with RegExp: /some visible$/ matched an element with hidden text is deprecated. Use :visible_text instead."))
+        expect { browser.div(text: /some visible$/).exists? }.to output(msg).to_stdout_from_any_process
+      end
+
+      it "throws deprecation when begins to be matched by text content" do
+        msg = Regexp.new(Regexp.escape(":text locator with RegExp: /some hidden/ matched an element with hidden text is deprecated. Use :visible_text instead."))
+        expect { browser.div(text: /some hidden/).exists? }.to output(msg).to_stdout_from_any_process
+      end
+
+      it "does not throw deprecation when still not matched by text content" do
+        expect { browser.div(text: /does not exist/).exists? }.not_to output.to_stdout_from_any_process
+      end
     end
   end
 

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -37,8 +37,7 @@ describe "Link" do
       expect(browser.link(title: "no_such_title")).to_not exist
       expect(browser.link(title: /no_such_title/)).to_not exist
       expect(browser.link(text: "no_such_text")).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead./
-      expect { expect(browser.link(text: /no_such_text/i)).to_not exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.link(text: /no_such_text/i)).to_not exist
       expect(browser.link(href: 'no_such_href')).to_not exist
       expect(browser.link(href: /no_such_href/)).to_not exist
       expect(browser.link(index: 1337)).to_not exist

--- a/spec/watirspec/elements/ol_spec.rb
+++ b/spec/watirspec/elements/ol_spec.rb
@@ -23,8 +23,7 @@ describe "Ol" do
       expect(browser.ol(id: "no_such_id")).to_not exist
       expect(browser.ol(id: /no_such_id/)).to_not exist
       expect(browser.ol(text: "no_such_text")).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead./
-      expect { expect(browser.ol(text: /no_such_text/)).to_not exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.ol(text: /no_such_text/)).to_not exist
       expect(browser.ol(class: "no_such_class")).to_not exist
       expect(browser.ol(class: /no_such_class/)).to_not exist
       expect(browser.ol(index: 1337)).to_not exist
@@ -35,8 +34,7 @@ describe "Ol" do
       expect(browser.ol(id: "no_such_id")).to_not exist
       expect(browser.ol(id: /no_such_id/)).to_not exist
       expect(browser.ol(text: "no_such_text")).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead./
-      expect { expect(browser.ol(text: /no_such_text/)).to_not exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.ol(text: /no_such_text/)).to_not exist
       expect(browser.ol(class: "no_such_class")).to_not exist
       expect(browser.ol(class: /no_such_class/)).to_not exist
       expect(browser.ol(index: 1337)).to_not exist

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -31,8 +31,7 @@ describe "SelectList" do
       expect(browser.select_list(value: 'no_such_value')).to_not exist
       expect(browser.select_list(value: /no_such_value/)).to_not exist
       expect(browser.select_list(text: 'no_such_text')).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead./
-      expect { expect(browser.select_list(text: /no_such_text/)).to_not exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.select_list(text: /no_such_text/)).to_not exist
       expect(browser.select_list(class: 'no_such_class')).to_not exist
       expect(browser.select_list(class: /no_such_class/)).to_not exist
       expect(browser.select_list(index: 1337)).to_not exist

--- a/spec/watirspec/elements/span_spec.rb
+++ b/spec/watirspec/elements/span_spec.rb
@@ -27,8 +27,7 @@ describe "Span" do
       expect(browser.span(id: "no_such_id")).to_not exist
       expect(browser.span(id: /no_such_id/)).to_not exist
       expect(browser.span(text: "no_such_text")).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead./
-      expect { expect(browser.span(text: /no_such_text/)).to_not exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.span(text: /no_such_text/)).to_not exist
       expect(browser.span(class: "no_such_class")).to_not exist
       expect(browser.span(class: /no_such_class/)).to_not exist
       expect(browser.span(index: 1337)).to_not exist

--- a/spec/watirspec/elements/table_spec.rb
+++ b/spec/watirspec/elements/table_spec.rb
@@ -103,16 +103,12 @@ describe "Table" do
 
     it "finds rows belonging to this table" do
       expect(table.row(id: "outer_last")).to exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead./
-      expect { expect(table.row(text: /Table 1, Row 1, Cell 1/)).to exist }.to output(msg).to_stdout_from_any_process
+      expect(table.row(text: /Table 1, Row 1, Cell 1/)).to exist
     end
 
     it "does not find rows from a nested table" do
       expect(table.row(id: "inner_first")).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead./
-      expect do
-        expect(table.row(text: /\ATable 2, Row 1, Cell 1 Table 2, Row 1, Cell 2\z/)).to_not exist
-      end.to output(msg).to_stdout_from_any_process
+      expect(table.row(text: /\ATable 2, Row 1, Cell 1 Table 2, Row 1, Cell 2\z/)).to_not exist
     end
   end
 

--- a/spec/watirspec/elements/td_spec.rb
+++ b/spec/watirspec/elements/td_spec.rb
@@ -25,8 +25,7 @@ describe "TableCell" do
       expect(browser.td(id: 'no_such_id')).to_not exist
       expect(browser.td(id: /no_such_id/)).to_not exist
       expect(browser.td(text: 'no_such_text')).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated. Use :visible_text instead./
-      expect { expect(browser.td(text: /no_such_text/)).to_not exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.td(text: /no_such_text/)).to_not exist
       expect(browser.td(index: 1337)).to_not exist
       expect(browser.td(xpath: "//td[@id='no_such_id']")).to_not exist
     end

--- a/spec/watirspec/elements/ul_spec.rb
+++ b/spec/watirspec/elements/ul_spec.rb
@@ -23,8 +23,7 @@ describe "Ul" do
       expect(browser.ul(id: "no_such_id")).to_not exist
       expect(browser.ul(id: /no_such_id/)).to_not exist
       expect(browser.ul(text: "no_such_text")).to_not exist
-      msg = /:text locator with RegExp values to find elements based on only visible text is deprecated\. Use :visible_text instead/
-      expect { expect(browser.ul(text: /no_such_text/)).to_not exist }.to output(msg).to_stdout_from_any_process
+      expect(browser.ul(text: /no_such_text/)).to_not exist
       expect(browser.ul(class: "no_such_class")).to_not exist
       expect(browser.ul(class: /no_such_class/)).to_not exist
       expect(browser.ul(index: 1337)).to_not exist


### PR DESCRIPTION
The deprecation warning for :text with Regexp is too aggressive. A warning is *always* logged. We still want people to prefer :text over :visible_text since :text is faster (can be combined into XPath).

The deprecation warning should only be logged when switching to text content will change the :text with Regexp behaviour.