### PR TITLE
deprecate #wait_while_present and #wait_until_present

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -651,7 +651,8 @@ module Watir
       return assert_enabled unless Watir.relaxed_locate?
 
       wait_for_exists
-      return if [Input, Button, Select, Option].none? { |c| is_a? c }
+      return unless [Input, Button, Select, Option].any? { |c| is_a? c } || @content_editable
+      return if enabled?
 
       begin
         wait_until(&:enabled?)
@@ -665,6 +666,8 @@ module Watir
       unless Watir.relaxed_locate?
         raise_writable unless !respond_to?(:readonly?) || !readonly?
       end
+
+      return if !respond_to?(:readonly?) || !readonly?
 
       begin
         wait_until { !respond_to?(:readonly?) || !readonly? }

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -3,6 +3,8 @@ module Watir
     include EventuallyPresent
     include Waitable
 
+    attr_reader :browser
+
     def initialize(browser, selector)
       @browser = browser
       @driver = browser.driver

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -6,7 +6,9 @@ if defined?(RSpec)
                             text_regexp
                             stale_visible
                             stale_present
-                            select_by].freeze
+                            select_by
+                            wait_until_present
+                            wait_while_present].freeze
 
   DEPRECATION_WARNINGS.each do |deprecation|
     RSpec::Matchers.define "have_deprecated_#{deprecation}" do

--- a/spec/watirspec/wait_spec.rb
+++ b/spec/watirspec/wait_spec.rb
@@ -107,48 +107,63 @@ describe Watir::Element do
   describe '#wait_until_present' do
     it 'waits until the element appears' do
       browser.a(id: 'show_bar').click
-      expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
+      expect {
+        expect { browser.div(id: 'bar').wait_until_present(timeout: 5) }.to_not raise_exception
+      }.to have_deprecated_wait_until_present
     end
 
     it 'waits until the element re-appears' do
       browser.link(id: 'readd_bar').click
-      expect { browser.div(id: 'bar').wait_until_present }.to_not raise_exception
+      expect {
+        expect { browser.div(id: 'bar').wait_until_present }.to_not raise_exception
+      }.to have_deprecated_wait_until_present
     end
 
     it "times out if the element doesn't appear" do
       inspected = '#<Watir::Div: located: true; {:id=>"bar", :tag_name=>"div"}>'
       error = Watir::Wait::TimeoutError
-      message = "timed out after 1 seconds, waiting for element #{inspected} to become present"
+      message = "timed out after 1 seconds, waiting for #{inspected} to become present"
 
-      expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(error, message)
+      expect {
+        expect { browser.div(id: 'bar').wait_until_present(timeout: 1) }.to raise_error(error, message)
+      }.to have_deprecated_wait_until_present
     end
 
     it 'uses provided interval' do
       element = browser.div(id: 'bar')
       expect(element).to receive(:present?).twice
 
-      expect { element.wait_until_present(timeout: 0.4, interval: 0.2) }.to raise_timeout_exception
+      expect {
+        expect { element.wait_until_present(timeout: 0.4, interval: 0.2) }.to raise_timeout_exception
+      }.to have_deprecated_wait_until_present
     end
   end
 
   describe '#wait_while_present' do
     it 'waits until the element disappears' do
       browser.a(id: 'hide_foo').click
-      expect { browser.div(id: 'foo').wait_while_present(timeout: 2) }.to_not raise_exception
+      expect {
+        expect { browser.div(id: 'foo').wait_while_present(timeout: 2) }.to_not raise_exception
+      }.to have_deprecated_wait_while_present
     end
 
     it "times out if the element doesn't disappear" do
       error = Watir::Wait::TimeoutError
       inspected = '#<Watir::Div: located: true; {:id=>"foo", :tag_name=>"div"}>'
-      message = "timed out after 1 seconds, waiting for element #{inspected} not to be present"
-      expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(error, message)
+      message = "timed out after 1 seconds, waiting for #{inspected} not to be present"
+      expect {
+        expect { browser.div(id: 'foo').wait_while_present(timeout: 1) }.to raise_error(error, message)
+      }.to have_deprecated_wait_while_present
     end
 
     it 'uses provided interval' do
