### PR TITLE
deprecate locating elements by ordered parameters

### DIFF
--- a/lib/watir/container.rb
+++ b/lib/watir/container.rb
@@ -36,6 +36,9 @@ module Watir
     def extract_selector(selectors)
       case selectors.size
       when 2
+        Watir.logger.deprecate "Using ordered parameters to locate elements (:#{selectors.first}, #{selectors.last.inspect})",
+                               "{#{selectors.first}: #{selectors.last.inspect}}",
+                               ids: [:selector_parameters]
         return { selectors[0] => selectors[1] }
       when 1
         obj = selectors.first
@@ -44,7 +47,7 @@ module Watir
         return {}
       end
 
-      raise ArgumentError, "expected Hash or (:how, 'what'), got #{selectors.inspect}"
+      raise ArgumentError, "expected Hash, got #{selectors.inspect}"
     end
 
   end # Container

--- a/spec/unit/container_spec.rb
+++ b/spec/unit/container_spec.rb
@@ -11,7 +11,9 @@ describe Watir::Container do
     end
 
     it "converts 2-arg selector into a hash" do
-      expect(@container.public_extract_selector([:how, 'what'])).to eq Hash[how: 'what']
+      expect {
+        expect(@container.public_extract_selector([:how, 'what'])).to eq Hash[how: 'what']
+      }.to have_deprecated_selector_parameters
     end
 
     it "returns the hash given" do

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -77,8 +77,7 @@ describe Watir::Locators::Element::Locator do
       it "handles selector with multiple classes in string" do
         expect_one :xpath, ".//*[contains(concat(' ', @class, ' '), ' a b ')]"
 
-        msg = /:class locator to locate multiple classes with a String value .* is deprecated/
-        expect { locate_one class: "a b" }.to output(msg).to_stdout_from_any_process
+        expect { locate_one class: "a b" }.to have_deprecated_class_array
       end
 
       it "handles selector with tag_name and xpath" do
@@ -435,8 +434,7 @@ describe Watir::Locators::Element::Locator do
       it "handles selector with multiple classes in string" do
         expect_all :xpath, ".//*[contains(concat(' ', @class, ' '), ' a b ')]"
 
-        msg = /:class locator to locate multiple classes with a String value .* is deprecated/
-        expect { locate_all class: "a b" }.to output(msg).to_stdout_from_any_process
+        expect { locate_all class: "a b" }.to have_deprecated_class_array
       end
     end
 

--- a/spec/watirspec/elements/checkbox_spec.rb
+++ b/spec/watirspec/elements/checkbox_spec.rb
@@ -169,7 +169,7 @@ describe "CheckBox" do
 
     it "returns false if the checkbox button is disabled" do
       expect(browser.checkbox(id: "new_user_interests_dentistry")).to_not be_enabled
-      expect(browser.checkbox(:xpath,"//input[@id='new_user_interests_dentistry']")).to_not be_enabled
+      expect(browser.checkbox(xpath: "//input[@id='new_user_interests_dentistry']")).to_not be_enabled
     end
 
     it "raises UnknownObjectException if the checkbox button doesn't exist" do

--- a/spec/watirspec/elements/del_spec.rb
+++ b/spec/watirspec/elements/del_spec.rb
@@ -95,7 +95,7 @@ describe "Del" do
 
     it "raises UnknownObjectException if the del doesn't exist" do
       expect { browser.del(id: 'no_such_id').text }.to raise_unknown_object_exception
