### PR TITLE
increase .flash speed and keep original bg-color of element

### DIFF
--- a/lib/watir/js_execution.rb
+++ b/lib/watir/js_execution.rb
@@ -43,11 +43,9 @@ module Watir
     # @return [Watir::Element]
     #
 
-    def flash(color: 'red', flashes: 5, delay: 0.2)
-      background_color = style("backgroundColor")
+    def flash(color: 'red', flashes: 10, delay: 0.05)
+      background_color = original_color = style("background-color")
       background_color = 'white' if background_color.empty?
-      element_color = element_call { execute_js(:backgroundColor, @element) }.strip
-      element_color = 'white' if element_color.empty?
 
       (flashes * 2).times do |n|
         nextcolor = n.even? ? color : background_color
@@ -55,7 +53,7 @@ module Watir
         sleep(delay)
       end
 
-      element_call { execute_js(:backgroundColor, @element, element_color) }
+      element_call { execute_js(:backgroundColor, @element, original_color) }
 
       self
     end

--- a/lib/watir/js_execution.rb
+++ b/lib/watir/js_execution.rb
@@ -33,22 +33,38 @@ module Watir
     #   browser.li(id: 'non_link_1').flash
     #   browser.li(id: 'non_link_1').flash(color: "green", flashes: 3, delay: 0.05)
     #   browser.li(id: 'non_link_1').flash(color: "yellow")
+    #   browser.li(id: 'non_link_1').flash(color: ["yellow", "green"])
     #   browser.li(id: 'non_link_1').flash(flashes: 4)
     #   browser.li(id: 'non_link_1').flash(delay: 0.1)
+    #   browser.li(id: 'non_link_1').flash(:fast)
+    #   browser.li(id: 'non_link_1').flash(:slow)
+    #   browser.li(id: 'non_link_1').flash(:rainbow)
     #
-    # @param [String] color what color to flash with
+    # @param [Symbol] preset :fast, :slow, :long or :rainbow for pre-set values
+    # @param [String/Array] color what color or colors to flash with
     # @param [Integer] flashes number of times element should be flashed
     # @param [Integer, Float] delay how long to wait between flashes
     #
     # @return [Watir::Element]
     #
 
-    def flash(color: 'red', flashes: 10, delay: 0.05)
+    def flash(preset = :default, color: 'red', flashes: 10, delay: 0.1)
+      presets = {
+          fast: { delay: 0.04 },
+          slow: { delay: 0.2 },
+          long: { flashes: 5, delay: 0.5 },
+          rainbow: { flashes: 5, color: %w(red orange yellow green blue indigo violet) }
+      }
+      return self.flash(presets[preset]) unless presets[preset].nil?
+
       background_color = original_color = style("background-color")
       background_color = 'white' if background_color.empty?
+      color = [color] if color.is_a? String
+      color.push(background_color)
 
-      (flashes * 2).times do |n|
-        nextcolor = n.even? ? color : background_color
+      (flashes * color.length).times do |n|
+        modulo = n % color.length
+        nextcolor = color[modulo]
         element_call { execute_js(:backgroundColor, @element, nextcolor) }
         sleep(delay)
       end

--- a/lib/watir/js_execution.rb
+++ b/lib/watir/js_execution.rb
@@ -41,7 +41,7 @@ module Watir
     #   browser.li(id: 'non_link_1').flash(:rainbow)
     #
     # @param [Symbol] preset :fast, :slow, :long or :rainbow for pre-set values
-    # @param [String/Array] color what color or colors to flash with
+    # @param [String/Array] color what 'color' or [colors] to flash with
     # @param [Integer] flashes number of times element should be flashed
     # @param [Integer, Float] delay how long to wait between flashes
     #
@@ -59,13 +59,10 @@ module Watir
 
       background_color = original_color = style("background-color")
       background_color = 'white' if background_color.empty?
-      color = [color] if color.is_a? String
-      color.push(background_color)
+      colors = Array(color).push(background_color)
 
-      (flashes * color.length).times do |n|
-        modulo = n % color.length
-        nextcolor = color[modulo]
-        element_call { execute_js(:backgroundColor, @element, nextcolor) }
+      (colors * flashes).each do |next_color|
+        element_call { execute_js(:backgroundColor, @element, next_color) }
         sleep(delay)
       end
 

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -485,10 +485,8 @@ describe "Element" do
   end
 
   describe "#flash" do
-
     let(:h2) { browser.h2(text: 'Add user') }
     let(:h1) { browser.h1(text: 'User administration') }
-
 
     it 'returns the element on which it was called' do
       expect(h2.flash).to eq h2
@@ -498,7 +496,6 @@ describe "Element" do
       expect(h2.style('background-color')).to eq h2.flash.style('background-color')
       expect(h1.style('background-color')).to eq h1.flash.style('background-color')
     end
-
   end
 
   describe "#hover" do

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -493,9 +493,17 @@ describe "Element" do
     end
 
     it 'should keep the element background color after flashing' do
-      expect(h2.style('background-color')).to eq h2.flash.style('background-color')
+      expect(h2.style('background-color')).to eq h2.flash(:rainbow).style('background-color')
       expect(h1.style('background-color')).to eq h1.flash.style('background-color')
     end
+
+    it 'should respond to preset symbols like :fast and :slow' do
+      expect(h1.flash(:rainbow)).to eq h1
+      expect(h2.flash(:slow)).to eq h2
+      expect(h1.flash(:fast)).to eq h1
+      expect(h2.flash(:long)).to eq h2
+    end
+
   end
 
   describe "#hover" do

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -487,10 +487,18 @@ describe "Element" do
   describe "#flash" do
 
     let(:h2) { browser.h2(text: 'Add user') }
+    let(:h1) { browser.h1(text: 'User administration') }
+
 
     it 'returns the element on which it was called' do
       expect(h2.flash).to eq h2
     end
+
+    it 'should keep the element background color after flashing' do
+      expect(h2.style('background-color')).to eq h2.flash.style('background-color')
+      expect(h1.style('background-color')).to eq h1.flash.style('background-color')
+    end
+
   end
 
   describe "#hover" do

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -10,7 +10,7 @@
   <body onload="document.user_new.new_user_first_name.focus()">
     <div id="messages"></div>
     <h1><a href="">User administration</a></h1>
-    <h2>Add user</h2>
+    <h2 style="background-color: gray;">Add user</h2>
     <form enctype="multipart/form-data" action="post_to_me" method="post" name="user_new" id="new_user" class="user" onsubmit="WatirSpec.addMessage('submit'); return false;">
         <fieldset>
             <input type="hidden" /> <!-- Ensure it's not included in #text_field -->


### PR DESCRIPTION
PR https://github.com/watir/watir/pull/695 could not be updated anymore, so hereby the new PR.

I've also added specs that check if the bg-color is the same after flashing. Tested in chrome and ff.