### PR TITLE
update Exceptions and Watir namespacing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,13 +56,15 @@ Metrics/MethodLength:
 
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 116
+  Max: 105
   Exclude:
     - 'lib/watir/locators/element/locator.rb'
     - 'lib/watir/locators/element/selector_builder/xpath.rb'
     - 'lib/watir/browser.rb'
+    - 'lib/watir/window.rb'
     - 'lib/watir/elements/element.rb'
     - 'lib/watir/elements/select.rb'
+    - 'lib/watir/generator/base/spec_extractor.rb'
 
 Metrics/PerceivedComplexity:
   Max: 9

--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -104,7 +104,7 @@ module Watir
   #
 
   def self.logger
-    @logger ||= Watir::Logger.new
+    @logger ||= Logger.new
   end
 end
 require 'watir/locators'

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -2,6 +2,7 @@ module Watir
   class Alert
     include EventuallyPresent
     include Waitable
+    include Exception
 
     def initialize(browser)
       @browser = browser
@@ -79,7 +80,7 @@ module Watir
     def exists?
       assert_exists
       true
-    rescue Exception::UnknownObjectException
+    rescue UnknownObjectException
       false
     end
     alias present? exists?
@@ -97,7 +98,7 @@ module Watir
     def assert_exists
       @alert = @browser.driver.switch_to.alert
     rescue Selenium::WebDriver::Error::NoSuchAlertError
-      raise Exception::UnknownObjectException, 'unable to locate alert'
+      raise UnknownObjectException, 'unable to locate alert'
     end
 
     def wait_for_exists
@@ -112,7 +113,7 @@ module Watir
           message << 'consider using Alert#exists? instead of rescuing UnknownObjectException'
           Watir.logger.warn message, ids: [:wait_for_alert]
         end
-        raise Exception::UnknownObjectException, 'unable to locate alert'
+        raise UnknownObjectException, 'unable to locate alert'
       end
     end
   end # Alert

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -8,6 +8,7 @@ module Watir
     include HasWindow
     include Waitable
     include Navigation
+    include Exception
 
     attr_writer :default_context, :original_window, :locator_namespace
     attr_reader :driver, :after_hooks
@@ -40,7 +41,7 @@ module Watir
     def initialize(browser = :chrome, *args)
       case browser
       when ::Symbol, String
-        selenium_args = Watir::Capabilities.new(browser, *args).to_args
+        selenium_args = Capabilities.new(browser, *args).to_args
         @driver = Selenium::WebDriver.for(*selenium_args)
       when Selenium::WebDriver::Driver
         @driver = browser
@@ -212,7 +213,7 @@ module Watir
     #
 
     def execute_script(script, *args)
-      args.map! { |e| e.is_a?(Watir::Element) ? e.wd : e }
+      args.map! { |e| e.is_a?(Element) ? e.wd : e }
 
       wrap_elements_in(self, @driver.execute_script(script, *args))
     end
@@ -262,11 +263,11 @@ module Watir
       locate
       return if window.present?
 
-      raise Exception::NoMatchingWindowFoundException, 'browser window was closed'
+      raise NoMatchingWindowFoundException, 'browser window was closed'
     end
 
     def locate
-      raise Exception::Error, 'browser was closed' if @closed
+      raise Error, 'browser was closed' if @closed
 
       ensure_context
     end
@@ -298,7 +299,7 @@ module Watir
     #
 
     def locator_namespace
-      @locator_namespace ||= Watir::Locators
+      @locator_namespace ||= Locators
     end
 
     #

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -90,7 +90,7 @@ module Watir
           selector = @selector.merge(element: e)
           selector[:index] = idx
           element = element_class.new(@query_scope, selector)
-          if [Watir::HTMLElement, Watir::Input].include? element.class
+          if [HTMLElement, Input].include? element.class
             tag_name = @selector[:tag_name] || element.tag_name.to_sym
             hash[tag_name] ||= 0
             hash[tag_name] += 1

--- a/lib/watir/elements/button.rb
+++ b/lib/watir/elements/button.rb
@@ -6,7 +6,7 @@ module Watir
   #
 
   class Button < HTMLElement
