### PR TITLE
add test coverage for all non-deprecated lines of code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'http://rubygems.org'
 
-gem 'simplecov', '>= 0.3.5', platform: :ruby_19 unless ENV['TRAVIS']
-
 gem 'webidl', path: File.expand_path('../webidl') if ENV['LOCAL_WEBIDL']
 
 gem 'selenium-webdriver', path: File.expand_path('../selenium/build/rb') if ENV['LOCAL_SELENIUM']

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -87,6 +87,7 @@ module Watir
 
     #
     # @api private
+    # @see Watir::Wait
     #
 
     def selector_string

--- a/lib/watir/attribute_helper.rb
+++ b/lib/watir/attribute_helper.rb
@@ -52,8 +52,6 @@ module Watir
 
     def define_attribute(type, name, attr)
       case type.to_s
-      when 'String'
-        define_string_attribute(name, attr)
       when 'Boolean'
         define_boolean_attribute(name, attr)
       when 'Integer'
@@ -61,7 +59,7 @@ module Watir
       when 'Float'
         define_float_attribute(name, attr)
       else
-        Watir.logger.debug "treating #{type.inspect} as string for now"
+        define_string_attribute(name, attr)
       end
     end
 

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -253,19 +253,6 @@ module Watir
     end
     alias exists? exist?
 
-    #
-    # Protocol shared with Watir::Element
-    #
-    # @api private
-    #
-
-    def assert_exists
-      locate
-      return if window.present?
-
-      raise NoMatchingWindowFoundException, 'browser window was closed'
-    end
-
     def locate
       raise Error, 'browser was closed' if @closed
 

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -638,7 +638,7 @@ module Watir
 
       begin
         @query_scope.wait_for_present unless @query_scope.is_a? Browser
-        wait_until_present
+        wait_until(&:present?)
       rescue Wait::TimeoutError
         msg = "element located, but timed out after #{Watir.default_timeout} seconds, " \
               "waiting for #{inspect} to be present"
@@ -671,9 +671,7 @@ module Watir
       begin
         wait_until { !respond_to?(:readonly?) || !readonly? }
       rescue Wait::TimeoutError
-        message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, " \
-                  "waiting for #{inspect} to not be readonly"
-        raise ObjectReadOnlyException, message
+        raise_writable
       end
     end
 
@@ -721,10 +719,6 @@ module Watir
 
     def element_class
       self.class
-    end
-
-    def attribute?(attribute_name)
-      !attribute_value(attribute_name).nil?
     end
 
     def assert_enabled

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -105,6 +105,8 @@ module Watir
   #
 
   class FramedDriver
+    include Exception
+
     def initialize(element, browser)
       @element = element
       @browser = browser
@@ -132,8 +134,8 @@ module Watir
       @element
     end
 
-    def respond_to_missing?(meth)
-      @driver.respond_to?(meth) || @element.respond_to?(meth)
+    def respond_to_missing?(meth, _include_private = false)
+      @driver.respond_to?(meth) || @element.respond_to?(meth) || super
     end
 
     def method_missing(meth, *args, &blk)

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -144,13 +144,11 @@ module Watir
     def select_by(str_or_rx)
       found = find_options(:value, str_or_rx)
 
-      if found && found.size > 1
+      if found.size > 1
         Watir.logger.deprecate 'Selecting Multiple Options with #select', '#select_all',
                                ids: [:select_by]
       end
-      return select_matching(found) if found&.any?
-
-      raise NoValueFoundException, "#{str_or_rx.inspect} not found in select list"
+      select_matching(found)
     end
 
     def select_by!(str_or_rx, number)
@@ -197,9 +195,7 @@ module Watir
 
       found = find_options :text, str_or_rx
 
-      return select_matching(found) if found
-
-      raise NoValueFoundException, "#{str_or_rx.inspect} not found in select list"
+      select_matching(found)
     end
 
     def find_options(how, str_or_rx)
@@ -214,6 +210,7 @@ module Watir
           raise TypeError, "expected String or Regexp, got #{str_or_rx.inspect}:#{str_or_rx.class}"
         end
       end
+      # TODO: Remove conditional when remove relaxed_locate toggle
       return @found unless @found.empty?
 
       raise NoValueFoundException, "#{str_or_rx.inspect} not found in select list"