-      expect { browser.del(:xpath , "//del[@id='no_such_id']").text }.to raise_unknown_object_exception
+      expect { browser.del(xpath: "//del[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -148,21 +148,19 @@ describe "Div" do
   describe "Deprecation Warnings" do
     describe "text locator with RegExp values" do
       it "does not throw deprecation when still matched by text content" do
-        expect { browser.div(text: /some visible/).exists? }.not_to output(/visible_text/).to_stdout_from_any_process
+        expect { browser.div(text: /some visible/).exists? }.not_to have_deprecated_text_regexp
       end
 
       it "throws deprecation when no longer matched by text content" do
-        msg = /Using :text locator with RegExp \/some visible\$\/ to match an element that includes hidden text is deprecated\. Use :visible_text instead/
-        expect { browser.div(text: /some visible$/).exists? }.to output(msg).to_stdout_from_any_process
+        expect { browser.div(text: /some visible$/).exists? }.to have_deprecated_text_regexp
       end
 
       it "throws deprecation when begins to be matched by text content" do
-        msg = /Using :text locator with RegExp \/some hidden\/ to match an element that includes hidden text is deprecated\. Use :visible_text instead/
-        expect { browser.div(text: /some hidden/).exists? }.to output(msg).to_stdout_from_any_process
+        expect { browser.div(text: /some hidden/).exists? }.to have_deprecated_text_regexp
       end
 
       it "does not throw deprecation when still not matched by text content" do
-        expect { browser.div(text: /does not exist/).exists? }.not_to output(/visible_text/).to_stdout_from_any_process
+        expect { browser.div(text: /does not exist/).exists? }.not_to have_deprecated_text_regexp
       end
     end
   end

--- a/spec/watirspec/elements/dt_spec.rb
+++ b/spec/watirspec/elements/dt_spec.rb
@@ -31,11 +31,11 @@ describe "Dt" do
   # Attribute methods
   describe "#class_name" do
     it "returns the class attribute if the element exists" do
-      expect(browser.dt(:id , "experience").class_name).to eq "industry"
+      expect(browser.dt(id: "experience").class_name).to eq "industry"
     end
 
     it "returns an empty string if the element exists but the attribute doesn't" do
-      expect(browser.dt(:id , "education").class_name).to eq ""
+      expect(browser.dt(id: "education").class_name).to eq ""
     end
 
     it "raises UnknownObjectException if the element does not exist" do

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -217,10 +217,9 @@ describe "Element" do
       browser.refresh
 
       expect(element).to be_stale
-      msg = /Checking `#visible\?` or `#present\? == false` to determine a stale element is deprecated. Use `#stale\? == true` instead\./
       expect {
         expect { element.visible? }.to raise_unknown_object_exception
-      }.to output(msg).to_stdout_from_any_process
+      }.to have_deprecated_stale_visible
     end
 
     it "returns true if the element has style='visibility: visible' even if parent has style='visibility: hidden'" do
@@ -270,15 +269,15 @@ describe "Element" do
     end
 
     it 'returns true if the element exists and is visible' do
-      expect(browser.div(:id, 'foo')).to be_present
+      expect(browser.div(id: 'foo')).to be_present
     end
 
     it 'returns false if the element exists but is not visible' do
-      expect(browser.div(:id, 'bar')).to_not be_present
+      expect(browser.div(id: 'bar')).to_not be_present
     end
 
     it 'returns false if the element does not exist' do
-      expect(browser.div(:id, 'should-not-exist')).to_not be_present
+      expect(browser.div(id: 'should-not-exist')).to_not be_present
     end
 
     # TODO Refactor so that this returns true
@@ -289,10 +288,9 @@ describe "Element" do
 
       expect(element).to be_stale
 
-      msg = /Checking `#visible\?` or `#present\? == false` to determine a stale element is deprecated. Use `#stale\? == true` instead\./
       expect {
         expect(element).to_not be_present
-      }.to output(msg).to_stdout_from_any_process
+      }.to have_deprecated_stale_visible
     end
 
     # TODO Documents Current Behavior, but needs to be refactored/removed
@@ -303,10 +301,9 @@ describe "Element" do
 
       expect(element).to be_stale
 
-      msg = /Checking `#visible\?` or `#present\? == false` to determine a stale element is deprecated. Use `#stale\? == true` instead\./
       expect {
         expect(element).to_not be_present
-      }.to output(msg).to_stdout_from_any_process
+      }.to have_deprecated_stale_visible
       expect(element).to be_present
     end
 
@@ -555,7 +552,7 @@ describe "Element" do
     end
 
     it "locate is false when not located" do
-      element = browser.div(:id, 'not_present')
+      element = browser.div(id: 'not_present')
       expect(element.inspect).to include('located: false')
     end
 

--- a/spec/watirspec/elements/hn_spec.rb
+++ b/spec/watirspec/elements/hn_spec.rb
@@ -77,7 +77,7 @@ describe ["H1", "H2", "H3", "H4", "H5", "H6"] do
 
     it "raises UnknownObjectException if the p doesn't exist" do
       expect { browser.h1(id: 'no_such_id').text }.to raise_unknown_object_exception
