### PR TITLE
Ignore warnings

### DIFF
--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -46,11 +46,12 @@ module Watir
     end
 
     def always_locate_message
-      Watir.logger.warn <<-EOS
+      msg = <<-EOS.gsub("\n", " ")
 Watir#always_locate is deprecated; elements are always cached and will always
 be re-located if they go stale before use.
 Use Element#stale? or Element#wait_until(&:stale?) if needed for flow control.
       EOS
+      Watir.logger.warn msg, ids: [:always_locate, :deprecations]
     end
 
     #
@@ -63,11 +64,12 @@ Use Element#stale? or Element#wait_until(&:stale?) if needed for flow control.
     end
 
     def prefer_css_message
-      Watir.logger.warn <<-EOS
+      msg = <<-EOS.gsub("\n", " ")
 Watir#prefer_css is deprecated; all elements that can not be passed directly
 as Selenium locators will be translated to XPath. To continue using CSS Selectors
 require the watir_css gem - https://github.com/watir/watir_css
       EOS
+      Watir.logger.warn msg, ids: [:prefer_css, :deprecations]
     end
 
     #

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -110,7 +110,7 @@ module Watir
           message = "This code has slept for the duration of the default timeout "
           message << "waiting for an Alert to exist. If the test is still passing, "
           message << "consider using Alert#exists? instead of rescuing UnknownObjectException"
-          Watir.logger.warn message
+          Watir.logger.warn message, ids: [:wait_for_alert]
         end
         raise Exception::UnknownObjectException, 'unable to locate alert'
       end

--- a/lib/watir/capabilities.rb
+++ b/lib/watir/capabilities.rb
@@ -50,7 +50,8 @@ module Watir
 
       %i(open_timeout read_timeout client_timeout).each do |t|
         next if http_client.nil? || !respond_to?(t)
-        Watir.logger.warn "You can now pass #{t} value directly into Watir::Browser opt without needing to use :http_client"
+        Watir.logger.warn "You can now pass #{t} value directly into Watir::Browser opt without needing to use :http_client",
+                          ids: [:http_client, :use_capabilities]
       end
 
       http_client ||= Selenium::WebDriver::Remote::Http::Default.new
@@ -81,7 +82,10 @@ module Watir
         profile = @options.delete(:profile)
         if browser_options.is_a? Selenium::WebDriver::Firefox::Options
           @selenium_opts[:options] = browser_options
-          Watir.logger.deprecate 'Initializing Browser with both :profile and :option', ':profile as a key inside :option' if profile
+          if profile
+            Watir.logger.deprecate 'Initializing Browser with both :profile and :option', ':profile as a key inside :option',
+                                   ids: [:firefox_profile]
+          end
         end
         if @options.delete(:headless)
           browser_options ||= {}
@@ -111,7 +115,8 @@ module Watir
       caps = @options.delete(:desired_capabilities)
 
       if caps
-        Watir.logger.warn 'You can now pass values directly into Watir::Browser opt without needing to use :desired_capabilities'
+        Watir.logger.warn 'You can now pass values directly into Watir::Browser opt without needing to use :desired_capabilities',
+                          ids: [:use_capabilities]
         @selenium_opts.merge!(@options)
       else
         caps = Selenium::WebDriver::Remote::Capabilities.send @browser, @options

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -406,7 +406,8 @@ module Watir
       assert_exists
       @element.displayed?
     rescue Selenium::WebDriver::Error::StaleElementReferenceError
-      Watir.logger.deprecate "Checking `#visible?` or `#present? == false` to determine a StaleElement", "`#stale? == true`"
+      Watir.logger.deprecate "Checking `#visible?` or `#present? == false` to determine a stale element", "`#stale? == true`",
+                             ids: [:stale_visible]
       reset!
       raise unknown_exception
     end

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -94,7 +94,7 @@ module Watir
     #
 
     def select_value(str_or_rx)
-      Watir.logger.deprecate '#select_value', "#select"
+      Watir.logger.deprecate '#select_value', "#select", ids: [:select_value]
       select_by str_or_rx
     end
 
@@ -157,7 +157,8 @@ module Watir
       found = find_options(:value, str_or_rx)
 
       if found && found.size > 1
-        Watir.logger.deprecate "Selecting Multiple Options with #select", "#select_all"
+        Watir.logger.deprecate "Selecting Multiple Options with #select", "#select_all",
+                               ids: [:select_by]
       end
       return select_matching(found) if found && found.any?
       raise NoValueFoundException, "#{str_or_rx.inspect} not found in select list"

