### PR TITLE
Fix Context Methods

### DIFF
--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -311,13 +311,17 @@ module Watir
     #
 
     def assert_exists
-      ensure_context
+      locate
       return if window.present?
       raise Exception::NoMatchingWindowFoundException, "browser window was closed"
     end
 
-    def ensure_context
+    def locate
       raise Exception::Error, "browser was closed" if @closed
+      ensure_context
+    end
+
+    def ensure_context
       driver.switch_to.default_content unless @default_context
       @default_context = true
     end

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -168,8 +168,7 @@ module Watir
     end
 
     def locate_all
-      @locator ||= build_locator
-      @elements ||= @locator.locate_all
+      build_locator.locate_all
     end
 
     def element_class

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -88,14 +88,16 @@ module Watir
       hash = {}
       @to_a ||=
           elements.map.with_index do |e, idx|
-            element = element_class.new(@query_scope, @selector.merge(element: e, index: idx))
+            selector = @selector.merge(element: e)
+            selector[:index] = idx
+            element = element_class.new(@query_scope, selector)
             if [Watir::HTMLElement, Watir::Input].include? element.class
               tag_name = @selector[:tag_name] || element.tag_name.to_sym
               hash[tag_name] ||= 0
               hash[tag_name] += 1
-              Watir.element_class_for(tag_name).new(@query_scope, @selector.merge(element: e,
-                                                                                   tag_name: tag_name,
-                                                                                   index: hash[tag_name] - 1))
+              selector[:index] = hash[tag_name] - 1
+              selector[:tag_name] = tag_name
+              Watir.element_class_for(tag_name).new(@query_scope, selector)
             else
               element
             end
@@ -151,6 +153,16 @@ module Watir
     private
 
     def elements
+      ensure_context
+      locate_all
+    end
+
+    def ensure_context
+      @query_scope.send :locate
+      @query_scope.switch_to! if @query_scope.is_a?(IFrame)
+    end
+
+    def locate_all
       @locator ||= build_locator
       @elements ||= @locator.locate_all
     end

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -154,7 +154,12 @@ module Watir
 
     def elements
       ensure_context
-      locate_all
+      if @query_scope.is_a?(Watir::Browser) || @query_scope.located?
+        locate_all
+      else
+        # This gives all of the standard Watir waiting behaviors to Collections
+        @query_scope.send(:element_call) { locate_all }
+      end
     end
 
     def ensure_context

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -1,36 +1,25 @@
 module Watir
   class IFrame < HTMLElement
 
-    def locate
-      return if @selector.empty?
-      @query_scope.ensure_context
-
-      selector = @selector.merge(tag_name: frame_tag)
-      element_validator = element_validator_class.new
-      selector_builder = selector_builder_class.new(@query_scope, selector, self.class.attribute_list)
-      @locator = locator_class.new(@query_scope, selector, selector_builder, element_validator)
-
-      element = @locator.locate
-      element or raise unknown_exception, "unable to locate #{@selector[:tag_name]} using #{selector_string}"
-
-      @element = FramedDriver.new(element, browser)
-    end
-
-    def ==(other)
-      return false unless other.is_a?(self.class)
-      wd == other.wd.is_a?(FramedDriver) ? other.wd.send(:wd) : other.wd
+    def locate_in_context
+      @selector.merge(tag_name: frame_tag)
+      super
     end
 
     def switch_to!
-      locate.send :switch!
+      wd.send :switch!
     end
 
     def assert_exists
+      super
       if @element && @selector.empty?
         raise UnknownFrameException, "wrapping a Selenium element as a Frame is not currently supported"
       end
+    end
 
+    def wd
       super
+      @driver ||= FramedDriver.new(@element, browser)
     end
 
     #
@@ -50,8 +39,7 @@ module Watir
     #
 
     def html
-      wait_for_exists
-      @element.page_source
+      wd.page_source
     end
 
     #
@@ -65,10 +53,6 @@ module Watir
       returned = driver.execute_script(script, *args)
 
       browser.send(:wrap_elements_in, self, returned)
-    end
-
-    def ensure_context
-      switch_to!
     end
 
     private
@@ -125,7 +109,6 @@ module Watir
     def initialize(element, browser)
       @element = element
       @browser = browser
-      @driver = browser.driver
     end
 
     def ==(other)
@@ -135,28 +118,28 @@ module Watir
 
     def send_keys(*args)
       switch!
-      @driver.switch_to.active_element.send_keys(*args)
+      wd.switch_to.active_element.send_keys(*args)
     end
 
     protected
 
     def wd
-      @element
+      @browser.driver
     end
 
     private
 
     def method_missing(meth, *args, &blk)
-      if @driver.respond_to?(meth)
+      if wd.respond_to?(meth) && !%i[find_element find_elements].include?(meth)
         switch!
