### PR TITLE
fix generator code and skip unreachable title and html methods

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ end
 
       File.open(spec_path, 'w') do |io|
         io << "<!--  downloaded from #{spec_uri} on #{Time.now} -->\n"
-        io << data = URI.open(spec_uri).read
+        io << data = URI.parse(spec_uri).read
         downloaded_bytes = data.bytesize
       end
 
@@ -73,7 +73,7 @@ end
         generator.generate(spec_path, file)
       end
 
-      system "diff -Naut #{old_file} #{old_file}.new | less" if File.exist?(old_file)
+      system "diff -Naut #{old_file} #{old_file}.new" if File.exist?(old_file)
     end
 
     desc "Move #{type}.rb.new to #{type}.rb"

--- a/lib/watir/generator/base/idl_sorter.rb
+++ b/lib/watir/generator/base/idl_sorter.rb
@@ -2,7 +2,7 @@ require 'tsort'
 
 module Watir
   module Generator
-    module Base
+    class Base
       class IDLSorter
         include TSort
 

--- a/lib/watir/generator/base/spec_extractor.rb
+++ b/lib/watir/generator/base/spec_extractor.rb
@@ -1,6 +1,6 @@
 module Watir
   module Generator
-    module Base
+    class Base
       class SpecExtractor
         IDL_SELECTOR = "//pre[contains(@class, 'idl')]".freeze
 
@@ -49,7 +49,7 @@ module Watir
         private
 
         def download_and_parse
-          URI.open(@uri) { |io| @doc = Nokogiri.HTML(io) }
+          File.open(@uri) { |io| @doc = Nokogiri.HTML(io) }
         end
 
         def extract_idl_parts

--- a/lib/watir/generator/base/visitor.rb
+++ b/lib/watir/generator/base/visitor.rb
@@ -1,6 +1,6 @@
 module Watir
   module Generator
-    module Base
+    class Base
       class Visitor < WebIDL::RubySexpVisitor
         STRING_TYPES = ['WindowProxy', 'ValidityState', 'TimeRanges', 'Location',
                         'Any', 'TimedTrackArray', 'TimedTrack', 'TextTrackArray', 'TextTrack',

--- a/lib/watir/generator/html/generator.rb
+++ b/lib/watir/generator/html/generator.rb
@@ -4,7 +4,6 @@ module Watir
       private
 
       def ignored_tags
-        # ignore the link element for now
         %w[link]
       end
 

--- a/lib/watir/generator/html/spec_extractor.rb
+++ b/lib/watir/generator/html/spec_extractor.rb
@@ -1,6 +1,6 @@
 module Watir
   module Generator
-    module HTML
+    class HTML
       class SpecExtractor < Base::SpecExtractor
         private
 

--- a/lib/watir/generator/html/visitor.rb
+++ b/lib/watir/generator/html/visitor.rb
@@ -1,6 +1,6 @@
 module Watir
   module Generator
-    module HTML
+    class HTML
       class Visitor < Base::Visitor
         def classify_regexp
           /^HTML(.+)Element$/

--- a/lib/watir/generator/svg/spec_extractor.rb
+++ b/lib/watir/generator/svg/spec_extractor.rb
@@ -1,6 +1,6 @@
 module Watir
   module Generator
-    module SVG
+    class SVG
       class SpecExtractor < Base::SpecExtractor
         private
 

--- a/lib/watir/generator/svg/visitor.rb
+++ b/lib/watir/generator/svg/visitor.rb
@@ -1,6 +1,6 @@
 module Watir
   module Generator
-    module SVG
+    class SVG
       class Visitor < Base::Visitor
         def classify_regexp
           /^SVG(.+)Element$/


### PR DESCRIPTION
I broke the generation code in my refactor.
Does the change I made to remove #html & #title make sense?

You can now do `browser.head.title` to get the `Title` instance, and `browser.element` will provide an `Html` instance.

I'm not sure why piping `less` causes rake to hang, and I can't get SVG to finish, hopefully this isn't something I broke.