### PR TITLE
Create visible_label locator to maintain backward compatibility

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -172,7 +172,8 @@ module Watir
         end
 
         def process_label(label_key)
-          return unless @normalized_selector[label_key].kind_of?(Regexp) && selector_builder.should_use_label_element?
+          regexp = @normalized_selector[label_key].kind_of?(Regexp)
+          return unless (regexp || label_key == :visible_label)  && selector_builder.should_use_label_element?
 
           label = label_from_text(label_key)
           unless label # label not found, stop looking for element

--- a/spec/watirspec/elements/text_field_spec.rb
+++ b/spec/watirspec/elements/text_field_spec.rb
@@ -25,6 +25,10 @@ describe "TextField" do
       expect(browser.text_field(label: /(Last|First) name/)).to exist
       expect(browser.text_field(label: 'Without for')).to exist
       expect(browser.text_field(label: /Without for/)).to exist
+      expect(browser.text_field(label: 'With hidden text')).to exist
+      expect(browser.text_field(label: 'With text')).not_to exist
+      expect(browser.text_field(visible_label: /With text/)).to exist
+      expect(browser.text_field(visible_label: /With hidden text/)).not_to exist
     end
 
     it "returns the first text field if given no args" do

--- a/spec/watirspec/elements/text_field_spec.rb
+++ b/spec/watirspec/elements/text_field_spec.rb
@@ -27,6 +27,13 @@ describe "TextField" do
       expect(browser.text_field(label: /Without for/)).to exist
       expect(browser.text_field(label: 'With hidden text')).to exist
       expect(browser.text_field(label: 'With text')).not_to exist
+      expect(browser.text_field(visible_label: 'With hidden text')).not_to exist
+      expect(browser.text_field(visible_label: 'With text')).to exist
+
+      # These will work after text is deprecated for visible_text
+      # expect(browser.text_field(label: /With hidden text/)).to exist
+      # expect(browser.text_field(label: /With text/)).not_to exist
+
       expect(browser.text_field(visible_label: /With text/)).to exist
       expect(browser.text_field(visible_label: /With hidden text/)).not_to exist
     end

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -39,6 +39,7 @@
             <label for="new_user_occupation">Occupation</label>
             <input type="text" name="new_user_occupation" id="new_user_occupation" value="Developer" onfocus="document.getElementById('onfocus_test').innerHTML = 'changed by onfocus event'"/> <br />
             <label>Without for <input /></label>
+            <label>With<span style="display:none;"> hidden</span> text<input /></label>
             <label for="new_user_species">Species</label>
             <input type="text" name="new_user_species" id="new_user_species" value="Homo sapiens sapiens" disabled="disabled" /> <br />
             <label for="new_user_code">Personal code</label>


### PR DESCRIPTION
This is an alternative to #717 

I don't love this locator, but I think I like this locator more than I like the alternatives (breaking backward compatibility and nested hashes).