### PR TITLE
Redo selector builder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,7 +75,7 @@ Metrics/CyclomaticComplexity:
 Metrics/AbcSize:
   Max: 21
   Exclude:
-    - 'lib/watir/locators/element/selector_builder.rb'
+    - 'lib/watir/locators/element/selector_builder/xpath.rb'
     - 'lib/watir/locators/element/locator.rb'
     - 'lib/watir/generator/base/generator.rb'
 

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -60,7 +60,8 @@ module Watir
 
       def build_locator
         element_validator = element_validator_class.new
-        selector_builder = selector_builder_class.new(@query_scope, @selector.dup, element_class.attribute_list)
+        scope_tag_name = @query_scope.selector[:tag_name] if @query_scope.respond_to?(:selector)
+        selector_builder = selector_builder_class.new(scope_tag_name, element_class.attribute_list)
         locator_class.new(@query_scope, @selector.dup, selector_builder, element_validator)
       end
     end

--- a/lib/watir/locators/button/selector_builder/xpath.rb
+++ b/lib/watir/locators/button/selector_builder/xpath.rb
@@ -8,7 +8,8 @@ module Watir
             "[local-name()='button']"
           end
 
-          def add_attributes(selector)
+          def add_attributes(selector, _scope_tag_name)
+            selector = selector.dup
             button_attr_exp = attribute_expression(:button, selector)
             xpath = button_attr_exp.empty? ? '' : "[#{button_attr_exp}]"
             return xpath if selector[:type].eql? false

--- a/lib/watir/locators/button/selector_builder/xpath.rb
+++ b/lib/watir/locators/button/selector_builder/xpath.rb
@@ -4,8 +4,8 @@ module Watir
       class SelectorBuilder
         class XPath < Element::SelectorBuilder::XPath
           def add_tag_name(selector)
-            selector.delete(:tag_name)
-            "[local-name()='button']"
+            selector[:tag_name] = 'button'
+            super
           end
 
           def add_attributes(selector, _scope_tag_name)

--- a/lib/watir/locators/cell/selector_builder/xpath.rb
+++ b/lib/watir/locators/cell/selector_builder/xpath.rb
@@ -3,7 +3,7 @@ module Watir
     class Cell
       class SelectorBuilder
         class XPath < Element::SelectorBuilder::XPath
-          def add_attributes(selector)
+          def add_attributes(selector, _scope_tag_name)
             attr_expr = attribute_expression(nil, selector)
 
             expressions = %w[./th ./td]

--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -18,7 +18,7 @@ module Watir
 
         def initialize(query_scope, selector, selector_builder, element_validator)
           @query_scope = query_scope # either element or browser
-          @selector = selector.dup
+          @selector = selector
           @selector_builder = selector_builder
           @element_validator = element_validator
         end
@@ -38,11 +38,12 @@ module Watir
         private
 
         def using_selenium(filter = :first)
-          tag = @selector[:tag_name].is_a?(::Symbol) ? @selector.delete(:tag_name).to_s : @selector.delete(:tag_name)
-          return if @selector.size > 1
+          selector = @selector.dup
+          tag = selector[:tag_name].is_a?(::Symbol) ? selector.delete(:tag_name).to_s : selector.delete(:tag_name)
+          return if selector.size > 1
 
-          how = @selector.keys.first || :tag_name
-          what = @selector.values.first || tag
+          how = selector.keys.first || :tag_name
+          what = selector.values.first || tag
 
           return unless wd_supported?(how, what, tag)
 
@@ -50,20 +51,32 @@ module Watir
         end
 
         def using_watir(filter = :first)
-          create_normalized_selector(filter)
-          return unless @normalized_selector
+          raise ArgumentError, "can't locate all elements by :index" if @selector.key?(:index) && filter == :all
 
-          how, what = selector_builder.build(@normalized_selector, values_to_match)
-
-          unless how
-            msg = "#{selector_builder.class} was unable to build selector from #{@normalized_selector.inspect}"
-            raise LocatorException, msg
+          begin
+            generate_scope
+          rescue LocatorException
+            return nil
           end
 
-          if filter == :all || !values_to_match.empty?
-            locate_matching_elements(how, what, filter)
+          selector, values_to_match = selector_builder.build(@selector)
+
+          validate_built_selector(selector, values_to_match)
+
+          if filter == :all || values_to_match.any?
+            locate_matching_elements(selector, values_to_match, filter)
           else
-            locate_element(how, what, @driver_scope)
+            locate_element(selector.keys.first, selector.values.first, @driver_scope)
+          end
+        end
+
+        def validate_built_selector(selector, values_to_match)
+          if selector.nil?
+            msg = "#{selector_builder.class} was unable to build selector from #{@selector.inspect}"
+            raise LocatorException, msg
+          elsif values_to_match.nil?
+            msg = "#{selector_builder.class}#build is not returning expected responses for the current version of Watir"
+            raise LocatorException, msg
           end
         end
 
@@ -85,7 +98,7 @@ module Watir
           end
         end
 
-        def matching_elements(elements, filter: :first)
+        def matching_elements(elements, values_to_match, filter: :first)
           if filter == :first
             idx = element_index(elements, values_to_match)
             counter = 0
@@ -111,82 +124,29 @@ module Watir
           idx.abs - 1
         end
 
-        def create_normalized_selector(filter)
-          return @normalized_selector if @normalized_selector
+        def generate_scope
+          return @driver_scope if @driver_scope
 
           @driver_scope = @query_scope.wd
 
-          @normalized_selector = selector_builder.normalized_selector
-
-          if @normalized_selector.key?(:label)
-            label_key = :label
-          elsif @normalized_selector.key?(:visible_label)
-            label_key = :visible_label
+          if @selector.key?(:label)
+            process_label :label
+          elsif @selector.key?(:visible_label)
+            process_label :visible_label
           end
-
-          if label_key
-            process_label(label_key)
-            return if @normalized_selector.nil?
-          end
-
-          if @normalized_selector.key?(:index) && filter == :all
-            raise ArgumentError, "can't locate all elements by :index"
-          end
-
-          @normalized_selector
-        end
-
-        def values_to_match
-          return @values_to_match if @values_to_match
-
-          @values_to_match = {}
-
-          # Remove locators that can never be used in XPath builder
-          %i[visible visible_text].each do |how|
-            next unless @normalized_selector.key?(how)
-
-            @values_to_match[how] = @normalized_selector.delete(how)
-          end
-
-          set_tag_validation if tag_validation_required?(@normalized_selector)
-
-          # Regexp locators currently need to be validated even if they are included in the XPath builder
-          # TODO: Identify Regexp that can have an exact equivalent using XPath contains (ie would not require
-          #  additional matching) vs approximations (ie would still require additional matching)
-          @normalized_selector.each do |how, what|
-            next unless what.is_a?(Regexp)
-
-            @values_to_match[how] = @normalized_selector.delete(how)
-          end
-
-          if @normalized_selector[:index] && !@normalized_selector[:adjacent]
-            idx = @normalized_selector.delete(:index)
-
-            # Do not add {index: 0} if the only value to match
-            # This will allow using #find_element instead of #find_elements.
-            implicit_idx_match = @values_to_match.empty? && idx.zero?
-            @values_to_match[:index] = idx unless implicit_idx_match
-          end
-
-          @values_to_match
-        end
-
-        def set_tag_validation
-          values_to_match[:tag_name] = @normalized_selector[:tag_name].to_s
         end
 
         def process_label(label_key)
