### PR TITLE
deprecate using `#present?` to determine if an element is stale

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -405,6 +405,7 @@ module Watir
       assert_exists
       @element.displayed?
     rescue Selenium::WebDriver::Error::StaleElementReferenceError
+      Watir.logger.deprecate "Checking `#present? == false` to determine a StaleElement", "``#stale? == true``"
       reset!
       raise unknown_exception
     end

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -278,6 +278,7 @@ describe "Element" do
       expect(browser.div(:id, 'should-not-exist')).to_not be_present
     end
 
+    # TODO Refactor so that this returns true
     it "returns false if the element is stale" do
       element = browser.div(id: "foo").tap(&:exists?)
 
@@ -285,6 +286,17 @@ describe "Element" do
 
       expect(element).to be_stale
       expect(element).to_not be_present
+    end
+
+    # TODO Documents Current Behavior, but needs to be refactored/removed
+    it "returns true the second time if the element is stale" do
+      element = browser.div(id: "foo").tap(&:exists?)
+
+      browser.refresh
+
+      expect(element).to be_stale
+      expect(element).to_not be_present
+      expect(element).to be_present
     end
 
   end


### PR DESCRIPTION
As discussed in #732:

I'm concerned about the following scenario. Right now it works, but I don't think it should:
```
element = browser.div(id: 'foo').tap(&:exists?)
browser.refresh
expect { element.wait_while(&:present?) }.to_not raise_exception
```
I want to change `#present?` to `retry` instead of returning `false` when the element is stale.
```
def present?
  assert_exists
  @element.displayed?
rescue UnknownObjectException, UnknownFrameException
  false
rescue Selenium::WebDriver::Error::StaleElementReferenceError
  reset!
  retry
end
```
This would require the scenario above to change to:
```
element = browser.div(id: 'foo').tap(&:exists?)
browser.refresh
expect { element.wait_until(&:stale?) }.to_not raise_exception
```