--- a/lib/watir/legacy_wait.rb
+++ b/lib/watir/legacy_wait.rb
@@ -83,7 +83,7 @@ module Watir
     def when_present(timeout = nil)
       warning = '#when_present has been deprecated and is unlikely to be needed; '
       warning << 'replace this with #wait_until_present if a wait is still needed'
-      Watir.logger.warn warning
+      Watir.logger.warn warning, ids: [:when_present, :deprecations]
 
       timeout ||= Watir.default_timeout
       message = "waiting for #{selector_string} to become present"
@@ -109,7 +109,8 @@ module Watir
     #
 
     def when_enabled(timeout = nil)
-      Watir.logger.warn '#when_enabled has been deprecated and is unlikely to be needed'
+      Watir.logger.warn '#when_enabled has been deprecated and is unlikely to be needed',
+                        ids: [:when_enabled, :deprecations]
 
       timeout ||= Watir.default_timeout
       message = "waiting for #{selector_string} to become enabled"

--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -212,7 +212,8 @@ module Watir
             text_content_matches = selector[:text] === text_content
             unless matches == text_content_matches
               key = @selector.key?(:text) ? "text" : "label"
-              Watir.logger.deprecate("Using :#{key} locator with RegExp (#{selector[:text].inspect}) to match an element that includes hidden text", ":visible_#{key}")
+              Watir.logger.deprecate("Using :#{key} locator with RegExp #{selector[:text].inspect} to match an element that includes hidden text", ":visible_#{key}",
+                  ids: [:text_regexp])
             end
           end
 
@@ -269,7 +270,7 @@ module Watir
           return false unless W3C_FINDERS.include? how
           return false unless what.kind_of?(String)
           if %i[partial_link_text link_text link].include?(how)
-            Watir.logger.deprecate(":#{how} locator", ':visible_text')
+            Watir.logger.deprecate(":#{how} locator", ':visible_text', ids: [:visible_text])
             return true if [:a, :link, nil].include?(tag)
             raise StandardError, "Can not use #{how} locator to find a #{what} element"
           elsif how == :tag_name

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -50,7 +50,8 @@ module Watir
             if key == :class
               if value.strip.include?(' ')
                 Watir.logger.deprecate "Using the :class locator to locate multiple classes with a String value (i.e. \"#{value}\")",
-                                       "Array (e.g. #{value.split})"
+                                       "Array (e.g. #{value.split})",
+                                        ids: [:class_array]
               end
               build_class_match(value)
             elsif key == :label && @should_use_label_element

--- a/lib/watir/logger.rb
+++ b/lib/watir/logger.rb
@@ -33,8 +33,9 @@ module Watir
       @ignored = []
     end
 
-    def ignore(id)
-      @ignored << id.to_s
+    def ignore(ids)
+      ids = [ids] unless ids.is_a? Array
+      @ignored.concat ids.map(&:to_s)
     end
 
     def output=(io)

--- a/lib/watir/screenshot.rb
+++ b/lib/watir/screenshot.rb
@@ -3,7 +3,8 @@ module Watir
 
     def initialize(browser)
       if browser.is_a? Selenium::WebDriver::Driver
-        Watir.logger.deprecate "Initializing `Watir::Screenshot` with a `Selenium::Driver` instance", "a `Watir::Browser` instance"
+        Watir.logger.deprecate "Initializing `Watir::Screenshot` with a `Selenium::Driver` instance", "a `Watir::Browser` instance",
+                               ids: [:screenshot_driver]
         @driver = browser
       else
         @browser = browser

--- a/lib/watir/wait.rb
+++ b/lib/watir/wait.rb
@@ -37,7 +37,7 @@ module Watir
 
       def until(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: nil, object: nil)
         if deprecated_message || deprecated_timeout
-          Watir.logger.deprecate "Using arguments for Wait#until", "keywords"
+          Watir.logger.deprecate "Using arguments for Wait#until", "keywords", ids: [:until, :timeout_arguments]
           timeout = deprecated_timeout
           message = deprecated_message
         end
@@ -63,7 +63,7 @@ module Watir
 
       def while(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: nil, object: nil)
         if deprecated_message || deprecated_timeout
-          Watir.logger.deprecate "Using arguments for Wait#while", "keywords"
+          Watir.logger.deprecate "Using arguments for Wait#while", "keywords", ids: [:while, :timeout_arguments]
           timeout = deprecated_timeout
           message = deprecated_message
         end