-          regexp = @normalized_selector[label_key].is_a?(Regexp)
+          regexp = @selector[label_key].is_a?(Regexp)
           return unless (regexp || label_key == :visible_label) && selector_builder.should_use_label_element?
 
           label = label_from_text(label_key)
-          unless label # label not found, stop looking for element
-            @normalized_selector = nil
-            return
-          end
+          msg = "Unable to locate element with label #{label_key}: #{@selector[:label_key]}"
+          raise LocatorException, msg unless label
 
-          if (id = label.attribute('for'))
-            @normalized_selector[:id] = id
+          id = label.attribute('for')
+          if id
+            @selector[:id] = id
           else
             @driver_scope = label
           end
@@ -195,8 +155,8 @@ module Watir
         def label_from_text(label_key)
           # TODO: this won't work correctly if @wd is a sub-element, write spec
           # TODO: Figure out how to do this with find_element
-          label_text = @normalized_selector.delete(label_key)
-          locator_key = label_key.to_s.gsub('label', 'text').to_sym
+          label_text = @selector.delete(label_key)
+          locator_key = label_key.to_s.gsub('label', 'text').gsub('_element', '').to_sym
           locate_elements(:tag_name, 'label', @driver_scope).find do |el|
             matches_values?(el, locator_key => label_text)
           end
@@ -229,10 +189,6 @@ module Watir
           Watir.logger.deprecate(dep, ":visible_#{key}", ids: [:text_regexp])
         end
 
-        def tag_validation_required?(selector)
-          (selector.key?(:css) || selector.key?(:xpath)) && selector.key?(:tag_name)
-        end
-
         def locate_element(how, what, scope = @query_scope.wd)
           scope.find_element(how, what)
         end
@@ -241,11 +197,11 @@ module Watir
           scope.find_elements(how, what)
         end
 
-        def locate_matching_elements(how, what, filter)
+        def locate_matching_elements(selector, values_to_match, filter)
           retries = 0
           begin
-            elements = locate_elements(how, what, @driver_scope) || []
-            matching_elements(elements, filter: filter)
+            elements = locate_elements(selector.keys.first, selector.values.first, @driver_scope) || []
+            matching_elements(elements, values_to_match, filter: filter)
           rescue Selenium::WebDriver::Error::StaleElementReferenceError
             retries += 1
             sleep 0.5

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -28,7 +28,7 @@ module Watir
                     xpath_css
                   end
 
-          @selector.delete(:index) if @selector[:index] == 0
+          @selector.delete(:index) if @selector[:index]&.zero?
 
           Watir.logger.debug "Converted #{@selector.inspect} to #{built}"
           [built, @selector]

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -7,24 +7,38 @@ module Watir
         VALID_WHATS = [Array, String, Regexp, TrueClass, FalseClass, ::Symbol].freeze
         WILDCARD_ATTRIBUTE = /^(aria|data)_(.+)$/
 
-        def initialize(query_scope, selector, valid_attributes)
-          @query_scope = query_scope # either element or browser
-          @selector = selector
+        def initialize(scope_tag_name, valid_attributes)
+          @scope_tag_name = scope_tag_name
           @valid_attributes = valid_attributes
           @custom_attributes = []
         end
 
-        def normalized_selector
-          selector = {}
+        def build(selector)
+          @selector = selector
+          normalize_selector
 
-          @selector.each do |how, what|
-            check_type(how, what)
-
-            how, what = normalize_selector(how, what)
-            selector[how] = what
+          xpath_css = (@selector.keys & %i[xpath css]).each_with_object({}) do |key, hash|
+            hash[key] = @selector.delete(key)
           end
 
-          selector
+          built = if xpath_css.empty?
+                    build_wd_selector(@selector, @scope_tag_name)
+                  else
+                    process_xpath_css(xpath_css)
+                    xpath_css
+                  end
+
+          Watir.logger.debug "Converted #{@selector.inspect} to #{built}"
+          [built, @selector]
+        end
+
+        def normalize_selector
+          @selector.keys.each do |key|
+            check_type(key, @selector[key])
+
+            how, what = normalize_locator(key, @selector.delete(key))
+            @selector[how] = what
+          end
         end
 
         def check_type(how, what)
@@ -50,23 +64,16 @@ module Watir
           !valid_attribute?(:label)
         end
 
-        def build(selector, values_to_match)
-          inspect = selector.inspect
-          return given_xpath_or_css(selector) if selector.key?(:xpath) || selector.key?(:css)
-
-          built = build_wd_selector(selector, values_to_match)
-          Watir.logger.debug "Converted #{inspect} to #{built}"
-          built
-        end
-
         private
 
-        def normalize_selector(how, what)
+        def normalize_locator(how, what)
           case how
-          when :tag_name, :text, :xpath, :index, :class, :label, :css, :visible, :visible_text, :adjacent
+          when :tag_name, :text, :xpath, :index, :class, :css, :visible, :visible_text, :adjacent
             # include :class since the valid attribute is 'class_name'
             # include :for since the valid attribute is 'html_for'
             [how, what]
+          when :label, :visible_label
+            should_use_label_element? ? ["#{how}_element".to_sym, what] : [how, what]
           when :class_name
             [:class, what]
           when :caption
@@ -83,30 +90,18 @@ module Watir
           @custom_attributes << attribute.to_s
         end
 
-        def given_xpath_or_css(selector)
-          locator = {}
-          locator[:xpath] = selector.delete(:xpath) if selector.key?(:xpath)
-          locator[:css] = selector.delete(:css) if selector.key?(:css)
+        def process_xpath_css(xpath_css)
+          raise ArgumentError, ":xpath and :css cannot be combined (#{@selector.inspect})" if xpath_css.size > 1
 
-          return if locator.empty?
-          raise ArgumentError, ":xpath and :css cannot be combined (#{selector.inspect})" if locator.size > 1
+          return if combine_with_xpath_or_css?(@selector)
 
-          return locator.first unless selector.any? && !combine_with_xpath_or_css?(selector)
-
-          msg = "#{locator.keys.first} cannot be combined with other locators (#{selector.inspect})"
+          msg = "#{xpath_css.keys.first} cannot be combined with all of these locators (#{@selector.inspect})"
           raise ArgumentError, msg
         end
 
-        def build_wd_selector(selector, values_to_match)
-          xpath_builder.build(selector, values_to_match)
-        end
-
-        def xpath_builder
-          @xpath_builder ||= xpath_builder_class.new(should_use_label_element?)
-        end
-
-        def xpath_builder_class
-          Kernel.const_get("#{self.class.name}::XPath")
+        # Implement this method when creating a different selector builder
+        def build_wd_selector(selector, scope_tag_name)
+          Kernel.const_get("#{self.class.name}::XPath").new.build(selector, scope_tag_name)
         end
 
         def valid_attribute?(attribute)