@@ -225,17 +222,6 @@ module Watir
       elements = [elements.first] unless multiple?
       elements.each { |e| e.click unless e.selected? }
       elements.first.exist? ? elements.first.text : ''
-    end
-
-    def matches_regexp?(how, element, exp)
-      case how
-      when :text
-        element.text =~ exp || element.label =~ exp
-      when :value
-        element.value =~ exp
-      else
-        raise Exception::Error, "unknown how: #{how.inspect}"
-      end
     end
   end # Select
 

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -18,7 +18,7 @@ module Watir
       else
         return if selector.keys.all? { |k| %i[title url index].include? k }
 
-        raise ArgumentError, "invalid window selector: #{selector.inspect}"
+        raise ArgumentError, "invalid window selector: #{selector_string}"
       end
     end
 
@@ -197,8 +197,6 @@ module Watir
       @selector.inspect
     end
 
-    protected
-
     def handle
       @handle ||= locate
     end
@@ -218,7 +216,7 @@ module Watir
     def assert_exists
       return if @driver.window_handles.include?(handle)
 
-      raise(NoMatchingWindowFoundException, @selector.inspect)
+      raise(NoMatchingWindowFoundException, selector_string)
     end
 
     # return a handle to the currently active window if it is still open; otherwise nil
@@ -230,8 +228,8 @@ module Watir
 
     def matches?(handle)
       @driver.switch_to.window(handle) do
-        matches_title = @selector[:title].nil? || @driver.title =~ /#{@selector[:title]}/
-        matches_url = @selector[:url].nil? || @driver.current_url =~ /#{@selector[:url]}/
+        matches_title = @selector[:title].nil? || @browser.title =~ /#{@selector[:title]}/
+        matches_url = @selector[:url].nil? || @browser.url =~ /#{@selector[:url]}/
 
         matches_title && matches_url
       end
@@ -246,7 +244,7 @@ module Watir
       begin
         wait_until(&:exists?)
       rescue Wait::TimeoutError
-        raise NoMatchingWindowFoundException, @selector.inspect
+        raise NoMatchingWindowFoundException, selector_string
       end
     end
   end # Window

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,21 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'coveralls'
-Coveralls.wear!
+require 'simplecov'
+require 'simplecov-console'
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    Coveralls::SimpleCov::Formatter,
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console,
+]
+SimpleCov.start do
+  add_filter %r{/spec/}
+  add_filter 'lib/watir/elements/html_elements.rb'
+  add_filter 'lib/watir/elements/svg_elements.rb'
+  add_filter 'lib/watir/legacy_wait.rb'
+  add_filter 'lib/watirspec'
+  refuse_coverage_drop
+end
 
 require 'watir'
 require 'webdrivers'

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -24,6 +24,11 @@ module Watir
       expect(Watir.logger.level).to eq(1)
     end
 
+    it 'allows to change level with integer' do
+      Watir.logger.level = 3
+      expect(Watir.logger.level).to eq(3)
+    end
+
     it 'outputs to stdout by default' do
       expect { Watir.logger.warn('message') }.to output(/WARN Watir message/).to_stdout_from_any_process
     end

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -19,6 +19,18 @@ describe 'Browser::AfterHooks' do
         browser.after_hooks.delete(proc)
       end
     end
+
+    it 'runs the given block on each page load' do
+      output = ''
+      begin
+        browser.after_hooks.add { |browser| output << browser.text }
+        browser.goto(WatirSpec.url_for('non_control_elements.html'))
+
+        expect(output).to include('Dubito, ergo cogito, ergo sum')
+      ensure
+        browser.after_hooks.delete browser.after_hooks[0]
+      end
+    end
   end
 
   describe '#delete' do
@@ -177,6 +189,28 @@ describe 'Browser::AfterHooks' do
           browser.original_window.use
         end
       end