-    inherit_attributes_from Watir::Input
+    inherit_attributes_from Input
 
     VALID_TYPES = %w[button reset submit image].freeze
 
@@ -28,7 +28,7 @@ module Watir
       when 'button'
         super
       else
-        raise Exception::Error, "unknown tag name for button: #{tn}"
+        raise Error, "unknown tag name for button: #{tn}"
       end
     end
   end # Button

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -557,7 +557,7 @@ module Watir
     #
 
     def stale?
-      raise Watir::Exception::Error, 'Can not check staleness of unused element' unless @element
+      raise Error, 'Can not check staleness of unused element' unless @element
 
       ensure_context
       stale_in_context?
@@ -627,7 +627,7 @@ module Watir
       begin
         @query_scope.wait_for_exists unless @query_scope.is_a? Browser
         wait_until(&:exists?)
-      rescue Watir::Wait::TimeoutError
+      rescue Wait::TimeoutError
         msg = "timed out after #{Watir.default_timeout} seconds, waiting for #{inspect} to be located"
         raise unknown_exception, msg
       end
@@ -640,7 +640,7 @@ module Watir
       begin
         @query_scope.wait_for_present unless @query_scope.is_a? Browser
         wait_until_present
-      rescue Watir::Wait::TimeoutError
+      rescue Wait::TimeoutError
         msg = "element located, but timed out after #{Watir.default_timeout} seconds, " \
               "waiting for #{inspect} to be present"
         raise unknown_exception, msg
@@ -656,7 +656,7 @@ module Watir
 
       begin
         wait_until(&:enabled?)
-      rescue Watir::Wait::TimeoutError
+      rescue Wait::TimeoutError
         raise_disabled
       end
     end
@@ -671,7 +671,7 @@ module Watir
 
       begin
         wait_until { !respond_to?(:readonly?) || !readonly? }
-      rescue Watir::Wait::TimeoutError
+      rescue Wait::TimeoutError
         message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, " \
                   "waiting for #{inspect} to not be readonly"
         raise ObjectReadOnlyException, message
@@ -699,7 +699,7 @@ module Watir
     private
 
     def unknown_exception
-      Watir::Exception::UnknownObjectException
+      UnknownObjectException
     end
 
     def raise_writable
@@ -733,7 +733,7 @@ module Watir
     end
 
     def assert_is_element(obj)
-      raise TypeError, "execpted Watir::Element, got #{obj.inspect}:#{obj.class}" unless obj.is_a? Watir::Element
+      raise TypeError, "execpted Watir::Element, got #{obj.inspect}:#{obj.class}" unless obj.is_a? Element
     end
 
     # Removes duplication in #present? & #visible? and makes setting deprecation notice easier
@@ -780,7 +780,7 @@ module Watir
         raise_disabled unless %i[wait_for_present wait_for_enabled wait_for_writable].include?(precondition)
         retry
       rescue Selenium::WebDriver::Error::NoSuchWindowError
-        raise Exception::NoMatchingWindowFoundException, 'browser window was closed'
+        raise NoMatchingWindowFoundException, 'browser window was closed'
       ensure
         Watir.logger.info "<- `Completed #{inspect}##{caller}`"
         Wait.timer.reset! unless already_locked

--- a/lib/watir/elements/hidden.rb
+++ b/lib/watir/elements/hidden.rb
@@ -5,7 +5,7 @@ module Watir
     end
 
     def click
-      raise Watir::Exception::ObjectDisabledException, 'click is not available on the hidden field element'
+      raise ObjectDisabledException, 'click is not available on the hidden field element'
     end
   end
 

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -45,7 +45,7 @@ module Watir
     #
 
     def execute_script(script, *args)
-      args.map! { |e| e.is_a?(Watir::Element) ? e.wd : e }
+      args.map! { |e| e.is_a?(Element) ? e.wd : e }
       returned = driver.execute_script(script, *args)
 
       browser.wrap_elements_in(self, returned)
@@ -77,7 +77,7 @@ module Watir
     private
 
     def unknown_exception
-      Watir::Exception::UnknownFrameException
+      UnknownFrameException
     end
   end # IFrame
 
@@ -125,7 +125,7 @@ module Watir
       @driver.switch_to.frame @element
       @browser.default_context = false
     rescue Selenium::WebDriver::Error::NoSuchFrameError => e
