### PR TITLE
Do not convert metacharacters to literal characters

### DIFF
--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -11,6 +11,7 @@ module Watir
             \A
               ([^\[\]\\^$.|?*+()]*) # leading literal characters
               [^|]*?                # do not try to convert expressions with alternates
+              (?<!\\)               # skip metacharacters - ie has preceding slash
               ([^\[\]\\^$.|?*+()]*) # trailing literal characters
             \z
           /x

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -603,6 +603,17 @@ describe Watir::Locators::Element::Locator do
 
           expect(locate_one(tag_name: 'div', class: /x|b/)).to eq elements[1]
         end
+
+        it 'does not convert metacharacters to literal characters' do
+          elements = [
+            element(tag_name: 'div', attributes: {class: 'abcd'}),
+            element(tag_name: 'div', attributes: {class: 'abc23'})
+          ]
+
+          expect_all(:xpath, "(.//*[local-name()='div'])[contains(@class, 'abc')]").and_return(elements)
+
+          expect(locate_one(tag_name: 'div', class: /abc\d\d/)).to eq elements[1]
+        end
       end
     end
 


### PR DESCRIPTION
This will exclude metacharacters when converting regexps to xpath.

Fixes #729 