### PR TITLE
Add deprecation notice for when we alias visible? and present?

### DIFF
--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -204,11 +204,17 @@ describe "Element" do
 
   describe "#visible?" do
     it "returns true if the element is visible" do
-      expect(browser.text_field(id: "new_user_email")).to be_visible
+      msg = /WARN Watir \[\"visible_element\"\]/
+      expect {
+        expect(browser.text_field(id: "new_user_email")).to be_visible
+      }.to output(msg).to_stdout_from_any_process
     end
 
     it "raises UnknownObjectException exception if the element does not exist" do
-      expect { browser.text_field(id: "no_such_id").visible? }.to raise_unknown_object_exception
+      msg = /WARN Watir \[\"visible_element\"\]/
+      expect {
+        expect { browser.text_field(id: "no_such_id").visible? }.to raise_unknown_object_exception
+      }.to output(msg).to_stdout_from_any_process
     end
 
     it "raises UnknownObjectException exception if the element is stale" do
@@ -223,7 +229,10 @@ describe "Element" do
     end
 
     it "returns true if the element has style='visibility: visible' even if parent has style='visibility: hidden'" do
-      expect(browser.div(id: "visible_child")).to be_visible
+      msg = /WARN Watir \[\"visible_element\"\]/
+      expect {
+        expect(browser.div(id: "visible_child")).to be_visible
+      }.to output(msg).to_stdout_from_any_process
     end
 
     it "returns false if the element is input element where type eq 'hidden'" do
@@ -231,15 +240,24 @@ describe "Element" do
     end
 
     it "returns false if the element has style='display: none;'" do
-      expect(browser.div(id: 'changed_language')).to_not be_visible
+      msg = /WARN Watir \[\"visible_element\"\]/
+      expect {
+        expect(browser.div(id: 'changed_language')).to_not be_visible
+      }.to output(msg).to_stdout_from_any_process
     end
 
     it "returns false if the element has style='visibility: hidden;" do
-      expect(browser.div(id: 'wants_newsletter')).to_not be_visible
+      msg = /WARN Watir \[\"visible_element\"\]/
+      expect {
+        expect(browser.div(id: 'wants_newsletter')).to_not be_visible
+      }
     end
 
     it "returns false if one of the parent elements is hidden" do
-      expect(browser.div(id: 'hidden_parent')).to_not be_visible
+      msg = /WARN Watir \[\"visible_element\"\]/
+      expect {
+        expect(browser.div(id: 'hidden_parent')).to_not be_visible
+      }
     end
   end
 
@@ -290,7 +308,7 @@ describe "Element" do
 
       expect {
         expect(element).to_not be_present
-      }.to have_deprecated_stale_visible
+      }.to have_deprecated_stale_present
     end
 
     # TODO Documents Current Behavior, but needs to be refactored/removed
@@ -303,7 +321,7 @@ describe "Element" do
 
       expect {
         expect(element).to_not be_present
-      }.to have_deprecated_stale_visible
+      }.to have_deprecated_stale_present
       expect(element).to be_present
     end
 

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -5,6 +5,7 @@ if defined?(RSpec)
                           :visible_text,
                           :text_regexp,
                           :stale_visible,
+                          :stale_present,
                           :select_by].freeze
 
   DEPRECATION_WARNINGS.each do |deprecation|
@@ -24,7 +25,7 @@ if defined?(RSpec)
                       else
                         "deprecation Warning of #{deprecations_found} was found instead"
                       end
-        "expected Warning message of \"#{deprecated}\" being deprecated, but #{but_message}"
+        "expected Warning message of \"#{deprecation}\" being deprecated, but #{but_message}"
       end
 
       def supports_block_expectations?


### PR DESCRIPTION
This is based on the discussion in the PR where I tried to deprecate `#visible?` (https://github.com/watir/watir/pull/734)

Which was based on this issue that I forgot about: https://github.com/watir/watir/issues/626 (See @jkotests  & @p0deje we did talk about actually deprecating it last fall).

Regardless, here's the code for prepping to alias `#visible?` to `#present?`

`#visible?` gets the deprecation notices it needs to inform users who are calling that method directly and then rescuing the method in their own code that the behavior will be changing.

`#present?` can't call `#visible?` for the deprecation notices to make sense

`#wait_for_present` can't call `#visible`, and now that `assert_exists` doesn't re-locate an element by itself, there is no performance hit to calling `wait_for_exists`, just the annoying `Watir.relaxed_locate?` conditionals still. :)