### PR TITLE
allow wait methods to wait for values of any attribute

### DIFF
--- a/spec/watirspec/html/wait.html
+++ b/spec/watirspec/html/wait.html
@@ -11,7 +11,9 @@
 
       function setTimeoutDisplay(id, display, timeout) {
           setTimeout(function() {
-              document.getElementById(id).style.display = display;
+              var el = document.getElementById(id)
+                  el.style.display = display;
+                  el.setAttribute("custom", id)
           }, timeout);
       }
 
@@ -54,7 +56,7 @@
   </head>
 
   <body>
-    <div id="foo" style="display:block;">foo</div>
+    <div id="foo" custom="" style="display:block;">foo</div>
     <div id="bar" style="display:none;" onclick='this.innerHTML = "changed"'>bar</div>
     <a id="show_bar" href="#" onclick="setTimeoutDisplay('bar', 'block', 500);">show bar</a>
     <a id="hide_foo" href="#" onclick="setTimeoutDisplay('foo', 'none', 500);">hide foo</a>

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -204,6 +204,49 @@ describe Watir::Element do
       element = browser.div(id: 'bar')
       expect { element.wait_until(interval: 0.1) { true } }.to_not raise_exception
     end
+
+    context "accepts keywords instead of block" do
+      before { browser.refresh }
+
+      it "accepts text keyword" do
+        element = browser.div(id: 'bar')
+        browser.a(id: 'show_bar').click
+        expect { element.wait_until(text: 'bar') }.to_not raise_exception
+      end
+
+      it "accepts regular expression value" do
+        element = browser.div(id: 'bar')
+        browser.a(id: 'show_bar').click
+        expect { element.wait_until(style: /block/) }.to_not raise_exception
+      end
+
+      it "accepts multiple keywords" do
+        element = browser.div(id: 'bar')
+        browser.a(id: 'show_bar').click
+        expect { element.wait_until(text: 'bar', style: /block/) }.to_not raise_exception
+      end
+
+      it "accepts custom keyword" do
+        element = browser.div(id: 'bar')
+        browser.a(id: 'show_bar').click
+        expect { element.wait_until(custom: 'bar') }.to_not raise_exception
+      end
+
+      it "times out when single keyword not met" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until(id: 'foo') }.to raise_timeout_exception
+      end
+
+      it "times out when one of multiple keywords not met" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until(id: 'bar', text: 'foo') }.to raise_timeout_exception
+      end
+
+      it "times out when a custom keywords not met" do
+        element = browser.div(id: 'bar')
+        expect { element.wait_until(custom: 'foo') }.to raise_timeout_exception
+      end
+    end
   end
 
   describe "#wait_while" do
@@ -239,6 +282,48 @@ describe Watir::Element do
     it "accepts just an interval parameter" do
       element = browser.div(id: 'foo')
       expect { element.wait_while(interval: 0.1) { false } }.to_not raise_exception
+    end
+
+    context "accepts keywords instead of block" do
+      it "accepts text keyword" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect { element.wait_while(text: 'foo') }.to_not raise_exception
+      end
+
+      it "accepts regular expression value" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect { element.wait_while(style: /block/) }.to_not raise_exception
+      end
+
+      it "accepts multiple keywords" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect { element.wait_while(text: 'foo', style: /block/) }.to_not raise_exception
+      end
+
+      it "accepts custom attributes" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect { element.wait_while(custom: '') }.to_not raise_exception
+      end
+
+      it "times out when single keyword not met" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while(id: 'foo') }.to raise_timeout_exception
+      end
+
+      it "times out when one of multiple keywords not met" do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect { element.wait_while(id: 'foo', style: /block/) }.to raise_timeout_exception
+      end
+
+      it "times out when one of custom keywords not met" do
+        element = browser.div(id: 'foo')
+        expect { element.wait_while(custom: '') }.to raise_timeout_exception
+      end
     end
   end
 end


### PR DESCRIPTION
When debugging the question on watir-general it got me thinking about why we can't make the wait_while & wait_until methods more powerful.

Get a Hash of everything that doesn't match one of the predefined keywords and then wait for them to have the value provided. This code supports RegExp & String, not sure the use cases for other types, so let me know if you think it should be opened up,