-        @driver.send(meth, *args, &blk)
+        wd.send(meth, *args, &blk)
       else
-        @element.send(meth, *args, &blk)
+        wd.send(meth, *args, &blk)
       end
     end
 
     def switch!
-      @driver.switch_to.frame @element
+      wd.switch_to.frame @element
       @browser.default_context = false
     rescue Selenium::WebDriver::Error::NoSuchFrameError => e
       raise Exception::UnknownFrameException, e.message

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -55,6 +55,16 @@ module Watir
       browser.send(:wrap_elements_in, self, returned)
     end
 
+    #
+    # Sends sequence of keystrokes to the driver within the frame context.
+    #
+    # @param [String, Symbol] args
+    #
+
+    def send_keys(*args)
+      element_call(:wait_for_writable) { wd.send_keys(*args) }
+    end
+
     private
 
     def frame_tag

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -57,8 +57,6 @@ module Watir
       end
 
       def build_locator
-        @query_scope.send :ensure_context
-
         element_validator = element_validator_class.new
         selector_builder = selector_builder_class.new(@query_scope, @selector.dup, element_class.attribute_list)
         locator_class.new(@query_scope, @selector.dup, selector_builder, element_validator)

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -317,7 +317,7 @@ describe Watir::Locators::Element::Locator do
         expect_all(:tag_name, "label").ordered.and_return(label_elements)
         expect_one(:xpath, ".//div[@id='baz']").ordered.and_return(div_elements.first)
 
-        allow(browser).to receive(:ensure_context).and_return(nil)
+        allow(browser).to receive(:assert_exists).and_return(nil)
         allow(browser).to receive(:execute_script).and_return('foo', 'foob')
 
         expect(locate_one(tag_name: "div", label: /oob/)).to eq div_elements.first

--- a/spec/watirspec/elements/frame_spec.rb
+++ b/spec/watirspec/elements/frame_spec.rb
@@ -12,8 +12,6 @@ describe "Frame" do
 
   not_compliant_on :safari do
     it "handles crossframe javascript" do
-      browser.goto WatirSpec.url_for("frames.html")
-
       expect(browser.frame(id: "frame_1").text_field(name: 'senderElement').value).to eq 'send_this_value'
       expect(browser.frame(id: "frame_2").text_field(name: 'recieverElement').value).to eq 'old_value'
       browser.frame(id: "frame_1").button(id: 'send').click

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -166,6 +166,12 @@ describe "IFrame" do
     expect { browser.text_field(name: 'senderElement').set('no') }.to raise_unknown_object_exception('Maybe look in an iframe?')
   end
 
+  it 'will suggest looking in a nested iframe when iframes exist' do
+    browser.goto(WatirSpec.url_for("nested_iframes.html"))
+    top = browser.iframe(id: "two")
+    expect { top.link(id: 'four').click }.to raise_unknown_object_exception('Maybe look in an iframe?')
+  end
+
   describe "#execute_script" do
     bug "Safari does not strip text", :safari do
       it "executes the given javascript in the specified frame" do

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -353,6 +353,13 @@ describe "SelectList" do
         select_list = browser.select_list(id: 'languages')
         expect { select_list.select('No') }.to wait_and_raise_no_value_found_exception
       end
+
+      it 'waits for select list when selecting an option' do
+        browser.goto WatirSpec.url_for("wait.html")
+        select_list = browser.select_list(id: 'not_there')
+
+        expect { select_list.select('Anything') }.to wait_and_raise_unknown_object_exception
+      end
     end
 
     it "raises NoValueFoundException if the option doesn't exist" do

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -351,14 +351,7 @@ describe "SelectList" do
         browser.goto WatirSpec.url_for("wait.html")
         browser.a(id: 'add_select').click
         select_list = browser.select_list(id: 'languages')
-        Watir.default_timeout = 2
-        begin
-          start_time = ::Time.now
-          expect { select_list.select('No') }.to raise_error Watir::Exception::NoValueFoundException
-          expect(::Time.now - start_time).to be > 2
-        ensure
-          Watir.default_timeout = 30
-        end
+        expect { select_list.select('No') }.to wait_and_raise_no_value_found_exception
       end
     end
 

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -99,6 +99,20 @@ describe 'Watir#relaxed_locate?' do
           Watir.default_timeout = 30
         end
       end
+
+      it 'waits for parent element to be present before locating a collection' do
+        els = browser.element(id: "not_there").elements(id: "doesnt_matter")
+        begin
+          time_out = 2
+          Watir.default_timeout = time_out
+          element = browser.link(id: 'not_there')
+          start_time = ::Time.now
+          expect { els.to_a }.to raise_exception(Watir::Exception::UnknownObjectException)
+          expect(::Time.now - start_time).to be > time_out
+        ensure
+          Watir.default_timeout = 30
+        end
+      end
     end
   end
 

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -9,57 +9,28 @@ describe 'Watir#relaxed_locate?' do
 
       context 'when acting on an element that is never present' do
         it 'raises exception after timing out' do
