### PR TITLE
automatically retry examples for specific exceptions typical on Travis

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,16 @@ require 'webdrivers'
 require 'locator_spec_helper'
 require 'rspec'
 
+if ENV['TRAVIS']
+  require 'rspec/retry'
+  RSpec.configure do |config|
+    config.verbose_retry = true
+    config.display_try_failure_messages = true
+    config.default_retry_count = 3
+    config.exceptions_to_retry = [IOError, Net::ReadTimeout]
+  end
+end
+
 SELENIUM_SELECTORS = %i[css tag_name xpath link_text partial_link_text link].freeze
 
 Watir.relaxed_locate = false if ENV['RELAXED_LOCATE'] == 'false'

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'rspec-retry'
   s.add_development_dependency 'rubocop', '~> 0.59'
   s.add_development_dependency 'selenium_statistics'
   s.add_development_dependency 'webdrivers', '~> 3.4'


### PR DESCRIPTION
I'm getting tired of hitting the re-run button on Travis when we have a IOError or Net::ReadTimeout. I'm not certain this actually fixes the problem, though, since each "it" statement isn't starting a new session; a dead session might be a dead session.