@@ -117,7 +117,7 @@ module Watir
 
     def wait_until(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: nil, &blk)
       if deprecated_message || deprecated_timeout
-        Watir.logger.deprecate "Using arguments for #wait_until", "keywords"
+        Watir.logger.deprecate "Using arguments for #wait_until", "keywords", ids: [:wait_until, :timeout_arguments]
         timeout = deprecated_timeout
         message = deprecated_message
       end
@@ -143,7 +143,7 @@ module Watir
 
     def wait_while(deprecated_timeout = nil, deprecated_message = nil, timeout: nil, message: nil, interval: nil, &blk)
       if deprecated_message || deprecated_timeout
-        Watir.logger.deprecate "Using arguments for #wait_while", "keywords"
+        Watir.logger.deprecate "Using arguments for #wait_while", "keywords", ids: [:wait_while, :timeout_arguments]
         timeout = deprecated_timeout
         message = deprecated_message
       end
@@ -167,7 +167,7 @@ module Watir
 
     def wait_until_present(deprecated_timeout = nil, timeout: nil, interval: nil)
       if deprecated_timeout
-        Watir.logger.deprecate "Using arguments for #wait_until_present", "keywords"
+        Watir.logger.deprecate "Using arguments for #wait_until_present", "keywords", ids: [:wait_until_present, :timeout_arguments]
         timeout = deprecated_timeout
       end
       wait_until(timeout: timeout, interval: interval, &:present?)
@@ -187,7 +187,7 @@ module Watir
 
     def wait_while_present(deprecated_timeout = nil, timeout: nil)
       if deprecated_timeout
-        Watir.logger.deprecate "Using arguments for #wait_while_present", "keywords"
+        Watir.logger.deprecate "Using arguments for #wait_while_present", "keywords", ids: [:wait_while_present, :timeout_arguments]
         timeout = deprecated_timeout
       end
       wait_while(timeout: timeout) do

--- a/lib/watirspec.rb
+++ b/lib/watirspec.rb
@@ -77,7 +77,8 @@ module WatirSpec
       info << "#{caps.browser_name}"
       info << "#{caps.version}"
 
-      Watir.logger.warn "running watirspec against #{info.join ' '} using:\n#{WatirSpec.implementation.inspect_args}"
+      Watir.logger.warn "running watirspec against #{info.join ' '} using:\n#{WatirSpec.implementation.inspect_args}",
+                        ids: [:browser_info]
     rescue
       # ignored
     end

--- a/lib/watirspec/guards.rb
+++ b/lib/watirspec/guards.rb
@@ -22,7 +22,7 @@ module WatirSpec
             guard_name = "#{guard[:name]}:".ljust(15)
             str << " \t#{guard_name} #{guard[:data].inspect}\n"
           end
-          Watir.logger.warn str
+          Watir.logger.warn str, ids: [:guard_names]
         end
       end
     end # class << self

--- a/lib/watirspec/server.rb
+++ b/lib/watirspec/server.rb
@@ -54,7 +54,7 @@ module WatirSpec
 
         client.write(response(status, headers, body))
       rescue Errno::ECONNRESET
-        Watir.logger.warn 'Client reset connection, skipping.'
+        Watir.logger.warn 'Client reset connection, skipping.', ids: [:reset_connection]
       ensure
         client.close
       end

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -68,5 +68,11 @@ module Watir
       expect { Watir.logger.deprecate('#old', '#new') }.to_not output.to_stdout_from_any_process
     end
 
+    it 'allows to ignore multiple ids' do
+      Watir.logger.ignore([:foo, :bar])
+      expect { Watir.logger.warn('warning', ids: [:foo]) }.to_not output.to_stdout_from_any_process
+      expect { Watir.logger.warn('warning', ids: [:bar]) }.to_not output.to_stdout_from_any_process
+    end
+
   end
 end

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -25,7 +25,7 @@ module Watir
     end
 
     it 'outputs to stdout by default' do
-      expect { Watir.logger.warn('message') }.to output(/WARN Watir message/).to_stdout
+      expect { Watir.logger.warn('message') }.to output(/WARN Watir message/).to_stdout_from_any_process
     end
 
     it 'allows to output to file' do
@@ -40,7 +40,33 @@ module Watir
 
     it 'allows to deprecate functionality' do
       message = /WARN Watir \[DEPRECATION\] #old is deprecated\. Use #new instead\./
