### PR TITLE
deprecate `#visible?`

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -402,6 +402,7 @@ module Watir
     #
 
     def visible?
+      Watir.logger.deprecate "#visible?", "#present?"
       assert_exists
       @element.displayed?
     rescue Selenium::WebDriver::Error::StaleElementReferenceError


### PR DESCRIPTION
We have a few options with this.

1. This PR, which is straightforward deprecation so there is no confusion. No one uses visible as a method any longer. Normally I like aliasing as part of the "principle of least surprise," but when we are changing the behavior, we are changing what is most likely to be surprising about the method.

2. Alias to `#present?`. This has the problem of trying to figure out how to give a good deprecation notice that is sufficiently focused before we change behavior. I'm especially concerned with how Page Object gems which have their own logic for what "visible" means might be using this.

3. Leave as-is and just create a better guide to `#exists?` vs `#present?` vs `#displayed?` vs `#visible?`. 

I personally don't see a problem with deprecating `#visible?` while still having a `:visible` locator.