### PR TITLE
Feature - Add Watir::Element#attribute_values and #attribute_list which return attributes from an element.

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -275,6 +275,43 @@ module Watir
     alias attribute attribute_value
 
     #
+    # Returns all attribute values. Attributes with special characters are returned as String,
+    # rest are returned as a Symbol.
+    #
+    # @return [Hash]
+    #
+    # @example
+    #   browser.pre(id: 'rspec').attribute_values
+    #   #=> {class:'ruby', id: 'rspec' }
+    #
+
+    def attribute_values
+      result = element_call { execute_js(:attributeValues, @element) }
+      result.keys.each do |key|
+        next unless key == key[/[a-zA-Z\-]*/]
+
+        result[key.tr('-', '_').to_sym] = result.delete(key)
+      end
+      result
+    end
+    alias attributes attribute_values
+
+    #
+    # Returns list of all attributes. Attributes with special characters are returned as String,
+    # rest are returned as a Symbol.
+    #
+    # @return [Array]
+    #
+    # @example
+    #   browser.pre(id: 'rspec').attribute_list
+    #   #=> [:class, :id]
+    #
+
+    def attribute_list
+      attribute_values.keys
+    end
+
+    #
     # Sends sequence of keystrokes to element.
     #
     # @example

--- a/lib/watir/js_snippets/attributeValues.js
+++ b/lib/watir/js_snippets/attributeValues.js
@@ -1,0 +1,11 @@
+// Original Author: Justin Ko
+// Source: https://stackoverflow.com/questions/12485833/how-do-i-retrieve-list-of-element-attributes-using-watir-webdriver
+function() {
+    var s = {};
+    var attrs = arguments[0].attributes;
+    for (var l = 0; l < attrs.length; ++l) {
+        var a = attrs[l];
+        s[a.name] = a.value.trim();
+    }
+    return s;
+}

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -432,7 +432,7 @@ describe 'Element' do
       end
 
       it 'finds the last element by index: -1' do
-        expect(browser.element(index: -1).tag_name).to eq 'p'
+        expect(browser.element(index: -1).tag_name).to eq 'div'
       end
     end
 
@@ -708,6 +708,44 @@ describe 'Element' do
 
     it 'returns attribute value by symbol attribute name' do
       expect(browser.p.attribute_value(:data_type)).to eq 'ruby-library'
+    end
+  end
+
+  describe '#attribute_values' do
+    before { browser.goto WatirSpec.url_for('data_attributes.html') }
+
+    it 'returns a Hash object' do
+      expect(browser.p.attribute_values).to be_an_instance_of(Hash)
+    end
+
+    it 'returns attribute values from an element' do
+      expected = {data_type: 'ruby-library'}
+      expect(browser.p.attribute_values).to eq expected
+    end
+
+    it 'returns attribute with special characters' do
+      expected = {data_type: 'description', 'data-type_$p3c!a1' => 'special-description'}
+      expect(browser.div.attribute_values).to eq expected
+    end
+
+    it 'returns attribute with special characters as a String' do
+      expect(browser.div.attribute_values.keys[0]).to be_an_instance_of(String)
+    end
+  end
+
+  describe '#attribute_list' do
+    before { browser.goto WatirSpec.url_for('data_attributes.html') }
+
+    it 'returns an Array object' do
+      expect(browser.div.attribute_list).to be_an_instance_of(Array)
+    end
+
+    it 'returns list of attributes from an element' do
+      expect(browser.p.attribute_list).to eq [:data_type]
+    end
+
+    it 'returns attribute name with special characters as a String' do
+      expect(browser.div.attribute_list[0]).to be_an_instance_of(String)
     end
   end
 

--- a/spec/watirspec/html/data_attributes.html
+++ b/spec/watirspec/html/data_attributes.html
@@ -5,5 +5,6 @@
   </head>
   <body>
     <p data-type=ruby-library>watir</p>
+    <div data-type=description data-type_$p3c!a1=special-description>It is amazing!</div>
   </body>
 </html>


### PR DESCRIPTION
Tagging @jkotests and @titusfortner.

**Question**: Should the attributes (keys) be returned as `Symbol` or `String` (from JS)? I prefer `Symbol`, but maybe `String` is more "pure" ¯\_(ツ)_/¯. Currently returns `String`.