-      expect { browser.h1(:xpath , "//h1[@id='no_such_id']").text }.to raise_unknown_object_exception
+      expect { browser.h1(xpath: "//h1[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/hns_spec.rb
+++ b/spec/watirspec/elements/hns_spec.rb
@@ -28,7 +28,7 @@ describe ["H1s", "H2s", "H3s", "H4s", "H5s", "H6s"] do
       lengths = (1..6).collect do |i|
         collection = browser.send(:"h#{i}s")
         collection.each_with_index do |h, index|
-          expect(h.id).to eq browser.send(:"h#{i}", :index, index).id
+          expect(h.id).to eq browser.send(:"h#{i}", index: index).id
         end
         collection.length
       end

--- a/spec/watirspec/elements/ins_spec.rb
+++ b/spec/watirspec/elements/ins_spec.rb
@@ -95,7 +95,7 @@ describe "Ins" do
 
     it "raises UnknownObjectException if the ins doesn't exist" do
       expect { browser.ins(id: 'no_such_id').text }.to raise_unknown_object_exception
-      expect { browser.ins(:xpath , "//ins[@id='no_such_id']").text }.to raise_unknown_object_exception
+      expect { browser.ins(xpath: "//ins[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/li_spec.rb
+++ b/spec/watirspec/elements/li_spec.rb
@@ -95,7 +95,7 @@ describe "Li" do
 
     it "raises UnknownObjectException if the li doesn't exist" do
       expect { browser.li(id: 'no_such_id').text }.to raise_unknown_object_exception
-      expect { browser.li(:xpath , "//li[@id='no_such_id']").text }.to raise_unknown_object_exception
+      expect { browser.li(xpath: "//li[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/p_spec.rb
+++ b/spec/watirspec/elements/p_spec.rb
@@ -95,7 +95,7 @@ describe "P" do
 
     it "raises UnknownObjectException if the p doesn't exist" do
       expect { browser.p(id: 'no_such_id').text }.to raise_unknown_object_exception
-      expect { browser.p(:xpath , "//p[@id='no_such_id']").text }.to raise_unknown_object_exception
+      expect { browser.p(xpath: "//p[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/pre_spec.rb
+++ b/spec/watirspec/elements/pre_spec.rb
@@ -95,7 +95,7 @@ describe "Pre" do
 
     it "raises UnknownObjectException if the pre doesn't exist" do
       expect { browser.pre(id: 'no_such_id').text }.to raise_unknown_object_exception
-      expect { browser.pre(:xpath , "//pre[@id='no_such_id']").text }.to raise_unknown_object_exception
+      expect { browser.pre(xpath: "//pre[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -261,8 +261,7 @@ describe "SelectList" do
 
       it "selects an option with a Regexp" do
         browser.select_list(name: "new_user_languages").clear
-        msg = /Selecting Multiple Options with #select is deprecated\. Use #select_all instead/
-        expect { browser.select_list(name: "new_user_languages").select(/1|3/) }.to output(msg).to_stdout_from_any_process
+        expect { browser.select_list(name: "new_user_languages").select(/1|3/) }.to have_deprecated_select_by
         expect(browser.select_list(name: "new_user_languages").selected_options.map(&:text)).to eq %w[Danish NO]
       end
     end

--- a/spec/watirspec/elements/span_spec.rb
+++ b/spec/watirspec/elements/span_spec.rb
@@ -95,7 +95,7 @@ describe "Span" do
 
     it "raises UnknownObjectException if the span doesn't exist" do
       expect { browser.span(id: 'no_such_id').text }.to raise_unknown_object_exception
-      expect { browser.span(:xpath , "//span[@id='no_such_id']").text }.to raise_unknown_object_exception
+      expect { browser.span(xpath: "//span[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/elements/strong_spec.rb
+++ b/spec/watirspec/elements/strong_spec.rb
@@ -72,7 +72,7 @@ describe "Strong" do
 
     it "raises UnknownObjectException if the element doesn't exist" do
       expect { browser.strong(id: 'no_such_id').text }.to raise_unknown_object_exception
-      expect { browser.strong(:xpath , "//strong[@id='no_such_id']").text }.to raise_unknown_object_exception
+      expect { browser.strong(xpath: "//strong[@id='no_such_id']").text }.to raise_unknown_object_exception
     end
   end
 

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -1,4 +1,39 @@
 if defined?(RSpec)
+  DEPRECATION_WARNINGS = [:selector_parameters,
+                          :class_array,
+                          :use_capabilities,
+                          :visible_text,
+                          :text_regexp,
+                          :stale_visible,
+                          :select_by].freeze
+
+  DEPRECATION_WARNINGS.each do |deprecation|
+    RSpec::Matchers.define "have_deprecated_#{deprecation}" do
+      match do |actual|
+        warning = /\[DEPRECATION\] \["#{deprecation}"\]/
+        expect {
+          actual.call
+          @stdout_message = File.read $stdout if $stdout.is_a?(File)
+        }.to output(warning).to_stdout_from_any_process
+      end
+
+      failure_message do |_actual|
+        deprecations_found = @stdout_message[/WARN Watir \[DEPRECATION\] ([^.*\ ]*)/, 1]
+        but_message = if deprecations_found.nil?
+                        "no Warnings were found"
+                      else
+                        "deprecation Warning of #{deprecations_found} was found instead"
+                      end
+        "expected Warning message of \"#{deprecated}\" being deprecated, but #{but_message}"
+      end
+
+      def supports_block_expectations?
+        true
+      end
+
+    end
+  end
+
   TIMING_EXCEPTIONS = {
     raise_unknown_object_exception: Watir::Exception::UnknownObjectException,
     raise_no_matching_window_exception: Watir::Exception::NoMatchingWindowFoundException,


### PR DESCRIPTION
Using ordered pair locators (how, what) makes it more difficult to add additional selectors if necessary. I'd like to see Watir standardize on always requiring Hashes. (e.g. `:id, 'foo'` be replaced in user code with `id: 'foo'`)