-          begin
-            time_out = 2
-            Watir.default_timeout = time_out
-            element = browser.link(id: 'not_there')
-            start_time = ::Time.now
-            allow($stderr).to receive(:write).twice
-            expect { element.click }.to raise_exception(Watir::Exception::UnknownObjectException)
-            expect(::Time.now - start_time).to be > time_out
-          ensure
-            Watir.default_timeout = 30
-          end
+          element = browser.link(id: 'not_there')
+          expect { element.click }.to wait_and_raise_unknown_object_exception
         end
       end
 
       context 'when acting on an element whose parent is never present' do
         it 'raises exception after timing out' do
-          begin
-            time_out = 2
-            Watir.default_timeout = time_out
-            element = browser.link(id: 'not_there')
-            start_time = ::Time.now
-            allow($stderr).to receive(:write).twice
-            expect { element.element.click }.to raise_exception(Watir::Exception::UnknownObjectException)
-            expect(::Time.now - start_time).to be > time_out
-          ensure
-            Watir.default_timeout = 30
-          end
+          element = browser.link(id: 'not_there')
+          expect { element.element.click }.to wait_and_raise_unknown_object_exception
         end
       end
 
       context 'when acting on an element from a collection whose parent is never present' do
         it 'raises exception after timing out' do
-          begin
-            time_out = 2
-            Watir.default_timeout = time_out
-            element = browser.link(id: 'not_there')
-            start_time = ::Time.now
-            allow($stderr).to receive(:write).twice
-            expect { element.elements[2].click }.to raise_exception(Watir::Exception::UnknownObjectException)
-            expect(::Time.now - start_time).to be > time_out
-          ensure
-            Watir.default_timeout = 30
-          end
+          element = browser.link(id: 'not_there')
+          expect { element.elements[2].click }.to wait_and_raise_unknown_object_exception
         end
       end
 
       context 'when acting on an element that is already present' do
         it 'does not wait' do
-          start_time = ::Time.now
-          expect { browser.link.click }.to_not raise_exception
-          expect(::Time.now - start_time).to be < Watir.default_timeout
+          expect { browser.link.click }.to execute_immediately
         end
       end
 
@@ -102,16 +73,7 @@ describe 'Watir#relaxed_locate?' do
 
       it 'waits for parent element to be present before locating a collection' do
         els = browser.element(id: "not_there").elements(id: "doesnt_matter")
-        begin
-          time_out = 2
-          Watir.default_timeout = time_out
-          element = browser.link(id: 'not_there')
-          start_time = ::Time.now
-          expect { els.to_a }.to raise_exception(Watir::Exception::UnknownObjectException)
-          expect(::Time.now - start_time).to be > time_out
-        ensure
-          Watir.default_timeout = 30
-        end
+        expect { els.to_a }.to wait_and_raise_unknown_object_exception
       end
     end
   end

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -331,39 +331,24 @@ end
 describe Watir do
   describe "#default_timeout" do
     before do
-      Watir.default_timeout = 1
-
       browser.goto WatirSpec.url_for("wait.html")
-    end
-
-    after do
-      # Reset the default timeout
-      Watir.default_timeout = 30
     end
 
     context "when no timeout is specified" do
       it "is used by Wait#until" do
-        expect {
-          Watir::Wait.until { false }
-        }.to raise_error(Watir::Wait::TimeoutError)
+        expect { Watir::Wait.until { false } }.to raise_timeout_exception
       end
 
       it "is used by Wait#while" do
-        expect {
-          Watir::Wait.while { true }
-        }.to raise_error(Watir::Wait::TimeoutError)
+        expect { Watir::Wait.while { true } }.to raise_timeout_exception
       end
 
       it "is used by Element#wait_until_present" do
-        expect {
-          browser.div(id: 'bar').wait_until_present
-        }.to raise_error(Watir::Wait::TimeoutError)
+        expect { browser.div(id: 'bar').wait_until_present }.to raise_timeout_exception
       end
 
       it "is used by Element#wait_while_present" do
-        expect {
-          browser.div(id: 'foo').wait_while_present
-        }.to raise_error(Watir::Wait::TimeoutError)
+        expect { browser.div(id: 'foo').wait_while_present }.to raise_timeout_exception
       end
     end
   end


### PR DESCRIPTION
1. Locators class shouldn't need to know anything about scope
2. Ensuring Context shouldn't also locate; it only needs to locate the parent
3. This also required fixing weirdness with Frames and FramedDriver. This code allows frames to use more of Element super class methods and logic. The only weirdness is in having to treat `#find_element` and `#find_elements` differently.

This should let us fix #759 though I wanted to get this refactor passing all the tests first