@@ -115,9 +110,10 @@ module Watir
 
         def combine_with_xpath_or_css?(selector)
           keys = selector.keys
-          return true if keys == [:tag_name]
+          keys.reject! { |key| %i[visible visible_text index].include? key }
+          return true if (keys - [:tag_name]).empty?
 
-          return keys.sort == %i[tag_name type] if selector[:tag_name] == 'input'
+          return true if selector[:tag_name] == 'input' && keys == %i[tag_name type]
 
           false
         end

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -28,6 +28,8 @@ module Watir
                     xpath_css
                   end
 
+          @selector.delete(:index) if @selector[:index] == 0
+
           Watir.logger.debug "Converted #{@selector.inspect} to #{built}"
           [built, @selector]
         end

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -16,26 +16,23 @@ module Watir
             \z
           /x
 
-          def initialize(use_label_element)
-            @should_use_label_element = use_label_element
-          end
-
-          def build(selector, values_to_match)
+          def build(selector, scope_tag_name)
             adjacent = selector.delete :adjacent
             xpath = adjacent.nil? ? default_start : process_adjacent(adjacent)
             xpath << add_tag_name(selector)
-            index = selector.delete(:index)
 
             # the remaining entries should be attributes
-            xpath << add_attributes(selector)
+            xpath << add_attributes(selector, scope_tag_name)
 
-            xpath << "[#{index + 1}]" if adjacent && index
+            xpath << "[#{selector.delete(:index) + 1}]" if adjacent && selector.key?(:index)
 
-            xpath = add_regexp_predicates(xpath, values_to_match)
+            selector.select! { |k, v| %i[index visible visible_text visible_label].include?(k) || v.is_a?(Regexp) }
+
+            xpath = add_regexp_predicates(xpath, selector)
 
             Watir.logger.debug(xpath: xpath, selector: selector)
 
-            [:xpath, xpath]
+            {xpath: xpath}
           end
 
           def default_start
@@ -47,16 +44,17 @@ module Watir
             tag_name.empty? ? '' : "[local-name()='#{tag_name}']"
           end
 
-          def add_attributes(selector)
+          def add_attributes(selector, _scope_tag_name)
             element_attr_exp = attribute_expression(nil, selector)
             element_attr_exp.empty? ? '' : "[#{element_attr_exp}]"
           end
 
           def add_regexp_predicates(what, selector)
+            return what if selector.empty?
             return what unless convert_regexp_to_contains?
 
             selector.each do |key, value|
-              next if %i[tag_name text visible_text visible index].include?(key)
+              next if %i[tag_name text visible_text visible index label_element].include?(key)
 
               predicates = regexp_selector_to_predicates(key, value)
               what = "(#{what})[#{predicates.join(' and ')}]" unless predicates.empty?
@@ -66,20 +64,11 @@ module Watir
 
           # @todo Get rid of building
           def attribute_expression(building, selector)
-            f = selector.map do |key, val|
-              if val.is_a?(Array) && key == :class
-                '(' + val.map { |v| build_class_match(v) }.join(' and ') + ')'
-              elsif val.is_a?(Array)
-                '(' + val.map { |v| equal_pair(building, key, v) }.join(' or ') + ')'
-              elsif val.eql? true
-                attribute_presence(key)
-              elsif val.eql? false
-                attribute_absence(key)
-              else
-                equal_pair(building, key, val)
-              end
-            end
-            f.join(' and ')
+            selector.map { |key, val|
+              next if val.is_a?(Regexp) || %i[visible visible_text visible_label index].include?(key)
+
+              locator_expression(building, key, val)
+            }.compact.join(' and ')
           end
 
           # @todo Get rid of building
@@ -92,7 +81,11 @@ module Watir
                                        ids: [:class_array]
               end
               build_class_match(value)
-            elsif key == :label && @should_use_label_element
+            elsif key == :index
+              nil
+            elsif key == :label_element
+              return if value.is_a? Regexp
+
               # we assume :label means a corresponding label element, not the attribute
               text = "normalize-space()=#{XpathSupport.escape value}"
               "(@id=//label[#{text}]/@for or parent::label[#{text}])"
@@ -123,6 +116,20 @@ module Watir
           end
 
           private
+
+          def locator_expression(building, key, val)
+            if val.is_a?(Array) && key == :class
+              '(' + val.map { |v| build_class_match(v) }.join(' and ') + ')'
+            elsif val.is_a?(Array)
+              '(' + val.map { |v| equal_pair(building, key, v) }.join(' or ') + ')'
+            elsif val.eql? true
+              attribute_presence(key)
+            elsif val.eql? false
+              attribute_absence(key)
+            else
+              equal_pair(building, key, val)
+            end
+          end
 
           def process_adjacent(adjacent)
             xpath = './'

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -28,8 +28,8 @@ module Watir
 
             xpath << add_regexp_predicates(selector) unless selector.empty?
 
-            # TODO: figure out how to delete the attributes as we use them instead of everything that might
-            # require additional matching
+            # TODO: figure out how to delete the attributes as we use them instead of
+            # just keeping everything that might require additional matching
             selector.select! { |k, v| %i[index visible visible_text visible_label].include?(k) || v.is_a?(Regexp) }
 
             Watir.logger.debug(xpath: xpath, selector: selector)

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -26,6 +26,7 @@ module Watir
 
             xpath << "[#{selector.delete(:index) + 1}]" if adjacent && selector.key?(:index)
 
+            # TODO: figure out how to delete the attributes as we use them instead of everything that doesn't match
             selector.select! { |k, v| %i[index visible visible_text visible_label].include?(k) || v.is_a?(Regexp) }
 
             xpath = add_regexp_predicates(xpath, selector)
@@ -81,11 +82,7 @@ module Watir
                                        ids: [:class_array]
               end
               build_class_match(value)
-            elsif key == :index
-              nil
             elsif key == :label_element
-              return if value.is_a? Regexp
-
               # we assume :label means a corresponding label element, not the attribute
               text = "normalize-space()=#{XpathSupport.escape value}"
               "(@id=//label[#{text}]/@for or parent::label[#{text}])"

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -26,7 +26,7 @@ module Watir
 
             xpath << "[#{selector.delete(:index) + 1}]" if adjacent && selector.key?(:index)
 
-            xpath << add_regexp_predicates(selector) unless selector.empty? || convert_regexp_to_contains?
+            xpath << add_regexp_predicates(selector) if convert_regexp_to_contains?
 
             # TODO: figure out how to delete the attributes as we use them instead of
             # just keeping everything that might require additional matching
@@ -59,7 +59,7 @@ module Watir
 
           def add_regexp_predicates(selector)
             selector.keys.each_with_object('') do |key, string|
-              next if %i[tag_name text visible_text visible index].include?(key)
+              next if %i[text visible_text visible index].include?(key)
 
               predicates = []
               if key == :class && selector[key].is_a?(Array)

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -26,7 +26,7 @@ module Watir
 
             xpath << "[#{selector.delete(:index) + 1}]" if adjacent && selector.key?(:index)
 
