### PR TITLE
More specs and removal of inaccessible code

### DIFF
--- a/lib/watir/adjacent.rb
+++ b/lib/watir/adjacent.rb
@@ -59,7 +59,7 @@ module Watir
     #
     # @example
     #   browser.text_field(name: "new_user_first_name").following_siblings.size
-    #   #=> 53
+    #   #=> 55
     #
 
     def following_siblings(opt = {})
@@ -74,7 +74,7 @@ module Watir
     #
     # @example
     #   browser.text_field(name: "new_user_first_name").siblings.size
-    #   #=> 57
+    #   #=> 59
     #
 
     def siblings(opt = {})

--- a/lib/watir/attribute_helper.rb
+++ b/lib/watir/attribute_helper.rb
@@ -87,6 +87,7 @@ module Watir
     def define_float_attribute(mname, aname)
       define_method mname do
         value = attribute_value(aname)
+        value = nil if value == 'NaN'
         value && Float(value)
       end
     end

--- a/lib/watir/elements/button.rb
+++ b/lib/watir/elements/button.rb
@@ -20,16 +20,7 @@ module Watir
     #
 
     def text
-      tn = tag_name
-
-      case tn
-      when 'input'
-        value
-      when 'button'
-        super
-      else
-        raise Error, "unknown tag name for button: #{tn}"
-      end
+      tag_name == 'input' ? value : super
     end
   end # Button
 end # Watir

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -256,18 +256,6 @@ module Watir
     end
 
     #
-    # Returns value of the element.
-    #
-    # @return [String]
-    #
-
-    def value
-      attribute_value('value') || ''
-    rescue Selenium::WebDriver::Error::InvalidElementStateError
-      ''
-    end
-
-    #
     # Returns given attribute value of element.
     #
     # @example
@@ -591,6 +579,7 @@ module Watir
     def locate
       ensure_context
       locate_in_context
+      self
     end
 
     #

--- a/lib/watir/elements/option.rb
+++ b/lib/watir/elements/option.rb
@@ -46,24 +46,13 @@ module Watir
     #
     # Returns the text of option.
     #
-    # Note that the text is either one of the following respectively:
-    #   * label attribute
-    #   * text attribute
-    #   * inner element text
+    # getAttribute atom pulls the text value if the label does not exist
     #
     # @return [String]
     #
 
     def text
-      # A little unintuitive - we'll return the 'label' or 'text' attribute if
-      # they exist, otherwise the inner text of the element
-
-      %i[label text].each do |a|
-        val = attribute_value(a)
-        return val unless val.nil?
-      end
-
-      super
+      attribute_value(:label)
     end
   end # Option
 end # Watir

--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -79,11 +79,9 @@ module Watir
             element.tag_name.downcase
           when :href
             element.attribute('href')&.strip
-          when String, ::Symbol
+          else
             how = how.to_s.tr('_', '-') if how.is_a?(::Symbol)
             element.attribute(how)
-          else
-            raise LocatorException, "Unable to fetch value for #{how}"
           end
         end
 
@@ -229,18 +227,6 @@ module Watir
           selector_text = selector[:text].inspect
           dep = "Using :#{key} locator with RegExp #{selector_text} to match an element that includes hidden text"
           Watir.logger.deprecate(dep, ":visible_#{key}", ids: [:text_regexp])
-        end
-
-        def add_regexp_predicates(what)
-          return what unless can_convert_regexp_to_contains?
-
-          values_to_match.each do |key, value|
-            next if %i[tag_name text visible_text visible index].include?(key)
-
-            predicates = regexp_selector_to_predicates(key, value)
-            what = "(#{what})[#{predicates.join(' and ')}]" unless predicates.empty?
-          end
-          what
         end
 
         def tag_validation_required?(selector)

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -435,6 +435,11 @@ describe Watir::Locators::Element::Locator do
         expect { locate_one(7 => 'bad') }.to raise_exception(Watir::Exception::Error, msg)
       end
 
+      it 'raises a Error if selector key is not a String or a Symbol' do
+        msg = 'Unable to build XPath using 7'
+        expect { locate_one(7 => 'bad') }.to raise_exception(Watir::Exception::Error, msg)
+      end
+
       it 'raises an Error if unable to build selector' do
         module Foo
           class SelectorBuilder < Watir::Locators::Element::SelectorBuilder

--- a/spec/watirspec/alert_spec.rb
+++ b/spec/watirspec/alert_spec.rb
@@ -10,6 +10,16 @@ not_compliant_on :headless do
       browser.alert.ok if browser.alert.exists?
     end
 
+    not_compliant_on :not_relaxed_locate do
+      context 'Relaxed Waits' do
+        context 'when acting on an alert' do
+          it 'raises exception after timing out' do
+            expect { browser.alert.text }.to wait_and_raise_unknown_object_exception
+          end
+        end
+      end
+    end
+
     context 'alert' do
       describe '#text' do
         it 'returns text of alert' do

--- a/spec/watirspec/elements/button_spec.rb
+++ b/spec/watirspec/elements/button_spec.rb
@@ -180,11 +180,15 @@ describe 'Button' do
   end
 
   describe '#text' do
-    it 'returns the text of the button' do
+    it 'returns the text of an input button' do
       expect(browser.button(index: 0).text).to eq 'Submit'
       expect(browser.button(index: 1).text).to eq 'Reset'
       expect(browser.button(index: 2).text).to eq 'Button'
       expect(browser.button(index: 3).text).to eq 'Preview'
