### PR TITLE
keep RSpec from running everything twice

### DIFF
--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -33,4 +33,19 @@ if defined?(RSpec)
       end
     end
   end
+
+  RSpec::Matchers.define :exist do |_message|
+    match do |actual|
+      actual.exist?
+    end
+
+    failure_message do |obj|
+      "expected #{obj.inspect} to exist"
+    end
+
+    failure_message_when_negated do |obj|
+      "expected #{obj.inspect} to not exist"
+    end
+  end
+
 end


### PR DESCRIPTION
By Default RSpec runs everything using `#exist?` and `#exists?` and makes sure they both match. There should be no need for this extra work.