-            xpath << add_regexp_predicates(selector) unless selector.empty?
+            xpath << add_regexp_predicates(selector) unless selector.empty? || convert_regexp_to_contains?
 
             # TODO: figure out how to delete the attributes as we use them instead of
             # just keeping everything that might require additional matching
@@ -48,7 +48,7 @@ module Watir
             elsif tag_name.to_s.empty?
               ''
             else
-              "[local-name()='#{tag_name.to_s}']"
+              "[local-name()='#{tag_name}']"
             end
           end
 
@@ -58,8 +58,6 @@ module Watir
           end
 
           def add_regexp_predicates(selector)
-            return '' unless convert_regexp_to_contains?
-
             selector.keys.each_with_object('') do |key, string|
               next if %i[tag_name text visible_text visible index].include?(key)
 
@@ -67,6 +65,7 @@ module Watir
               if key == :class && selector[key].is_a?(Array)
                 selector[key].dup.each do |val|
                   next unless val.is_a?(Regexp)
+
                   array_selector = {key => val}
                   predicates += regexp_selector_to_predicates(:class, array_selector)
                   selector[key].delete(val) if array_selector.empty?

--- a/lib/watir/locators/row/selector_builder.rb
+++ b/lib/watir/locators/row/selector_builder.rb
@@ -2,10 +2,6 @@ module Watir
   module Locators
     class Row
       class SelectorBuilder < Element::SelectorBuilder
-        def build_wd_selector(selector, values_to_match)
-          xpath_builder.scope_tag_name = @query_scope.selector[:tag_name]
-          super
-        end
       end
     end
   end

--- a/lib/watir/locators/row/selector_builder/xpath.rb
+++ b/lib/watir/locators/row/selector_builder/xpath.rb
@@ -3,12 +3,10 @@ module Watir
     class Row
       class SelectorBuilder
         class XPath < Element::SelectorBuilder::XPath
-          attr_accessor :scope_tag_name
-
-          def add_attributes(selector)
+          def add_attributes(selector, scope_tag_name)
             attr_expr = attribute_expression(nil, selector)
 
-            expressions = generate_expressions
+            expressions = generate_expressions(scope_tag_name)
             expressions.map! { |e| "#{e}[#{attr_expr}]" } unless attr_expr.empty?
             expressions.join(' | ')
           end
@@ -24,7 +22,7 @@ module Watir
 
           private
 
-          def generate_expressions
+          def generate_expressions(scope_tag_name)
             expressions = %w[./tr]
             return expressions if scope_tag_name.nil? || %w[tbody tfoot thead].include?(scope_tag_name)
 

--- a/lib/watir/locators/text_area/selector_builder.rb
+++ b/lib/watir/locators/text_area/selector_builder.rb
@@ -4,7 +4,7 @@ module Watir
       class SelectorBuilder < Element::SelectorBuilder
         private
 
-        def normalize_selector(how, what)
+        def normalize_locator(how, what)
           # We need to iterate through located elements and fetch
           # attribute value using Selenium because XPath doesn't understand
           # difference between IDL vs content attribute.

--- a/lib/watir/locators/text_field/selector_builder/xpath.rb
+++ b/lib/watir/locators/text_field/selector_builder/xpath.rb
@@ -3,7 +3,7 @@ module Watir
     class TextField
       class SelectorBuilder
         class XPath < Element::SelectorBuilder::XPath
-          def add_attributes(selector)
+          def add_attributes(selector, _scope_tag_name)
             input_attr_exp = attribute_expression(:input, selector)
             xpath = "[(not(@type) or (#{negative_type_expr}))"
             xpath << " and #{input_attr_exp}" unless input_attr_exp.empty?

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -10,7 +10,8 @@ module LocatorSpecHelper
   def locator(selector, attrs)
     attrs ||= Watir::HTMLElement.attributes
     element_validator = Watir::Locators::Element::Validator.new
-    selector_builder = Watir::Locators::Element::SelectorBuilder.new(driver, selector, attrs)
+    scope_tag_name = @query_scope.selector[:tag_name] if @query_scope.respond_to?(:selector)
+    selector_builder = Watir::Locators::Element::SelectorBuilder.new(scope_tag_name, attrs)
     Watir::Locators::Element::Locator.new(browser, selector, selector_builder, element_validator)
   end
 

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -453,10 +453,30 @@ describe Watir::Locators::Element::Locator do
 
         selector = {name: 'foo'}
         element_validator = Watir::Locators::Element::Validator.new
-        selector_builder = Foo::SelectorBuilder.new(driver, selector, Watir::HTMLElement.attributes)
+        scope_tag_name = @query_scope.selector[:tag_name] if @query_scope.respond_to?(:selector)
+        selector_builder = Foo::SelectorBuilder.new(scope_tag_name, Watir::HTMLElement.attributes)
         locator = Watir::Locators::Element::Locator.new(browser, selector, selector_builder, element_validator)
 
         msg = 'Foo::SelectorBuilder was unable to build selector from {:name=>"foo"}'
+        expect { locator.locate }.to raise_exception(Watir::Exception::LocatorException, msg)
+      end
+
+      it 'raises an Error if unable to build values to match' do
+        module Foo
+          class SelectorBuilder < Watir::Locators::Element::SelectorBuilder
+            def build(*_args)
+              {}
+            end
+          end
+        end
+
+        selector = {name: 'foo'}
+        element_validator = Watir::Locators::Element::Validator.new
+        scope_tag_name = @query_scope.selector[:tag_name] if @query_scope.respond_to?(:selector)
+        selector_builder = Foo::SelectorBuilder.new(scope_tag_name, Watir::HTMLElement.attributes)
+        locator = Watir::Locators::Element::Locator.new(browser, selector, selector_builder, element_validator)
+
+        msg = 'Foo::SelectorBuilder#build is not returning expected responses for the current version of Watir'
         expect { locator.locate }.to raise_exception(Watir::Exception::LocatorException, msg)
       end
     end

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -244,14 +244,11 @@ describe Watir::Locators::Element::Locator do
 
     describe 'with regexp selectors' do
       it 'handles selector with tag name and a single regexp attribute' do
-        elements = [
-          element(tag_name: 'div', attributes: {class: 'foo'}),
-          element(tag_name: 'div', attributes: {class: 'foob'})
-        ]
+        element = element(tag_name: 'div', attributes: {class: 'foob'})
 
-        expect_all(:xpath, "(.//*[local-name()='div'])[contains(@class, 'oob')]").and_return(elements)
+        expect_one(:xpath, ".//*[local-name()='div'][contains(@class, 'oob')]").and_return(element)
 
-        expect(locate_one(tag_name: 'div', class: /oob/)).to eq elements[1]
+        expect(locate_one(tag_name: 'div', class: /oob/)).to eq element
       end
 
       it 'handles :tag_name, :index and a single regexp attribute' do
@@ -260,7 +257,7 @@ describe Watir::Locators::Element::Locator do
           element(tag_name: 'div', attributes: {class: 'foo'})
         ]
 
