### PR TITLE
Angular attribute support

### DIFF
--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -66,6 +66,8 @@ module Watir
             case key
             when :text, 'text'
               'normalize-space()'
+            when String
+              "@#{key}"
             when :href
               # TODO: change this behaviour?
               'normalize-space(@href)'

--- a/spec/element_locator_spec.rb
+++ b/spec/element_locator_spec.rb
@@ -123,6 +123,12 @@ describe Watir::Locators::Element::Locator do
                    text: "foo"
       end
 
+      it "handles 'text' key when it's a string" do
+        expect_one :xpath, ".//div[normalize-space()='foo']"
+        locate_one tag_name: "div",
+                   "text" => "foo"
+      end
+
       it "translates :caption to :text" do
         expect_one :xpath, ".//div[normalize-space()='foo']"
 
@@ -142,6 +148,13 @@ describe Watir::Locators::Element::Locator do
 
         locate_one tag_name: "div",
                    aria_label: "foo"
+      end
+
+      it "doesn't modify attribute name when the attribute key is a string" do
+        expect_one :xpath, ".//div[@_ngcontent-c24]"
+
+        locate_one tag_name: "div",
+                   "_ngcontent-c24" => true
       end
 
       it "normalizes space for the :href attribute" do


### PR DESCRIPTION
HTML for Angular apps can have boolean attributes like "_ngcontent-c24" and "_nghost-pmm-5"

These currently can't be used as custom attributes because all underscores in the attribute keys get converted to dashes. This change will skip a leading underscore when converting the attribute key so that these attributes get processed successfully.

There's a performance hit but it's very tiny, about 0.1 seconds per 100k key conversions.

Adding support for attributes with leading underscores would allow you to do some useful things for angular apps. One example would be the angular components here:

https://material.angular.io/components/select/overview

When one of these select controls is clicked, the custom element that contains the select options shows up outside of the element for the select control. But the ngcontent attribute from the select control could be used to directly locate the container element for the select options as well the options themselves.

I spent some time looking at how custom attributes are getting implemented. There may be a few other cases where a leading underscore is used (other than angular.) I couldn't find any case where a leading dash was used (apparently that's _way_ too nutty for anyone out there.) But this change would support both of those cases. Because of how they'd have to specify these sorts of attributes it seems unlikely that anyone would do it by accident.

@titusfortner 




