### PR TITLE
initialize Screenshot class with Browser instance not a Driver instance

### DIFF
--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -156,5 +156,3 @@ require 'watir/elements/input'
 require 'watir/radio_set'
 
 require 'watir/aliases'
-
-Watir.tag_to_class.freeze

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -290,7 +290,7 @@ module Watir
     #
 
     def screenshot
-      Screenshot.new driver
+      Screenshot.new self
     end
 
     #

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -35,20 +35,24 @@ module Watir
     alias_method :empty?, :none?
 
     #
-    # Get the element at the given index.
+    # Get the element at the given index or range.
     #
     # Any call to an ElementCollection including an adjacent selector
     # can not be lazy loaded because it must store correct type
     #
-    # @param [Integer] idx Index of wanted element, 0-indexed
-    # @return [Watir::Element] Returns an instance of a Watir::Element subclass
+    # Ranges can not be lazy loaded
+    #
+    # @param [Integer, Range] value Index (0-based) or Range of desired element(s)
+    # @return [Watir::Element, Watir::ElementCollection] Returns an instance of a Watir::Element subclass
     #
 
-    def [](idx)
-      if @selector.key? :adjacent
-        to_a[idx] || element_class.new(@query_scope, {invalid_locator: true})
+    def [](value)
+      if value.is_a?(Range)
+        to_a[value]
+      elsif @selector.key? :adjacent
+        to_a[value] || element_class.new(@query_scope, {invalid_locator: true})
       else
-        element_class.new(@query_scope, @selector.merge(index: idx))
+        element_class.new(@query_scope, @selector.merge(index: value))
       end
     end
 

--- a/lib/watir/screenshot.rb
+++ b/lib/watir/screenshot.rb
@@ -1,8 +1,14 @@
 module Watir
   class Screenshot
 
-    def initialize(driver)
-      @driver = driver
+    def initialize(browser)
+      if browser.is_a? Selenium::WebDriver::Driver
+        Watir.logger.deprecate "Initializing `Watir::Screenshot` with a `Selenium::Driver` instance", "a `Watir::Browser` instance"
+        @driver = browser
+      else
+        @browser = browser
+        @driver = browser.wd
+      end
     end
 
     #

--- a/spec/watirspec/elements/divs_spec.rb
+++ b/spec/watirspec/elements/divs_spec.rb
@@ -22,6 +22,18 @@ describe "Divs" do
     it "returns the div at the given index" do
       expect(browser.divs[1].id).to eq "outer_container"
     end
+
+    it "returns an array of divs with a given range of positive values" do
+      divs = browser.divs[2..4]
+      ids = divs.map(&:id)
+      expect(ids).to eq %w(header promo content)
+    end
+
+    it "returns an array of divs with a given range including negative values" do
+      divs = browser.divs[11..-3]
+      ids = divs.map(&:id)
+      expect(ids).to eq %w(messages ins_tag_test del_tag_test)
+    end
   end
 
   describe "#each" do


### PR DESCRIPTION
This is for #731
Which was created to improve the API for https://github.com/samnissen/watir-screenshot-stitch

I added the deprecation notice since `Watir::Screenshot` is a public class, so theoretically people could be initializing it directly (even though the likelihood is low).