-        expect_all(:xpath, "(.//*[local-name()='div'])[contains(@class, 'foo')]").and_return(elements)
+        expect_all(:xpath, ".//*[local-name()='div'][contains(@class, 'foo')]").and_return(elements)
 
         selector = {
           tag_name: 'div',
@@ -304,12 +301,9 @@ describe Watir::Locators::Element::Locator do
       end
 
       it 'handles mix of string and regexp attributes' do
-        elements = [
-          element(tag_name: 'div', attributes: {dir: 'foo', title: 'bar'}),
-          element(tag_name: 'div', attributes: {dir: 'foo', title: 'baz'})
-        ]
+        element = element(tag_name: 'div', attributes: {dir: 'foo', title: 'baz'})
 
-        expect_all(:xpath, "(.//*[local-name()='div'][@dir='foo'])[contains(@title, 'baz')]").and_return(elements)
+        expect_one(:xpath, ".//*[local-name()='div'][@dir='foo'][contains(@title, 'baz')]").and_return(element)
 
         selector = {
           tag_name: 'div',
@@ -317,23 +311,20 @@ describe Watir::Locators::Element::Locator do
           title: /baz/
         }
 
-        expect(locate_one(selector)).to eq elements[1]
+        expect(locate_one(selector)).to eq element
       end
 
       it 'handles data-* attributes with regexp' do
-        elements = [
-          element(tag_name: 'div', attributes: {'data-automation-id': 'foo'}),
-          element(tag_name: 'div', attributes: {'data-automation-id': 'bar'})
-        ]
+        element = element(tag_name: 'div', attributes: {'data-automation-id': 'bar'})
 
-        expect_all(:xpath, "(.//*[local-name()='div'])[contains(@data-automation-id, 'bar')]").and_return(elements)
+        expect_one(:xpath, ".//*[local-name()='div'][contains(@data-automation-id, 'bar')]").and_return(element)
 
         selector = {
           tag_name: 'div',
           data_automation_id: /bar/
         }
 
-        expect(locate_one(selector)).to eq elements[1]
+        expect(locate_one(selector)).to eq element
       end
 
       it 'handles :label => /regexp/ selector' do
@@ -357,7 +348,8 @@ describe Watir::Locators::Element::Locator do
         expect(locate_one(tag_name: 'div', label: /foo/)).to be_nil
       end
 
-      it 'relocates an element that goes stale during filtering' do
+      # TODO - figure out how to test this since this is now one wire call not many
+      xit 'relocates an element that goes stale during filtering' do
         element1 = element(tag_name: 'div', attributes: {class: 'foo'})
         element2 = element(tag_name: 'div', attributes: {class: 'foob'})
 
@@ -371,7 +363,8 @@ describe Watir::Locators::Element::Locator do
         expect(locate_one(class: /foo/)).to eq elements2[0]
       end
 
-      it 'raises error if too many attempts to relocate a stale element during filtering' do
+      # TODO - figure out how to test this since this is now one wire call not many
+      xit 'raises error if too many attempts to relocate a stale element during filtering' do
         element1 = element(tag_name: 'div', attributes: {class: 'foo'})
         element2 = element(tag_name: 'div', attributes: {class: 'foob'})
 
@@ -383,7 +376,7 @@ describe Watir::Locators::Element::Locator do
         allow(elements2.first).to receive(:attribute).and_raise(Selenium::WebDriver::Error::StaleElementReferenceError)
         allow(elements3.first).to receive(:attribute).and_raise(Selenium::WebDriver::Error::StaleElementReferenceError)
 
-        expect_all(:xpath, "(.//*)[contains(@class, 'foo')]").and_return(elements1, elements2, elements3)
+        expect_all(:xpath, ".//*[contains(@class, 'foo')]").and_return(elements1, elements2, elements3)
 
         msg = 'Unable to locate element from {:class=>/foo/} due to changing page'
         expect { locate_one(class: /foo/) }.to raise_exception(StandardError, msg)
@@ -538,24 +531,22 @@ describe Watir::Locators::Element::Locator do
     describe 'with regexp selectors' do
       it 'handles selector with tag name and a single regexp attribute' do
         elements = [
-          element(tag_name: 'div', attributes: {class: 'foo'}),
           element(tag_name: 'div', attributes: {class: 'foob'}),
           element(tag_name: 'div', attributes: {class: 'doob'}),
           element(tag_name: 'div', attributes: {class: 'noob'})
         ]
 
-        expect_all(:xpath, "(.//*[local-name()='div'])[contains(@class, 'oob')]").and_return(elements)
+        expect_all(:xpath, ".//*[local-name()='div'][contains(@class, 'oob')]").and_return(elements)
         expect(locate_all(tag_name: 'div', class: /oob/)).to eq elements.last(3)
       end
 
       it 'handles mix of string and regexp attributes' do
         elements = [
-          element(tag_name: 'div', attributes: {dir: 'foo', title: 'bar'}),
           element(tag_name: 'div', attributes: {dir: 'foo', title: 'baz'}),
           element(tag_name: 'div', attributes: {dir: 'foo', title: 'bazt'})
         ]
 
-        expect_all(:xpath, "(.//*[local-name()='div'][@dir='foo'])[contains(@title, 'baz')]").and_return(elements)
+        expect_all(:xpath, ".//*[local-name()='div'][@dir='foo'][contains(@title, 'baz')]").and_return(elements)
 
         selector = {
           tag_name: 'div',
@@ -574,7 +565,7 @@ describe Watir::Locators::Element::Locator do
             element(tag_name: 'div', attributes: {class: 'bar'})
           ]
 
-          expect_all(:xpath, "(.//*[local-name()='div'])[contains(@class, 'fo')]").and_return(elements.first(2))
+          expect_all(:xpath, ".//*[local-name()='div'][contains(@class, 'fo')]").and_return(elements.first(2))
 
           expect(locate_one(tag_name: 'div', class: /fo.b$/)).to eq elements[1]
         end
@@ -585,7 +576,7 @@ describe Watir::Locators::Element::Locator do
             element(tag_name: 'div', attributes: {class: 'foob'})
           ]
 
-          expect_all(:xpath, "(.//*[local-name()='div'])[contains(@class, 'b')]").and_return(elements.last(1))
+          expect_all(:xpath, ".//*[local-name()='div'][contains(@class, 'b')]").and_return(elements.last(1))
 
           expect(locate_one(tag_name: 'div', class: /^fo.b/)).to eq elements[1]
         end
@@ -596,7 +587,7 @@ describe Watir::Locators::Element::Locator do
             element(tag_name: 'div', attributes: {class: 'foob'})
           ]
 
-          expect_all(:xpath, "(.//*[local-name()='div'])[contains(@class, 'fo') and contains(@class, 'b')]")
+          expect_all(:xpath, ".//*[local-name()='div'][contains(@class, 'fo') and contains(@class, 'b')]")
             .and_return(elements.last(1))
 
           expect(locate_one(tag_name: 'div', class: /fo.b/)).to eq elements[1]
@@ -630,7 +621,7 @@ describe Watir::Locators::Element::Locator do
             element(tag_name: 'div', attributes: {class: 'abc23'})
           ]
 
