### PR TITLE
Adds getters  for query scope and selector to element collections.

### DIFF
--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -5,6 +5,8 @@ module Watir
   #
 
   class ElementCollection
+    attr_reader :query_scope, :selector
+
     include Enumerable
     include Locators::ClassHelpers
 


### PR DESCRIPTION
Individual elements have getters for :query_scope and :selector but collections don't. Seemed like a low risk thing so I added the getters. I've actually been using them and this change would allow me to get rid of some logic to get the vars differently when the object is a collection. 

All specs are passing except "Browser #new with parameters accepts switches argument," which I've seen fail before this change -- think that's probably related to my laptop's screen resolution.