+    end
+
+    it 'returns the text of a button element' do
+      expect(browser.button(name: 'new_user_button_2').text).to eq 'Button 2'
     end
 
     it 'raises UnknownObjectException if the element does not exist' do

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -143,7 +143,7 @@ describe 'Element' do
     end
 
     it "finds several elements from an element's subtree" do
-      expect(browser.fieldset.elements(xpath: './/label').length).to eq 22
+      expect(browser.fieldset.elements(xpath: './/label').length).to eq 23
     end
   end
 
@@ -536,6 +536,20 @@ describe 'Element' do
     end
   end
 
+  describe '#click' do
+    bug 'https://github.com/mozilla/geckodriver/issues/1375', :firefox do
+      it 'accepts modifiers' do
+        begin
+          browser.a.click(:shift)
+          expect(browser.windows.size).to eq 2
+        ensure
+          browser.windows.reject(&:current?).each(&:close)
+          expect(browser.windows.size).to eq 1
+        end
+      end
+    end
+  end
+
   describe '#flash' do
     let(:h2) { browser.h2(text: 'Add user') }
     let(:h1) { browser.h1(text: 'User administration') }
@@ -790,6 +804,41 @@ describe 'Element' do
     it 'returns a Selenium::WebDriver::Element instance' do
       element = browser.text_field(id: 'new_user_email')
       expect(element.wd).to be_a(Selenium::WebDriver::Element)
+    end
+  end
+
+  describe '#hash' do
+    it 'returns a hash' do
+      element = browser.text_field(id: 'new_user_email')
+      hash1 = element.hash
+      hash2 = element.locate.hash
+      expect(hash1).to be_a Integer
+      expect(hash2).to be_a Integer
+      expect(hash1).to_not eq hash2
+    end
+  end
+
+  describe 'Float Attribute' do
+    it 'returns Float value of applicable element' do
+      element = browser.text_field(id: 'number')
+      expect(element.valueasnumber).to be_a Float
+    end
+
+    it 'returns nil value for an inapplicable Element' do
+      element = browser.input
+      expect(element.valueasnumber).to be_nil
+    end
+  end
+
+  describe 'Integer Attribute' do
+    it 'returns Float value of applicable element' do
+      element = browser.form
+      expect(element.length).to be_a Integer
+    end
+
+    it 'returns -1 for an inapplicable Element' do
+      element = browser.input
+      expect(element.maxlength).to eq(-1)
     end
   end
 

--- a/spec/watirspec/elements/labels_spec.rb
+++ b/spec/watirspec/elements/labels_spec.rb
@@ -13,7 +13,7 @@ describe 'Labels' do
 
   describe '#length' do
     it 'returns the number of labels' do
-      expect(browser.labels.length).to eq 41
+      expect(browser.labels.length).to eq 42
     end
   end
 

--- a/spec/watirspec/elements/list_spec.rb
+++ b/spec/watirspec/elements/list_spec.rb
@@ -17,6 +17,21 @@ describe 'List' do
     expect(items).to all(be_a Watir::LI)
   end
 
+  it 'gets the size of a list' do
+    ul = browser.ul(id: 'navbar')
+    expect(ul.size).to eq 7
+  end
+
+  it 'iterates over a list' do
+    ul = browser.ul(id: 'navbar')
+    expect(ul.map(&:tag_name)).to eq Array.new(7, 'li')
+  end
+
+  it 'gets a list item at the specified index' do
+    ul = browser.ul(id: 'navbar')
+    expect(ul[4].text).to eq 'Non-link 1'
+  end
+
   it 'returns the list item size' do
     items = browser.ol(id: 'favorite_compounds').list_items
     expect(items.size).to eq 5

--- a/spec/watirspec/elements/text_fields_spec.rb
+++ b/spec/watirspec/elements/text_fields_spec.rb
@@ -13,7 +13,7 @@ describe 'TextFields' do
 
   describe '#length' do
     it 'returns the number of text fields' do
-      expect(browser.text_fields.length).to eq 18
+      expect(browser.text_fields.length).to eq 19
     end
   end
 

--- a/spec/watirspec/elements/tr_spec.rb
+++ b/spec/watirspec/elements/tr_spec.rb
@@ -68,7 +68,7 @@ describe 'TableRow' do
     end
 
     it 'iterates correctly through the cells of the row' do
-      browser.table(id: 'outer').row(index: 1).cells.each_with_index do |cell, idx|
+      browser.table(id: 'outer').tr(index: 1).each_with_index do |cell, idx|
         expect(cell.id).to eq "t1_r2_c#{idx + 1}"
       end
     end

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -78,6 +78,8 @@
             <input type="week" id="html5_week" name="html5_week" />
             <label for="html5_time">HTML5 Time</label>
             <input type="time" id="html5_time" name="html5_time" />
+            <label for="number">Age</label>
+            <input type="number" value="42" name="number" id="number">
         </fieldset>
         <fieldset>
             <legend>Login information</legend>


### PR DESCRIPTION
A couple interesting things in here...

`Element#value` is useless because the methods for which `attribute_value('value')` makes sense, there is already an attribute 'value' defined on the element. So this method is never actually used in our specs, and were it to ever be used, it would have to return an empty string.

`Option#text` is fascinating. The `getAttribute` atom that Selenium uses returns the text content when calling `attribute_value('label')` or `attribute_value('text')`. It can't be overridden in the DOM (I tried adding labels and text attributes without any change), so there is no point in overriding the superclass. Also better to use `#text` directly than call in an atom.

We're currently doing a selector type check in both Locator class and SelectorBuilder class. Seemed to make more sense to do it in SelectorBuilder, so I removed the check from Locator class.

Plus a bunch more specs to hit places in the code that are currently ignored.