-          expect_all(:xpath, "(.//*[local-name()='div'])[contains(@class, 'abc')]").and_return(elements)
+          expect_all(:xpath, ".//*[local-name()='div'][contains(@class, 'abc')]").and_return(elements)
 
           expect(locate_one(tag_name: 'div', class: /abc\d\d/)).to eq elements[1]
         end

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -348,7 +348,7 @@ describe Watir::Locators::Element::Locator do
         expect(locate_one(tag_name: 'div', label: /foo/)).to be_nil
       end
 
-      # TODO - figure out how to test this since this is now one wire call not many
+      # TODO: - figure out how to test this since this is now one wire call not many
       xit 'relocates an element that goes stale during filtering' do
         element1 = element(tag_name: 'div', attributes: {class: 'foo'})
         element2 = element(tag_name: 'div', attributes: {class: 'foob'})
@@ -363,7 +363,7 @@ describe Watir::Locators::Element::Locator do
         expect(locate_one(class: /foo/)).to eq elements2[0]
       end
 
-      # TODO - figure out how to test this since this is now one wire call not many
+      # TODO: - figure out how to test this since this is now one wire call not many
       xit 'raises error if too many attempts to relocate a stale element during filtering' do
         element1 = element(tag_name: 'div', attributes: {class: 'foo'})
         element2 = element(tag_name: 'div', attributes: {class: 'foob'})

--- a/spec/unit/selector_builder_spec.rb
+++ b/spec/unit/selector_builder_spec.rb
@@ -7,33 +7,65 @@ describe 'Current behavior' do
     # Element Calls
     browser.element.exists? # {"using":"xpath","value":".//*"}
 
-    browser.element(tag_name: 'div').exists? # {"using":"tag name","value":"div"}
-    browser.element(xpath: ".//div").exists? # {"using":"xpath","value":".//div"}
-    browser.element(css: "div").exists? # {"using":"css selector","value":"div"}
-    browser.element(class: "foo").exists? # {"using":"xpath","value":".//*[contains(concat(' ', @class, ' '), ' foo ')]"}
-    browser.element(class: "foo").exists? # {"using":"xpath","value":".//*[contains(concat(' ', @class, ' '), ' foo ')]"}
-    browser.element(class: %w[foo bar]).exists? # {"using":"xpath","value":".//*[(contains(concat(' ', @class, ' '), ' foo ') and contains(concat(' ', @class, ' '), ' bar '))]"}
+    # {"using":"tag name","value":"div"}
+    browser.element(tag_name: 'div').exists?
+
+    # {"using":"xpath","value":".//div"}
+    browser.element(xpath: './/div').exists?
+
+    # {"using":"css selector","value":"div"}
+    browser.element(css: 'div').exists?
+
+    # {"using":"xpath","value":".//*[contains(concat(' ', @class, ' '), ' foo ')]"}
+    browser.element(class: 'foo').exists?
+
+    # {"using":"xpath","value":".//*[contains(concat(' ', @class, ' '), ' foo ')]"}
+    browser.element(class: 'foo').exists?
+
+    # {"using":"xpath","value":".//*[(contains(concat(' ', @class, ' '), ' foo ')
+    # and contains(concat(' ', @class, ' '), ' bar '))]"}
+    browser.element(class: %w[foo bar]).exists?
 
     # This does not currently work
     # browser.element(class: [/foo/, /bar/]).exists?
 
-    browser.element(xpath: ".//*[@id='foo']", tag_name: 'div').exists? # {"using":"xpath","value":".//*[@id='foo']"}
-    browser.element(class: "foo", tag_name: 'div').exists? # {"using":"xpath","value":".//*[local-name()='div'][contains(concat(' ', @class, ' '), ' foo ')]"}
-    browser.element(id: "foo", tag_name: 'div').exists? # {"using":"xpath","value":".//*[local-name()='div'][@id='foo']"}
-    browser.element(class: %w[foo bar], tag_name: 'div').exists? # {"using":"xpath","value":".//*[local-name()='div'][(contains(concat(' ', @class, ' '), ' foo ') and contains(concat(' ', @class, ' '), ' bar '))]"}
+    # {"using":"xpath","value":".//*[@id='foo']"}
+    browser.element(xpath: ".//*[@id='foo']", tag_name: 'div').exists?
 
-    browser.element(class: %w[!foo bar]).exists? # {"using":"xpath","value":".//*[(not(contains(concat(' ', @class, ' '), ' foo ')) and contains(concat(' ', @class, ' '), ' bar '))]"}
+    # {"using":"xpath","value":".//*[local-name()='div'][contains(concat(' ', @class, ' '), ' foo ')]"}
+    browser.element(class: 'foo', tag_name: 'div').exists?
+
+    # {"using":"xpath","value":".//*[local-name()='div'][@id='foo']"}
+    browser.element(id: 'foo', tag_name: 'div').exists?
+
+    # {"using":"xpath","value":".//*[local-name()='div'][(contains(concat(' ', @class, ' '), ' foo ') and
+    # contains(concat(' ', @class, ' '), ' bar '))]"}
+    browser.element(class: %w[foo bar], tag_name: 'div').exists?
+
+    # {"using":"xpath","value":".//*[(not(contains(concat(' ', @class, ' '), ' foo '))
+    # and contains(concat(' ', @class, ' '), ' bar '))]"}
+    browser.element(class: %w[!foo bar]).exists?
+
     browser.element(id: true).exists? # {"using":"xpath","value":".//*[@id]"}
+
     browser.element(id: false).exists? # {"using":"xpath","value":".//*[not(@id)]"}
 
     # Elements Calls
-    browser.element(tag_name: /div/).exists? # {"using":"xpath","value":".//*"}
-    browser.element(class: /foo/).exists? # {"using":"xpath","value":"(.//*)[contains(@class, 'foo')]"}
-    browser.element(id: /foo/).exists? #  {"using":"xpath","value":"(.//*)[contains(@id, 'foo')]"}
-    # Why does this need to match values???
-    browser.element(id: "foo").exists? # {"using":"xpath","value":".//*[@id='foo']"}
-    browser.element(css: ".bar", tag_name: 'div').exists? # {"using":"css selector","value":".bar"}
 
+    # {"using":"xpath","value":".//*"}
+    browser.element(tag_name: /div/).exists?
+
+    # {"using":"xpath","value":"(.//*)[contains(@class, 'foo')]"}
+    browser.element(class: /foo/).exists?
+
+    #  {"using":"xpath","value":"(.//*)[contains(@id, 'foo')]"}
+    browser.element(id: /foo/).exists?
+
+    # {"using":"xpath","value":".//*[@id='foo']"}
+    browser.element(id: 'foo').exists?
+
+    # {"using":"css selector","value":".bar"}
+    browser.element(css: '.bar', tag_name: 'div').exists?
   end
 end
 
@@ -50,7 +82,7 @@ describe Watir::Locators::Element::SelectorBuilder do
   describe '#build' do
     it 'builds with no locators provided' do
       selector = {}
-      expected = {xpath: ".//*"}
+      expected = {xpath: './/*'}
 
       expect_built(selector, expected)
     end