+      error = Watir::Wait::TimeoutError
       element = browser.div(id: 'foo')
-      expect(element).to receive(:present?).twice
+      expect(element).to receive(:present?).and_return(true).twice
 
-      expect { element.wait_until_present(timeout: 0.4, interval: 0.2) }.to raise_timeout_exception
+      expect {
+        expect { element.wait_while_present(timeout: 0.4, interval: 0.2) }.to raise_error(error)
+      }.to have_deprecated_wait_while_present
     end
 
     it 'does not error when element goes stale' do
@@ -157,13 +172,17 @@ describe Watir::Element do
       allow(element).to receive(:stale?).and_return(false, true)
 
       browser.a(id: 'hide_foo').click
-      expect { element.wait_while_present(timeout: 1) }.to_not raise_exception
+      expect {
+        expect { element.wait_while_present(timeout: 1) }.to_not raise_exception
+      }.to have_deprecated_wait_while_present
     end
 
     it 'waits until the selector no longer matches' do
       element = browser.link(name: 'add_select').wait_until(&:exists?)
       browser.link(id: 'change_select').click
-      expect { element.wait_while_present }.not_to raise_error
+      expect {
+        expect { element.wait_while_present }.not_to raise_error
+      }.to have_deprecated_wait_while_present
     end
   end
 
@@ -303,6 +322,34 @@ describe Watir::Element do
         expect { element.wait_while(custom: '') }.to_not raise_exception
       end
 
+      it 'accepts keywords and block' do
+        element = browser.div(id: 'foo')
+        browser.a(id: 'hide_foo').click
+        expect { element.wait_while(custom: '', &:present?) }.to_not raise_exception
+      end
+
+      it 'browser accepts keywords' do
+        expect { browser.wait_until(title: 'wait test') }.to_not raise_exception
+        expect { browser.wait_until(title: 'wrong') }.to raise_timeout_exception
+      end
+
+      it 'alert accepts keywords' do
+        browser.goto WatirSpec.url_for('alerts.html')
+
+        begin
+          browser.button(id: 'alert').click
+          expect { browser.alert.wait_until(text: 'ok') }.to_not raise_exception
+          expect { browser.alert.wait_until(text: 'not ok') }.to raise_timeout_exception
+        ensure
+          browser.alert.ok
+        end
+      end
+
+      it 'window accepts keywords' do
+        expect { browser.window.wait_until(title: 'wait test') }.to_not raise_exception
+        expect { browser.window.wait_until(title: 'wrong') }.to raise_timeout_exception
+      end
+
       it 'times out when single keyword not met' do
         element = browser.div(id: 'foo')
         expect { element.wait_while(id: 'foo') }.to raise_timeout_exception
@@ -338,11 +385,15 @@ describe Watir do
       end
 
       it 'is used by Element#wait_until_present' do
-        expect { browser.div(id: 'bar').wait_until_present }.to wait_and_raise_timeout_exception(timeout: 1)
+        expect {
+          expect { browser.div(id: 'bar').wait_until_present }.to wait_and_raise_timeout_exception(timeout: 1)
+        }.to have_deprecated_wait_until_present
       end
 
       it 'is used by Element#wait_while_present' do
-        expect { browser.div(id: 'foo').wait_while_present }.to wait_and_raise_timeout_exception(timeout: 1)
+        expect {
+          expect { browser.div(id: 'foo').wait_while_present }.to wait_and_raise_timeout_exception(timeout: 1)
+        }.to have_deprecated_wait_while_present
       end
     end
   end


### PR DESCRIPTION
Right now we have slightly different behavior between `wait_until(&:present?)` and `wait_until_present` because I didn't think we could do in the former what is necessary for special cases requiring the latter. Because when we use this in the automatic waiting code we always do a check on the cached element before getting into the wait loop, this shouldn't affect performance or functionality. It just means that people using `wait_while_present` and `wait_until_present` can use the to_proc methods again, and we can deprecate these methods.

Also, nesting blocks in procs is very Inception and I like it a lot. :)