### PR TITLE
don't publish documentation for watirspecs

### DIFF
--- a/.document
+++ b/.document
@@ -1,5 +1,4 @@
 README.rdoc
-lib/**/*.rb
-bin/*
-features/**/*.feature
 LICENSE
+lib/watir/**/*.rb
+lib/watir.rb


### PR DESCRIPTION
I think the watirspecs are unnecessary to include in the documentation. What do you think?