@@ -65,28 +97,28 @@ describe Watir::Locators::Element::SelectorBuilder do
         end
 
         it 'xpath' do
-          selector = {xpath: ".//div]"}
+          selector = {xpath: './/div]'}
           expected = selector.dup
 
           expect_built(selector, expected)
         end
 
         it 'css' do
-          selector = {css: "div"}
+          selector = {css: 'div'}
           expected = selector.dup
 
           expect_built(selector, expected)
         end
 
         it 'class name' do
-          selector = {class: "foo"}
+          selector = {class: 'foo'}
           expected = {xpath: ".//*[contains(concat(' ', @class, ' '), ' foo ')]"}
 
           expect_built(selector, expected)
         end
 
         it 'attribute' do
-          selector = {id: "foo"}
+          selector = {id: 'foo'}
           expected = {xpath: ".//*[@id='foo']"}
 
           expect_built(selector, expected)
@@ -104,7 +136,7 @@ describe Watir::Locators::Element::SelectorBuilder do
       context 'with Regexp values' do
         it 'tag name' do
           selector = {tag_name: /div/}
-          expected = {xpath: ".//*[contains(local-name(), div)]"}
+          expected = {xpath: './/*[contains(local-name(), div)]'}
 
           expect_built(selector, expected)
         end
@@ -139,7 +171,6 @@ describe Watir::Locators::Element::SelectorBuilder do
           expect_built(selector, expected)
         end
       end
-
     end
 
     context 'with tag name and single locator' do
@@ -153,15 +184,15 @@ describe Watir::Locators::Element::SelectorBuilder do
 
       # Desired Behavior
       xit 'css' do
-        selector = {css: ".bar", tag_name: 'div'}
-        expected = {css: "div.bar"}
+        selector = {css: '.bar', tag_name: 'div'}
+        expected = {css: 'div.bar'}
 
         expect_built(selector, expected)
       end
 
       it 'css' do
-        selector = {css: ".bar", tag_name: 'div'}
-        expected = {css: ".bar"}
+        selector = {css: '.bar', tag_name: 'div'}
+        expected = {css: '.bar'}
 
         expect_built(selector, expected, tag_name: 'div')
       end
@@ -174,14 +205,14 @@ describe Watir::Locators::Element::SelectorBuilder do
       end
 
       it 'class name' do
-        selector = {class: "foo", tag_name: 'div'}
+        selector = {class: 'foo', tag_name: 'div'}
         expected = {xpath: ".//*[local-name()='div'][contains(concat(' ', @class, ' '), ' foo ')]"}
 
         expect_built(selector, expected)
       end
 
       it 'attribute' do
-        selector = {id: "foo", tag_name: 'div'}
+        selector = {id: 'foo', tag_name: 'div'}
         expected = {xpath: ".//*[local-name()='div'][@id='foo']"}
 
         expect_built(selector, expected)

--- a/spec/unit/selector_builder_spec.rb
+++ b/spec/unit/selector_builder_spec.rb
@@ -1,0 +1,200 @@
+require_relative 'unit_helper'
+
+describe 'Current behavior' do
+  xit 'generated XPath' do
+    browser = Watir::Browser.new
+
+    # Element Calls
+    browser.element.exists? # {"using":"xpath","value":".//*"}
+
+    browser.element(tag_name: 'div').exists? # {"using":"tag name","value":"div"}
+    browser.element(xpath: ".//div").exists? # {"using":"xpath","value":".//div"}
+    browser.element(css: "div").exists? # {"using":"css selector","value":"div"}
+    browser.element(class: "foo").exists? # {"using":"xpath","value":".//*[contains(concat(' ', @class, ' '), ' foo ')]"}
+    browser.element(class: "foo").exists? # {"using":"xpath","value":".//*[contains(concat(' ', @class, ' '), ' foo ')]"}
+    browser.element(class: %w[foo bar]).exists? # {"using":"xpath","value":".//*[(contains(concat(' ', @class, ' '), ' foo ') and contains(concat(' ', @class, ' '), ' bar '))]"}
+
+    # This does not currently work
+    # browser.element(class: [/foo/, /bar/]).exists?
+
+    browser.element(xpath: ".//*[@id='foo']", tag_name: 'div').exists? # {"using":"xpath","value":".//*[@id='foo']"}
+    browser.element(class: "foo", tag_name: 'div').exists? # {"using":"xpath","value":".//*[local-name()='div'][contains(concat(' ', @class, ' '), ' foo ')]"}
+    browser.element(id: "foo", tag_name: 'div').exists? # {"using":"xpath","value":".//*[local-name()='div'][@id='foo']"}
+    browser.element(class: %w[foo bar], tag_name: 'div').exists? # {"using":"xpath","value":".//*[local-name()='div'][(contains(concat(' ', @class, ' '), ' foo ') and contains(concat(' ', @class, ' '), ' bar '))]"}
+
+    browser.element(class: %w[!foo bar]).exists? # {"using":"xpath","value":".//*[(not(contains(concat(' ', @class, ' '), ' foo ')) and contains(concat(' ', @class, ' '), ' bar '))]"}
+    browser.element(id: true).exists? # {"using":"xpath","value":".//*[@id]"}
+    browser.element(id: false).exists? # {"using":"xpath","value":".//*[not(@id)]"}
+
+    # Elements Calls
+    browser.element(tag_name: /div/).exists? # {"using":"xpath","value":".//*"}
+    browser.element(class: /foo/).exists? # {"using":"xpath","value":"(.//*)[contains(@class, 'foo')]"}
+    browser.element(id: /foo/).exists? #  {"using":"xpath","value":"(.//*)[contains(@id, 'foo')]"}
+    # Why does this need to match values???
+    browser.element(id: "foo").exists? # {"using":"xpath","value":".//*[@id='foo']"}
+    browser.element(css: ".bar", tag_name: 'div').exists? # {"using":"css selector","value":".bar"}
+
+  end
+end
+
+describe Watir::Locators::Element::SelectorBuilder do
+  let(:attributes) { Watir::HTMLElement.attribute_list }
+  let(:tag_name) { nil }
+  let(:selector_builder) { described_class.new(tag_name, attributes) }
+
+  def expect_built(selector, expected, to_match = {})
+    built = selector_builder.build(selector)
+    expect(built).to eq [expected, to_match]
+  end
+
+  describe '#build' do
+    it 'builds with no locators provided' do
+      selector = {}
+      expected = {xpath: ".//*"}
+
+      expect_built(selector, expected)
+    end
+
+    context 'with single locator' do
+      context 'with String values' do
+        it 'tag name' do
+          selector = {tag_name: 'div'}
+          expected = {xpath: ".//*[local-name()='div']"}
+
+          expect_built(selector, expected)
+        end
+
+        it 'xpath' do
+          selector = {xpath: ".//div]"}
+          expected = selector.dup
+
+          expect_built(selector, expected)
+        end
+
+        it 'css' do
+          selector = {css: "div"}
+          expected = selector.dup
+
+          expect_built(selector, expected)
+        end
+
+        it 'class name' do
+          selector = {class: "foo"}
+          expected = {xpath: ".//*[contains(concat(' ', @class, ' '), ' foo ')]"}
+
+          expect_built(selector, expected)
+        end
+
+        it 'attribute' do
+          selector = {id: "foo"}
+          expected = {xpath: ".//*[@id='foo']"}
+
+          expect_built(selector, expected)
+        end
+
+        it 'class name array' do
+          selector = {class: %w[foo bar]}
+          xpath = ".//*[(contains(concat(' ', @class, ' '), ' foo ') and contains(concat(' ', @class, ' '), ' bar '))]"
+          expected = {xpath: xpath}
+
+          expect_built(selector, expected)
+        end
+      end
+
+      context 'with Regexp values' do
+        it 'tag name' do
+          selector = {tag_name: /div/}
+          expected = {xpath: ".//*[contains(local-name(), div)]"}
+
+          expect_built(selector, expected)
+        end
+
+        it 'single class name' do
+          selector = {class: /foo/}
+          expected = {xpath: ".//*[contains(@class, 'foo')]"}
+
+          expect_built(selector, expected)
+        end
+
+        it 'attribute' do
+          selector = {id: /foo/}
+          expected = {xpath: ".//*[contains(@id, 'foo')]"}
+
+          expect_built(selector, expected)
+        end
+
+        it 'class name array same' do
+          selector = {class: [/foo/, /bar/]}
+          xpath = ".//*[contains(@class, 'foo') and contains(@class, 'bar')]"
+          expected = {xpath: xpath}
+
+          expect_built(selector, expected)
+        end
+
+        it 'class name array mixed' do
+          selector = {class: ['foo', /bar/]}
+          xpath = ".//*[(contains(concat(' ', @class, ' '), ' foo '))][contains(@class, 'bar')]"
+          expected = {xpath: xpath}
+
+          expect_built(selector, expected)
+        end
+      end
+
+    end
+
+    context 'with tag name and single locator' do
+      # Desired Behavior
+      xit 'xpath' do
+        selector = {xpath: ".//*[@id='foo']", tag_name: 'div'}
+        expected = {xpath: ".//*[local-name()='div'][@id='foo']"}
+
+        expect_built(selector, expected)
+      end
+
+      # Desired Behavior
+      xit 'css' do
+        selector = {css: ".bar", tag_name: 'div'}
+        expected = {css: "div.bar"}
+
+        expect_built(selector, expected)
+      end
+
+      it 'css' do
+        selector = {css: ".bar", tag_name: 'div'}
+        expected = {css: ".bar"}
+
+        expect_built(selector, expected, tag_name: 'div')
+      end
+
+      it 'xpath' do
+        selector = {xpath: ".//*[@id='foo']", tag_name: 'div'}
+        expected = {xpath: ".//*[@id='foo']"}
+
+        expect_built(selector, expected, tag_name: 'div')
+      end
+
+      it 'class name' do
+        selector = {class: "foo", tag_name: 'div'}
+        expected = {xpath: ".//*[local-name()='div'][contains(concat(' ', @class, ' '), ' foo ')]"}
+
+        expect_built(selector, expected)
+      end
+
+      it 'attribute' do
+        selector = {id: "foo", tag_name: 'div'}
+        expected = {xpath: ".//*[local-name()='div'][@id='foo']"}
+
+        expect_built(selector, expected)
+      end
+
+      it 'class name array' do
+        selector = {class: %w[foo bar], tag_name: 'div'}
+        xpath = ".//*[local-name()='div'][(contains(concat(' ', @class, ' '), ' foo ')" \
+        " and contains(concat(' ', @class, ' '), ' bar '))]"
+        expected = {xpath: xpath}
+
+        expect_built(selector, expected)
+      end
+    end
+  end
+end

