### PR TITLE
adds Element#classes

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -246,6 +246,16 @@ module Watir
     end
 
     #
+    # Returns list of class values.
+    #
+    # @return [Array]
+    #
+
+    def classes
+      class_name.split
+    end
+
+    #
     # Returns value of the element.
     #
     # @return [String]

--- a/spec/watirspec/elements/button_spec.rb
+++ b/spec/watirspec/elements/button_spec.rb
@@ -94,16 +94,6 @@ describe 'Button' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class name of the button' do
-      expect(browser.button(name: 'new_user_image').class_name).to eq 'image'
-    end
-
-    it 'returns an empty string if the button has no class name' do
-      expect(browser.button(name: 'new_user_submit').class_name).to eq ''
-    end
-  end
-
   describe '#id' do
     it 'returns the id if the button exists' do
       expect(browser.button(index: 0).id).to eq 'new_user_submit'

--- a/spec/watirspec/elements/checkbox_spec.rb
+++ b/spec/watirspec/elements/checkbox_spec.rb
@@ -70,21 +70,6 @@ describe 'CheckBox' do
   end
 
   # Attribute methods
-
-  describe '#class_name' do
-    it 'returns the class name if the checkbox exists and has an attribute' do
-      expect(browser.checkbox(id: 'new_user_interests_dancing').class_name).to eq 'fun'
-    end
-
-    it "returns an empty string if the checkbox exists and the attribute doesn't" do
-      expect(browser.checkbox(id: 'new_user_interests_books').class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the checkbox doesn't exist" do
-      expect { browser.checkbox(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute if the checkbox exists and has an attribute' do
       expect(browser.checkbox(index: 0).id).to eq 'new_user_interests_books'

--- a/spec/watirspec/elements/dd_spec.rb
+++ b/spec/watirspec/elements/dd_spec.rb
@@ -28,23 +28,6 @@ describe 'Dd' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute if the element exists' do
-      expect(browser.dd(id: 'someone').class_name).to eq 'name'
-    end
-
-    it "returns an empty string if the element exists but the attribute doesn't" do
-      expect(browser.dd(id: 'city').class_name).to eq ''
-    end
-
-    it 'raises UnknownObjectException if the element does not exist' do
-      expect { browser.dd(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-      expect { browser.dd(title: 'no_such_title').class_name }.to raise_unknown_object_exception
-      expect { browser.dd(index: 1337).class_name }.to raise_unknown_object_exception
-      expect { browser.dd(xpath: "//dd[@id='no_such_id']").class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute if the element exists' do
       expect(browser.dd(class: 'name').id).to eq 'someone'

--- a/spec/watirspec/elements/del_spec.rb
+++ b/spec/watirspec/elements/del_spec.rb
@@ -39,20 +39,6 @@ describe 'Del' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.del(index: 0).class_name).to eq 'lead'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.del(index: 2).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the del doesn't exist" do
-      expect { browser.del(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.del(index: 0).id).to eq 'lead'

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -45,23 +45,6 @@ describe 'Div' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute if the element exists' do
-      expect(browser.div(id: 'footer').class_name).to eq 'profile'
-    end
-
-    it "returns an empty string if the element exists but the attribute doesn't" do
-      expect(browser.div(id: 'content').class_name).to eq ''
-    end
-
-    it 'raises UnknownObjectException if the element does not exist' do
-      expect { browser.div(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-      expect { browser.div(title: 'no_such_title').class_name }.to raise_unknown_object_exception
-      expect { browser.div(index: 1337).class_name }.to raise_unknown_object_exception
-      expect { browser.div(xpath: "//div[@id='no_such_id']").class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute if the element exists' do
       expect(browser.div(index: 1).id).to eq 'outer_container'

--- a/spec/watirspec/elements/dl_spec.rb
+++ b/spec/watirspec/elements/dl_spec.rb
@@ -28,23 +28,6 @@ describe 'Dl' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute if the element exists' do
-      expect(browser.dl(id: 'experience-list').class_name).to eq 'list'
-    end
-
-    it "returns an empty string if the element exists but the attribute doesn't" do
-      expect(browser.dl(id: 'noop').class_name).to eq ''
-    end
-
-    it 'raises UnknownObjectException if the element does not exist' do
-      expect { browser.dl(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-      expect { browser.dl(title: 'no_such_title').class_name }.to raise_unknown_object_exception
-      expect { browser.dl(index: 1337).class_name }.to raise_unknown_object_exception
-      expect { browser.dl(xpath: "//dl[@id='no_such_id']").class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute if the element exists' do
       expect(browser.dl(class: 'list').id).to eq 'experience-list'

--- a/spec/watirspec/elements/dt_spec.rb
+++ b/spec/watirspec/elements/dt_spec.rb
@@ -28,23 +28,6 @@ describe 'Dt' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute if the element exists' do
-      expect(browser.dt(id: 'experience').class_name).to eq 'industry'
-    end
-
-    it "returns an empty string if the element exists but the attribute doesn't" do
-      expect(browser.dt(id: 'education').class_name).to eq ''
-    end
-
-    it 'raises UnknownObjectException if the element does not exist' do
-      expect { browser.dt(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-      expect { browser.dt(title: 'no_such_title').class_name }.to raise_unknown_object_exception
-      expect { browser.dt(index: 1337).class_name }.to raise_unknown_object_exception
-      expect { browser.dt(xpath: "//dt[@id='no_such_id']").class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute if the element exists' do
       expect(browser.dt(class: 'industry').id).to eq 'experience'

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -792,4 +792,36 @@ describe 'Element' do
       expect(element.wd).to be_a(Selenium::WebDriver::Element)
     end
   end
+
+  describe '#class_name' do
+    it 'returns single class name' do
+      expect(browser.form(id: 'new_user').class_name).to eq 'user'
+    end
+
+    it 'returns multiple class names in a String' do
+      expect(browser.div(id: 'messages').class_name).to eq 'multiple classes here'
+    end
+
+    it 'returns an empty string if the element exists but there is no class attribute' do
+      expect(browser.div(id: 'changed_language').class_name).to eq ''
+    end
+
+    it 'raises UnknownObjectException if the element does not exist' do
+      expect { browser.div(id: 'no_such_id').class_name }.to raise_unknown_object_exception
+    end
+  end
+
+  describe '#classes' do
+    it 'returns the class attribute if the element exists' do
+      expect(browser.div(id: 'messages').classes).to eq %w[multiple classes here]
+    end
+
+    it 'returns an empty array if the element exists but there is no class attribute' do
+      expect(browser.div(id: 'changed_language').classes).to eq []
+    end
+
+    it 'raises UnknownObjectException if the element does not exist' do
+      expect { browser.div(id: 'no_such_id').classes }.to raise_unknown_object_exception
+    end
+  end
 end

--- a/spec/watirspec/elements/em_spec.rb
+++ b/spec/watirspec/elements/em_spec.rb
@@ -28,19 +28,6 @@ describe 'Em' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute if the element exists' do
-      expect(browser.em(id: 'important-id').class_name).to eq 'important-class'
-    end
-
-    it 'raises UnknownObjectException if the element does not exist' do
-      expect { browser.em(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-      expect { browser.em(title: 'no_such_title').class_name }.to raise_unknown_object_exception
-      expect { browser.em(index: 1337).class_name }.to raise_unknown_object_exception
-      expect { browser.em(xpath: "//em[@id='no_such_id']").class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute if the element exists' do
       expect(browser.em(class: 'important-class').id).to eq 'important-id'

--- a/spec/watirspec/elements/filefield_spec.rb
+++ b/spec/watirspec/elements/filefield_spec.rb
@@ -42,17 +42,6 @@ describe 'FileField' do
   end
 
   # Attribute methods
-
-  describe '#class_name' do
-    it 'returns the class attribute if the text field exists' do
-      expect(browser.file_field(index: 0).class_name).to eq 'portrait'
-    end
-
-    it "raises UnknownObjectException if the text field doesn't exist" do
-      expect { browser.file_field(index: 1337).class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute if the text field exists' do
       expect(browser.file_field(index: 0).id).to eq 'new_user_portrait'

--- a/spec/watirspec/elements/hn_spec.rb
+++ b/spec/watirspec/elements/hn_spec.rb
@@ -36,20 +36,6 @@ describe ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'] do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.h1(index: 0).class_name).to eq 'primary'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.h2(index: 0).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.h2(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.h1(index: 0).id).to eq 'first_header'

--- a/spec/watirspec/elements/ins_spec.rb
+++ b/spec/watirspec/elements/ins_spec.rb
@@ -39,20 +39,6 @@ describe 'Ins' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.ins(index: 0).class_name).to eq 'lead'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.ins(index: 2).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the ins doesn't exist" do
-      expect { browser.ins(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.ins(index: 0).id).to eq 'lead'

--- a/spec/watirspec/elements/li_spec.rb
+++ b/spec/watirspec/elements/li_spec.rb
@@ -39,20 +39,6 @@ describe 'Li' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.li(id: 'non_link_1').class_name).to eq 'nonlink'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.li(index: 0).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the li doesn't exist" do
-      expect { browser.li(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.li(class: 'nonlink').id).to eq 'non_link_1'

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -49,20 +49,6 @@ describe 'Link' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the type attribute if the link exists' do
-      expect(browser.link(index: 1).class_name).to eq 'external'
-    end
-
-    it "returns an empty string if the link exists and the attribute doesn't" do
-      expect(browser.link(index: 0).class_name).to eq ''
-    end
-
-    it "raises an UnknownObjectException if the link doesn't exist" do
-      expect { browser.link(index: 1337).class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#href' do
     it 'returns the href attribute if the link exists' do
       expect(browser.link(index: 1).href).to match(/non_control_elements/)

--- a/spec/watirspec/elements/ol_spec.rb
+++ b/spec/watirspec/elements/ol_spec.rb
@@ -46,20 +46,6 @@ describe 'Ol' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.ol(id: 'favorite_compounds').class_name).to eq 'chemistry'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.ol(index: 1).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the ol doesn't exist" do
-      expect { browser.ol(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.ol(class: 'chemistry').id).to eq 'favorite_compounds'

--- a/spec/watirspec/elements/option_spec.rb
+++ b/spec/watirspec/elements/option_spec.rb
@@ -101,16 +101,6 @@ describe 'Option' do
     end
   end
 
-  describe '#class_name' do
-    it 'is able to get attributes (page context)' do
-      expect(browser.option(text: 'Sweden').class_name).to eq 'scandinavia'
-    end
-
-    it 'is able to get attributes (select_list context)' do
-      expect(browser.select_list(name: 'new_user_country').option(text: 'Sweden').class_name).to eq 'scandinavia'
-    end
-  end
-
   describe '#respond_to?' do
     it 'returns true for all attribute methods' do
       expect(browser.select_list(name: 'new_user_country').option(text: 'Sweden')).to respond_to(:class_name)

--- a/spec/watirspec/elements/p_spec.rb
+++ b/spec/watirspec/elements/p_spec.rb
@@ -39,20 +39,6 @@ describe 'P' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.p(index: 0).class_name).to eq 'lead'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.p(index: 2).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.p(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.p(index: 0).id).to eq 'lead'

--- a/spec/watirspec/elements/pre_spec.rb
+++ b/spec/watirspec/elements/pre_spec.rb
@@ -39,20 +39,6 @@ describe 'Pre' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.pre(id: 'rspec').class_name).to eq 'ruby'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.pre(index: 0).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the p doesn't exist" do
-      expect { browser.pre(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.pre(class: 'ruby').id).to eq 'rspec'

--- a/spec/watirspec/elements/radio_spec.rb
+++ b/spec/watirspec/elements/radio_spec.rb
@@ -68,20 +68,6 @@ describe 'Radio' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class name if the radio exists and has an attribute' do
-      expect(browser.radio(id: 'new_user_newsletter_yes').class_name).to eq 'huge'
-    end
-
-    it "returns an empty string if the radio exists and the attribute doesn't" do
-      expect(browser.radio(id: 'new_user_newsletter_no').class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the radio doesn't exist" do
-      expect { browser.radio(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute if the radio exists and has an attribute' do
       expect(browser.radio(index: 0).id).to eq 'new_user_newsletter_yes'

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -43,16 +43,6 @@ describe 'SelectList' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class name of the select list' do
-      expect(browser.select_list(name: 'new_user_country').class_name).to eq 'country'
-    end
-
-    it "raises UnknownObjectException if the select list doesn't exist" do
-      expect { browser.select_list(name: 'no_such_name').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id of the element' do
       expect(browser.select_list(index: 0).id).to eq 'new_user_country'

--- a/spec/watirspec/elements/span_spec.rb
+++ b/spec/watirspec/elements/span_spec.rb
@@ -39,20 +39,6 @@ describe 'Span' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.span(index: 0).class_name).to eq 'lead'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.span(index: 2).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the span doesn't exist" do
-      expect { browser.span(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.span(index: 0).id).to eq 'lead'

--- a/spec/watirspec/elements/strong_spec.rb
+++ b/spec/watirspec/elements/strong_spec.rb
@@ -39,20 +39,6 @@ describe 'Strong' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.strong(index: 0).class_name).to eq 'descartes'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.strong(index: 1).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the element doesn't exist" do
-      expect { browser.strong(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.strong(index: 0).id).to eq 'descartes'

--- a/spec/watirspec/elements/ul_spec.rb
+++ b/spec/watirspec/elements/ul_spec.rb
@@ -35,20 +35,6 @@ describe 'Ul' do
   end
 
   # Attribute methods
-  describe '#class_name' do
-    it 'returns the class attribute' do
-      expect(browser.ul(id: 'navbar').class_name).to eq 'navigation'
-    end
-
-    it "returns an empty string if the element exists and the attribute doesn't" do
-      expect(browser.ul(index: 1).class_name).to eq ''
-    end
-
-    it "raises UnknownObjectException if the ul doesn't exist" do
-      expect { browser.ul(id: 'no_such_id').class_name }.to raise_unknown_object_exception
-    end
-  end
-
   describe '#id' do
     it 'returns the id attribute' do
       expect(browser.ul(class: 'navigation').id).to eq 'navbar'

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -8,7 +8,7 @@
     <script src="javascript/helpers.js" type="text/javascript" charset="utf-8"></script>
   </head>
   <body onload="document.user_new.new_user_first_name.focus()">
-    <div id="messages"></div>
+    <div id="messages" class="multiple classes here"></div>
     <h1><a href="">User administration</a></h1>
     <h2 style="background-color: gray;">Add user</h2>
     <form enctype="multipart/form-data" action="post_to_me" method="post" name="user_new" id="new_user" class="user" onsubmit="WatirSpec.addMessage('submit'); return false;">


### PR DESCRIPTION
`#class_name` really only makes sense if there is only one class associated with the element. This just makes it a little more straightforward when dealing with multiple classes.

Also... @jkotests brought up the idea that we are duplicating a lot of specs by testing them with each and every element type. `#class_name` seems like a straightforward place to start when removing extraneous tests. The tests for `#classes` and `#class_name` is now in `element_spec.rb`