+    end
+  end
+
+  describe '#length' do
+    it 'provides the number of after hooks' do
+      hook = proc { true }
+      begin
+        4.times { browser.after_hooks.add(hook) }
+        expect(browser.after_hooks.length).to eq 4
+      ensure
+        4.times { browser.after_hooks.delete(hook) }
+      end
+    end
+  end
+
+  describe '#[]' do
+    it 'returns the after hook at the provided index' do
+      hook1 = proc { true }
+      hook2 = proc { false }
+      browser.after_hooks.add(hook1)
+      browser.after_hooks.add(hook2)
+      expect(browser.after_hooks[1]).to eq hook2
     end
   end
 end

--- a/spec/watirspec/elements/form_spec.rb
+++ b/spec/watirspec/elements/form_spec.rb
@@ -60,5 +60,11 @@ describe 'Form' do
         expect(messages[0]).to eq 'submit'
       end
     end
+
+    compliant_on :relaxed_locate do
+      it 'times out when submitting an element that is not displayed' do
+        expect { browser.form(name: 'no').submit }.to raise_unknown_object_exception
+      end
+    end
   end
 end

--- a/spec/watirspec/elements/iframe_spec.rb
+++ b/spec/watirspec/elements/iframe_spec.rb
@@ -224,3 +224,18 @@ describe 'IFrame' do
     end
   end
 end
+
+describe 'FramedDriver' do
+  it 'raises name error if method is not defined on driver or element' do
+    browser.goto WatirSpec.url_for('iframes.html')
+    expect(browser.iframe(id: 'iframe_1').wd).not_to respond_to :foo
+    expect { browser.iframe(id: 'iframe_1').wd.foo }.to raise_exception NoMethodError
+  end
+
+  it 'raises exception when attempting to switch to a non-frame element' do
+    browser.goto WatirSpec.url_for('iframes.html')
+    element = browser.h1.wd
+    fd = Watir::FramedDriver.new(element, browser)
+    expect { fd.switch! }.to raise_exception Watir::Exception::UnknownFrameException
+  end
+end

--- a/spec/watirspec/html/closeable.html
+++ b/spec/watirspec/html/closeable.html
@@ -2,11 +2,19 @@
 <html>
   <head>
     <title>closeable window</title>
+    <script>
+      function closeDelayed(timeout) {
+        setTimeout(function() {
+          window.close();
+        }, timeout);
+      }
+    </script>
   </head>
 
   <body>
     <p>
       Click <a id="close" href="#" onclick="window.close()">here</a> to close this window.
+      Click <a id="close-delay" href="#" onclick="closeDelayed(500)">here</a> to close this window with a delay.
     </p>
   </body>
 

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -1,5 +1,6 @@
 if defined?(RSpec)
   DEPRECATION_WARNINGS = %i[selector_parameters
+                            ready_state
                             class_array
                             use_capabilities
                             visible_text

--- a/spec/watirspec/user_editable_spec.rb
+++ b/spec/watirspec/user_editable_spec.rb
@@ -128,6 +128,10 @@ describe Watir::UserEditable do
     it "raises UnknownObjectException if the text field doesn't exist" do
       expect { browser.text_field(id: 'no_such_id').set('secret') }.to raise_unknown_object_exception
     end
+
+    it 'raises ObjectReadOnlyException if the object is read only' do
+      expect { browser.text_field(id: 'new_user_code').set('Foo') }.to raise_object_read_only_exception
+    end
   end
 
   describe '#set!' do

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 0.59'
   s.add_development_dependency 'selenium_statistics'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'simplecov-console'
   s.add_development_dependency 'webdrivers', '~> 3.4'
   s.add_development_dependency 'webidl', '>= 0.2.2'
   s.add_development_dependency 'yard', '> 0.8.2.1'


### PR DESCRIPTION
This doesn't take into consideration single line conditionals or ternary operators, unfortunately.

Coveralls uses simplecov under the hood, so I added simplecov filters to ignore the things we don't care about. I also threw in a `refuse_coverage_drop` which should fail the test if it sees a drop. That might not be a good idea, but I think I'm in favor of doing that and turning off the extra coveralls check on Github. What do you guys think?

I removed several methods that weren't or couldn't be used. Also, writing the test for `Browser#wait` was a huge pain. I tried several methods to create blocking javascript that would prevent the page from loading, without any success. So, if anyone knows a better way to mock that out, it would be great. Let me know if anything I did doesn't make sense and I'll explain it.