-      raise Exception::UnknownFrameException, e.message
+      raise UnknownFrameException, e.message
     end
 
     def wd

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -1,13 +1,11 @@
 module Watir
   class Select < HTMLElement
-    include Watir::Exception
-
     #
     # Clears all selected options.
     #
 
     def clear
-      raise Error, 'you can only clear multi-selects' unless multiple?
+      raise Exception::Error, 'you can only clear multi-selects' unless multiple?
 
       selected_options.each(&:click)
     end
@@ -189,7 +187,7 @@ module Watir
         next unless what.is_a?(String) ? value == what : value =~ what
         return true if opt.enabled?
 
-        raise Watir::Exception::ObjectDisabledException, "option matching #{what} by #{how} on #{inspect} is disabled"
+        raise ObjectDisabledException, "option matching #{what} by #{how} on #{inspect} is disabled"
       end
       false
     end
@@ -236,7 +234,7 @@ module Watir
       when :value
         element.value =~ exp
       else
-        raise Error, "unknown how: #{how.inspect}"
+        raise Exception::Error, "unknown how: #{how.inspect}"
       end
     end
   end # Select

--- a/lib/watir/elements/table.rb
+++ b/lib/watir/elements/table.rb
@@ -27,7 +27,7 @@ module Watir
 
     def hashes
       all_rows = rows.locate
-      header_row = all_rows.first || raise(Exception::Error, 'no rows in table')
+      header_row = all_rows.first || raise(Error, 'no rows in table')
 
       all_rows.entries[1..-1].map do |row|
         cell_size_check(header_row, row)
@@ -69,7 +69,7 @@ module Watir
 
       index = cell_row.selector[:index]
       row_id = index ? "row at index #{index - 1}" : 'designated row'
-      raise Exception::Error, "#{row_id} has #{row_size} cells, while header row has #{header_size}"
+      raise Error, "#{row_id} has #{row_size} cells, while header row has #{header_size}"
     end
   end # Table
 end # Watir

--- a/lib/watir/exception.rb
+++ b/lib/watir/exception.rb
@@ -7,9 +7,8 @@ module Watir
     class ObjectDisabledException < Error; end
     class ObjectReadOnlyException < Error; end
     class NoValueFoundException < Error; end
-    class UnknownCellException < Error; end
     class NoMatchingWindowFoundException < Error; end
     class UnknownFrameException < Error; end
-    class UnknownRowException < Error; end
+    class LocatorException < Error; end
   end # Exception
 end # Watir

--- a/lib/watir/js_snippets.rb
+++ b/lib/watir/js_snippets.rb
@@ -6,7 +6,7 @@ module Watir
 
     def execute_js(function_name, *arguments)
       file = File.expand_path("../js_snippets/#{function_name}.js", __FILE__)
-      raise Watir::Error, "Can not excute script as #{function_name}.js does not exist" unless File.exist?(file)
+      raise Exception::Error, "Can not excute script as #{function_name}.js does not exist" unless File.exist?(file)
 
       js = File.read(file)
       script = "return (#{js}).apply(null, arguments)"

--- a/lib/watir/legacy_wait.rb
+++ b/lib/watir/legacy_wait.rb
@@ -16,7 +16,7 @@ module Watir
     def method_missing(method, *args, &block)
       return super unless @element.respond_to?(method)
 
-      Watir::Wait.until(@timeout, @message) { wait_until }
+      Wait.until(@timeout, @message) { wait_until }
 
       @element.__send__(method, *args, &block)
     end
@@ -29,9 +29,9 @@ module Watir
 
   class WhenPresentDecorator < BaseDecorator
     def present?
-      Watir::Wait.until(@timeout, @message) { wait_until }
+      Wait.until(@timeout, @message) { wait_until }
       true
-    rescue Watir::Wait::TimeoutError
+    rescue Wait::TimeoutError
       false
     end
 
@@ -85,7 +85,7 @@ module Watir
       message = "waiting for #{selector_string} to become present"
 
       if block_given?
-        Watir::Wait.until(timeout, message) { present? }
+        Wait.until(timeout, message) { present? }
         yield self
       else
         WhenPresentDecorator.new(self, timeout, message)