--- a/spec/watirspec/elements/date_time_field_spec.rb
+++ b/spec/watirspec/elements/date_time_field_spec.rb
@@ -15,7 +15,12 @@ describe 'DateTimeField' do
       expect(browser.date_time_field(text: '')).to exist
       expect(browser.date_time_field(text: //)).to exist
       expect(browser.date_time_field(index: 0)).to exist
-      expect(browser.date_time_field(xpath: "//input[@id='html5_datetime-local']")).to exist
+
+      # Firefox validates attribute "type" as "text" not "datetime-local"
+      not_compliant_on :firefox do
+        expect(browser.date_time_field(xpath: "//input[@id='html5_datetime-local']")).to exist
+      end
+
       expect(browser.date_time_field(label: 'HTML5 Datetime Local')).to exist
       expect(browser.date_time_field(label: /Local$/)).to exist
     end

--- a/spec/watirspec/elements/table_nesting_spec.rb
+++ b/spec/watirspec/elements/table_nesting_spec.rb
@@ -7,7 +7,7 @@ describe 'Table' do
 
   # not a selenium bug - IE seems unable to deal with the invalid nesting
   not_compliant_on :internet_explorer do
-    it 'returns the correct number of rows under a table' do
+    it 'returns the correct number of rows under a table element' do
       tables = browser.div(id: 'table-rows-test').tables(id: /^tbl/)
       expect(tables.length).to be > 0
 


### PR DESCRIPTION
The goal here is to be able to better leverage regular expressions to make more single `#find_element` calls instead of `#find_elements` calls with follow-on wire calls to match from the returned collection. This addresses #447 and #786 and was discussed in #331. 

To do this, we needed to be able to interact with all of the Regexp values in the Selector Builder implementation itself. Per something @jkotests brought up a while back about the concerns of our location classes not being well separated, I tried to identify what classes should be responsible for what things.

I determined that the Locator class should be responsible for anything with a wire call, including matching values that weren't able to be added to the selenium locator returned by the SelectorBuilder.

SelectorBuilder class should be responsible for normalizing the selector / locators and delegating actual building of the selenium locator to the implementation class, then returning the crafted locator independently of whatever pieces of the Watir selector were not used in building that locator.

I created a `selector_builder_spec.rb` unit test file to show what the conversions should look like. I found a few minor bugs in our current implementation, and there are a ton more I want to add here before actually merging this, but I'd love some eyes on this approach before I keep digging through it.

This refactor made it easier to do [this](https://github.com/watir/watir/commit/4d9699683a7db4c8922fc394201fd4171b9e7240) so as not have to match the regex attribute values that are entirely handled by the XPath `contains` parameter. [You can see the difference here](https://gist.github.com/titusfortner/9e75a497dd87f3e1a303a1975462263e) in how many wire calls are shifted from `find_elements` to `find_element`. 

This code "works" but can definitely be tidied up a lot more. It's amazing how complicated all of the corner cases makes this. :)

This sets us up to be able to use `contains` and `starts-with` for text & attributes. You can see @p0deje's ideas for this in [this comment](https://github.com/watir/watir/pull/331#issuecomment-89555559). We could even use XPath index if everything else in the selector is handled in the XPath building. It would be great if we only needed to do extra matching for things related to displayedness and especially complicated regular expressions.

Note that the `SelectorBuilder` class here is initialized differently, so this will break whatever projects are leveraging Watir's use of it. We may want to wait on this (and the follow-on implementations using this) to release with Watir 7 due to how it will interact with some of the things we're deprecating.