-      expect { Watir.logger.deprecate('#old', '#new') }.to output(message).to_stdout
+      expect { Watir.logger.deprecate('#old', '#new') }.to output(message).to_stdout_from_any_process
     end
+
+    it 'allows to selectively ignore deprecations with Strings' do
+      Watir.logger.ignore("old deprecated")
+      expect { Watir.logger.deprecate('#old', '#new', ids: ['old deprecated']) }.to_not output.to_stdout_from_any_process
+    end
+
+    it 'allows to selectively ignore deprecations with Symbols' do
+      Watir.logger.ignore(:foo)
+      expect { Watir.logger.deprecate('#old', '#new', ids: [:foo]) }.to_not output.to_stdout_from_any_process
+    end
+
+    it 'allows to selectively ignore warnings with Strings' do
+      Watir.logger.ignore(:foo)
+      expect { Watir.logger.warn('warning', ids: ['foo']) }.to_not output.to_stdout_from_any_process
+    end
+
+    it 'allows to selectively ignore warnings with Symbols' do
+      Watir.logger.ignore(:foo)
+      expect { Watir.logger.warn('warning', ids: [:foo]) }.to_not output.to_stdout_from_any_process
+    end
+
+    it 'allows to ignore all deprecation notices' do
+      Watir.logger.ignore(:deprecations)
+      expect { Watir.logger.deprecate('#old', '#new') }.to_not output.to_stdout_from_any_process
+    end
+
   end
 end

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -152,12 +152,12 @@ describe "Div" do
       end
 
       it "throws deprecation when no longer matched by text content" do
-        msg = Regexp.new(Regexp.escape("Using :text locator with RegExp (/some visible$/) to match an element that includes hidden text is deprecated. Use :visible_text instead."))
+        msg = /Using :text locator with RegExp \/some visible\$\/ to match an element that includes hidden text is deprecated\. Use :visible_text instead/
         expect { browser.div(text: /some visible$/).exists? }.to output(msg).to_stdout_from_any_process
       end
 
       it "throws deprecation when begins to be matched by text content" do
-        msg = Regexp.new(Regexp.escape("Using :text locator with RegExp (/some hidden/) to match an element that includes hidden text is deprecated. Use :visible_text instead."))
+        msg = /Using :text locator with RegExp \/some hidden\/ to match an element that includes hidden text is deprecated\. Use :visible_text instead/
         expect { browser.div(text: /some hidden/).exists? }.to output(msg).to_stdout_from_any_process
       end
 

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -217,7 +217,7 @@ describe "Element" do
       browser.refresh
 
       expect(element).to be_stale
-      msg = /Checking `#visible\?` or `#present\? == false` to determine a StaleElement is deprecated. Use `#stale\? == true` instead\./
+      msg = /Checking `#visible\?` or `#present\? == false` to determine a stale element is deprecated. Use `#stale\? == true` instead\./
       expect {
         expect { element.visible? }.to raise_unknown_object_exception
       }.to output(msg).to_stdout_from_any_process
@@ -289,7 +289,7 @@ describe "Element" do
 
       expect(element).to be_stale
 
-      msg = /Checking `#visible\?` or `#present\? == false` to determine a StaleElement is deprecated. Use `#stale\? == true` instead\./
+      msg = /Checking `#visible\?` or `#present\? == false` to determine a stale element is deprecated. Use `#stale\? == true` instead\./
       expect {
         expect(element).to_not be_present
       }.to output(msg).to_stdout_from_any_process
@@ -303,7 +303,7 @@ describe "Element" do
 
       expect(element).to be_stale
 
-      msg = /Checking `#visible\?` or `#present\? == false` to determine a StaleElement is deprecated. Use `#stale\? == true` instead\./
+      msg = /Checking `#visible\?` or `#present\? == false` to determine a stale element is deprecated. Use `#stale\? == true` instead\./
       expect {
         expect(element).to_not be_present
       }.to output(msg).to_stdout_from_any_process


### PR DESCRIPTION
The idea here is to allow people to granularly ignore specific warnings if they don't think they apply to them.

I also added the ability to override the `progname` so that other projects can use this code...  Honestly, I *really* want to pull this code out of the Watir project and create a new gem called `WatirLogged`. Yes, mostly because I think it is an excellent pun, but I'm finding myself wanting to use this functionality in all of my gems.