@@ -112,7 +112,7 @@ module Watir
       message = "waiting for #{selector_string} to become enabled"
 
       if block_given?
-        Watir::Wait.until(timeout, message) { enabled? }
+        Wait.until(timeout, message) { enabled? }
         yield self
       else
         WhenEnabledDecorator.new(self, timeout, message)

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -31,21 +31,21 @@ module Watir
         class_from_string("#{browser.locator_namespace}::#{element_class_name}::Locator") ||
           class_from_string("Watir::Locators::#{element_class_name}::Locator") ||
           class_from_string("#{browser.locator_namespace}::Element::Locator") ||
-          Watir::Locators::Element::Locator
+          Locators::Element::Locator
       end
 
       def element_validator_class
         class_from_string("#{browser.locator_namespace}::#{element_class_name}::Validator") ||
           class_from_string("Watir::Locators::#{element_class_name}::Validator") ||
           class_from_string("#{browser.locator_namespace}::Element::Validator") ||
-          Watir::Locators::Element::Validator
+          Locators::Element::Validator
       end
 
       def selector_builder_class
         class_from_string("#{browser.locator_namespace}::#{element_class_name}::SelectorBuilder") ||
           class_from_string("Watir::Locators::#{element_class_name}::SelectorBuilder") ||
           class_from_string("#{browser.locator_namespace}::Element::SelectorBuilder") ||
-          Watir::Locators::Element::SelectorBuilder
+          Locators::Element::SelectorBuilder
       end
 
       def class_from_string(string)

--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -2,6 +2,8 @@ module Watir
   module Locators
     class Element
       class Locator
+        include Exception
+
         attr_reader :selector_builder
         attr_reader :element_validator
 
@@ -55,7 +57,7 @@ module Watir
 
           unless how
             msg = "internal error: unable to build Selenium selector from #{@normalized_selector.inspect}"
-            raise Exception::Error, msg
+            raise LocatorException, msg
           end
 
           if filter == :all || !values_to_match.empty?
@@ -85,7 +87,7 @@ module Watir
             how = how.to_s.tr('_', '-') if how.is_a?(::Symbol)
             element.attribute(how)
           else
-            raise Error::Exception, "Unable to fetch value for #{how}"
+            raise LocatorException, "Unable to fetch value for #{how}"
           end
         end
 
@@ -271,7 +273,7 @@ module Watir
             sleep 0.5
             retry unless retries > 2
             target = filter == :all ? 'element collection' : 'element'
-            raise StandardError, "Unable to locate #{target} from #{@selector} due to changing page"
+            raise LocatorException, "Unable to locate #{target} from #{@selector} due to changing page"
           end
         end
 
@@ -283,7 +285,7 @@ module Watir
             Watir.logger.deprecate(":#{how} locator", ':visible_text', ids: [:visible_text])
             return true if [:a, :link, nil].include?(tag)
 
-            raise StandardError, "Can not use #{how} locator to find a #{what} element"
+            raise LocatorException, "Can not use #{how} locator to find a #{what} element"
           elsif how == :tag_name
             return true
           else

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -3,6 +3,8 @@ module Watir
     class Element
       class SelectorBuilder
         class XPath
+          include Exception
+
           # Regular expressions that can be reliably converted to xpath `contains`
           # expressions in order to optimize the locator.
           CONVERTABLE_REGEXP = /
@@ -115,7 +117,7 @@ module Watir
             when ::Symbol
               "@#{key.to_s.tr('_', '-')}"
             else
-              raise Error::Exception, "Unable to build XPath using #{key}"
+              raise LocatorException, "Unable to build XPath using #{key}"
             end
           end
 

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -1,7 +1,7 @@
 module Watir
   class RadioSet
     extend Forwardable
-    include Watir::Exception
+    include Exception
     include Enumerable
 
     delegate %i[exists? present? visible? browser] => :source
@@ -52,7 +52,7 @@ module Watir
       elsif n.empty?
         return source
       else
-        raise Watir::Exception::UnknownObjectException, "#{opt[:name]} does not match name of RadioSet: #{n}"
+        raise UnknownObjectException, "#{opt[:name]} does not match name of RadioSet: #{n}"
       end
     end
 
@@ -65,9 +65,9 @@ module Watir
       if !n.empty? && (!opt[:name] || opt[:name] == n)
         element_call(:wait_for_present) { frame.radios(opt.merge(name: n)) }
       elsif n.empty?
-        Watir::RadioCollection.new(frame, element: source.wd)
+        RadioCollection.new(frame, element: source.wd)
       else
-        raise Watir::Exception::UnknownObjectException, "#{opt[:name]} does not match name of RadioSet: #{n}"
+        raise UnknownObjectException, "#{opt[:name]} does not match name of RadioSet: #{n}"
       end
     end
 

--- a/lib/watir/user_editable.rb
+++ b/lib/watir/user_editable.rb
@@ -33,7 +33,7 @@ module Watir
       append(input_value[-1])
       return if value == input_value
 
-      raise Watir::Exception::Error, "#set! value: '#{value}' does not match expected input: '#{input_value}'"
+      raise Exception::Error, "#set! value: '#{value}' does not match expected input: '#{input_value}'"
     end
 
     #
@@ -66,7 +66,7 @@ module Watir
       element_call { execute_js(:setText, @element, input_text) }
       return if text == input_text
 
-      raise Watir::Exception::Error, "#set! text: '#{text}' does not match expected input: '#{input_text}'"
+      raise Exception::Error, "#set! text: '#{text}' does not match expected input: '#{input_text}'"
     end
   end # UserEditable
 end # Watir

--- a/lib/watir/wait.rb
+++ b/lib/watir/wait.rb
@@ -212,7 +212,7 @@ module Watir
 
     def create_proc(opt)
       proc do
-        reset! if is_a?(Watir::Element)
+        reset! if is_a?(Element)
         (opt.empty? || match_attributes(opt).call) && (!block_given? || yield(self))
       end
     end
@@ -221,7 +221,7 @@ module Watir
       proc do
         opt.keys.all? do |key|
           expected = opt[key]
-          actual = if is_a?(Watir::Element) && !respond_to?(key)
+          actual = if is_a?(Element) && !respond_to?(key)
                      attribute_value(key)
                    else
                      send(key)

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -2,6 +2,7 @@ module Watir
   class Window
     include EventuallyPresent
     include Waitable
+    include Exception
 
     attr_reader :browser
 
@@ -101,7 +102,7 @@ module Watir
     def exists?
       assert_exists
       true
-    rescue Exception::NoMatchingWindowFoundException
+    rescue NoMatchingWindowFoundException
       false
     end
 
@@ -215,7 +216,9 @@ module Watir
     end
 
     def assert_exists
-      raise(Exception::NoMatchingWindowFoundException, @selector.inspect) unless @driver.window_handles.include?(handle)
+      return if @driver.window_handles.include?(handle)
+
+      raise(NoMatchingWindowFoundException, @selector.inspect)
     end
 
     # return a handle to the currently active window if it is still open; otherwise nil
@@ -243,7 +246,7 @@ module Watir
       begin
         wait_until(&:exists?)
       rescue Wait::TimeoutError
-        raise Exception::NoMatchingWindowFoundException, @selector.inspect
+        raise NoMatchingWindowFoundException, @selector.inspect
       end
     end
   end # Window

--- a/lib/watirspec/remote_server.rb
+++ b/lib/watirspec/remote_server.rb
@@ -1,5 +1,7 @@
 module WatirSpec
   class RemoteServer
+    include Watir::Exception
+
     attr_reader :server
 
     def start(port = 4444, args: [])
@@ -33,7 +35,7 @@ module WatirSpec
       end
     rescue SocketError
       # not connected to internet
-      raise Watir::Exception::Error, 'unable to find or download selenium-server-standalone jar'
+      raise Error, 'unable to find or download selenium-server-standalone jar'
     end
   end
 end


### PR DESCRIPTION
* Removes unnecessary namepsacing; including modules being referenced 
* Creates `LocatorException` for exceptions related to locating an Element
* Creates `WatirException` as a general exception instead of having to use `Error::Exception`
* Removes unused exceptions: `UnknownCellException` & `UnknownRowException`