### PR TITLE
Locate visible link text via wd link locators

### DIFF
--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -3,6 +3,8 @@ require 'watir/locators/element/selector_builder'
 require 'watir/locators/element/selector_builder/xpath'
 require 'watir/locators/element/validator'
 
+require 'watir/locators/anchor/selector_builder'
+
 require 'watir/locators/button/locator'
 require 'watir/locators/button/selector_builder'
 require 'watir/locators/button/selector_builder/xpath'

--- a/lib/watir/locators/anchor/selector_builder.rb
+++ b/lib/watir/locators/anchor/selector_builder.rb
@@ -1,0 +1,37 @@
+module Watir
+  module Locators
+    class Anchor
+      class SelectorBuilder < Element::SelectorBuilder
+        private
+
+        def build_wd_selector(selector)
+          build_link_text(selector) || build_partial_link_text(selector) || super
+        end
+
+        def build_link_text(selector)
+          return unless can_convert_to_link_text?(selector)
+
+          selector.delete(:tag_name)
+          {link_text: selector.delete(:visible_text)}
+        end
+
+        def can_convert_to_link_text?(selector)
+          selector.keys.sort == %i[tag_name visible_text] &&
+            selector[:visible_text].is_a?(String)
+        end
+
+        def build_partial_link_text(selector)
+          return unless can_convert_to_partial_link_text?(selector)
+
+          selector.delete(:tag_name)
+          {partial_link_text: selector.delete(:visible_text).source}
+        end
+
+        def can_convert_to_partial_link_text?(selector)
+          selector.keys.sort == %i[tag_name visible_text] &&
+            XpathSupport.simple_regexp?(selector[:visible_text])
+        end
+      end
+    end
+  end
+end

--- a/lib/watir/locators/button/selector_builder/xpath.rb
+++ b/lib/watir/locators/button/selector_builder/xpath.rb
@@ -43,7 +43,7 @@ module Watir
             text = @selector.delete :text
             if !text.is_a?(Regexp)
               "[normalize-space()='#{text}' or @value='#{text}']"
-            elsif simple_regexp?(text)
+            elsif XpathSupport.simple_regexp?(text)
               "[contains(text(), '#{text.source}') or contains(@value, '#{text.source}')]"
             else
               @selector[:text] = text

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -6,7 +6,6 @@ module Watir
           include Exception
 
           CAN_NOT_BUILD = %i[visible visible_text].freeze
-          LITERAL_REGEXP = /\A([^\[\]\\^$.|?*+()]*)\z/
 
           def build(selector)
             @selector = selector
@@ -63,18 +62,12 @@ module Watir
             end
           end
 
-          def simple_regexp?(regex)
-            return false if !regex.is_a?(Regexp) || regex.casefold? || regex.source.empty?
-
-            regex.source =~ LITERAL_REGEXP
-          end
-
           private
 
           def add_tag_name
             tag_name = @selector.delete(:tag_name)
 
-            if simple_regexp?(tag_name)
+            if XpathSupport.simple_regexp?(tag_name)
               "[contains(local-name(), '#{tag_name.source}')]"
             elsif tag_name.nil?
               ''
@@ -231,7 +224,7 @@ module Watir
 
             lhs = lhs_for(key)
 
-            if simple_regexp?(regexp)
+            if XpathSupport.simple_regexp?(regexp)
               ["contains(#{lhs}, '#{regexp.source}')", nil]
             else
               [lhs, {key => regexp}]

--- a/lib/watir/locators/text_field/selector_builder/xpath.rb
+++ b/lib/watir/locators/text_field/selector_builder/xpath.rb
@@ -30,7 +30,7 @@ module Watir
             text = @selector.delete :text
             if !text.is_a?(Regexp)
               "[@value=#{XpathSupport.escape text}]"
-            elsif simple_regexp?(text)
+            elsif XpathSupport.simple_regexp?(text)
               "[contains(@value, '#{text.source}')]"
             else
               @selector[:value] = text

--- a/lib/watir/xpath_support.rb
+++ b/lib/watir/xpath_support.rb
@@ -1,5 +1,7 @@
 module Watir
   module XpathSupport
+    LITERAL_REGEXP = /\A([^\[\]\\^$.|?*+()]*)\z/
+
     def self.escape(value)
       if value.include? "'"
         parts = value.split("'", -1).map { |part| "'#{part}'" }
@@ -13,6 +15,12 @@ module Watir
 
     def self.downcase(value)
       "translate(#{value},'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')"
+    end
+
+    def self.simple_regexp?(regex)
+      return false if !regex.is_a?(Regexp) || regex.casefold? || regex.source.empty?
+
+      regex.source =~ LITERAL_REGEXP
     end
   end # XpathSupport
 end # Watir

--- a/spec/unit/anchor_locator_spec.rb
+++ b/spec/unit/anchor_locator_spec.rb
@@ -1,0 +1,68 @@
+require_relative 'unit_helper'
+
+describe Watir::Locators::Element::Locator do
+  include LocatorSpecHelper
+
+  def locator(selector, attrs)
+    attrs ||= Watir::HTMLElement.attributes
+    element_validator = Watir::Locators::Element::Validator.new
+    selector_builder = Watir::Locators::Anchor::SelectorBuilder.new(attrs)
+    Watir::Locators::Element::Locator.new(browser, selector, selector_builder, element_validator)
+  end
+
+  it 'converts :visible_text with String to :link_text' do
+    link = element(tag_name: 'a')
+    expect_one(:link_text, 'exact text').and_return(link)
+    expect(link).not_to receive(:text) # matching does not validate text
+
+    locate_one(tag_name: 'a', visible_text: 'exact text')
+  end
+
+  it 'converts :visible_text with basic Regexp to :partial_link_text' do
+    link = element(tag_name: 'a')
+    expect_one(:partial_link_text, 'partial text').and_return(link)
+    expect(link).not_to receive(:text) # matching does not validate text
+
+    locate_one(tag_name: 'a', visible_text: /partial text/)
+  end
+
+  it 'does not convert :visible_text with complex Regexp' do
+    elements = [
+      element(tag_name: 'a', text: 'other text'),
+      element(tag_name: 'a', text: 'matching complex!text')
+    ]
+    expect_all(:xpath, ".//*[local-name()='a']").and_return(elements)
+
+    expect(locate_one(tag_name: 'a', visible_text: /complex.text/)).to eq(elements[1])
+  end
+
+  it 'does not convert :visible_text with casefold Regexp' do
+    elements = [
+      element(tag_name: 'a', text: 'other text'),
+      element(tag_name: 'a', text: 'partial text')
+    ]
+    expect_all(:xpath, ".//*[local-name()='a']").and_return(elements)
+
+    expect(locate_one(tag_name: 'a', visible_text: /partial text/i)).to eq(elements[1])
+  end
+
+  it 'does not convert :visible_text with String and other locators' do
+    els = [
+      element(tag_name: 'a', attributes: {class: 'klass', name: 'abc'}, text: 'other text'),
+      element(tag_name: 'a', attributes: {class: 'klass', name: 'abc'}, text: 'exact text')
+    ]
+    expect_all(:xpath, ".//*[local-name()='a'][contains(concat(' ', @class, ' '), ' klass ')][@name]").and_return(els)
+
+    expect(locate_one(tag_name: 'a', class: 'klass', name: /a|.c/,  visible_text: 'exact text')).to eq(els[1])
+  end
+
+  it 'does not convert :visible_text with Regexp and other locators' do
+    els = [
+      element(tag_name: 'a', attributes: {class: 'klass', name: 'abc'}, text: 'other text'),
+      element(tag_name: 'a', attributes: {class: 'klass', name: 'abc'}, text: 'partial text')
+    ]
+    expect_all(:xpath, ".//*[local-name()='a'][contains(concat(' ', @class, ' '), ' klass ')][@name]").and_return(els)
+
+    expect(locate_one(tag_name: 'a', class: 'klass', name: /a|.c/, visible_text: /partial text/)).to eq(els[1])
+  end
+end

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -87,32 +87,27 @@ describe 'Element' do
     it 'finds elements by visible text' do
       browser.goto WatirSpec.url_for('non_control_elements.html')
 
-      expect(browser.link(visible_text: 'all visible')).to exist
-      expect(browser.link(visible_text: /all visible/)).to exist
-      expect(browser.link(visible_text: 'some visible')).to exist
-      expect(browser.link(visible_text: /some visible/)).to exist
-      expect(browser.link(visible_text: 'none visible')).not_to exist
-      expect(browser.link(visible_text: /none visible/)).not_to exist
-
-      expect(browser.link(visible_text: 'Link 2', class: 'external')).to exist
-      expect(browser.link(visible_text: /Link 2/, class: 'external')).to exist
-
       expect(browser.element(visible_text: 'all visible')).to exist
       expect(browser.element(visible_text: /all visible/)).to exist
       expect(browser.element(visible_text: 'some visible')).to exist
       expect(browser.element(visible_text: /some visible/)).to exist
+      expect(browser.element(visible_text: 'none visible')).not_to exist
+      expect(browser.element(visible_text: /none visible/)).not_to exist
+
+      expect(browser.element(visible_text: 'Link 2', class: 'external')).to exist
+      expect(browser.element(visible_text: /Link 2/, class: 'external')).to exist
     end
 
     it 'raises exception unless value is a String or a RegExp' do
       browser.goto WatirSpec.url_for('non_control_elements.html')
       msg = /expected string_or_regexp, got 7\:(Fixnum|Integer)/
-      expect { browser.link(visible_text: 7).exists? }.to raise_exception(TypeError, msg)
+      expect { browser.element(visible_text: 7).exists? }.to raise_exception(TypeError, msg)
     end
 
     it 'raises exception unless key is valid' do
       browser.goto WatirSpec.url_for('non_control_elements.html')
       msg = /Unable to build XPath using 7:(Fixnum|Integer)/
-      expect { browser.link(7 => /foo/).exists? }.to raise_exception(Watir::Exception::Error, msg)
+      expect { browser.element(7 => /foo/).exists? }.to raise_exception(Watir::Exception::Error, msg)
     end
   end
 

--- a/spec/watirspec/elements/elements_spec.rb
+++ b/spec/watirspec/elements/elements_spec.rb
@@ -36,12 +36,13 @@ describe 'Elements' do
   describe 'visible text' do
     it 'finds elements by visible text' do
       browser.goto WatirSpec.url_for('non_control_elements.html')
-      expect(browser.links(visible_text: 'all visible').count).to eq(1)
-      expect(browser.links(visible_text: /all visible/).count).to eq(1)
-      expect(browser.links(visible_text: 'some visible').count).to eq(1)
-      expect(browser.links(visible_text: /some visible/).count).to eq(1)
-      expect(browser.links(visible_text: 'none visible').count).to eq(0)
-      expect(browser.links(visible_text: /none visible/).count).to eq(0)
+      container = browser.div(id: 'visible_text')
+      expect(container.elements(visible_text: 'all visible').count).to eq(1)
+      expect(container.elements(visible_text: /all visible/).count).to eq(1)
+      expect(container.elements(visible_text: 'some visible').count).to eq(1)
+      expect(container.elements(visible_text: /some visible/).count).to eq(1)
+      expect(container.elements(visible_text: 'none visible').count).to eq(0)
+      expect(container.elements(visible_text: /none visible/).count).to eq(0)
     end
   end
 end

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -150,4 +150,26 @@ describe 'Link' do
       expect(browser.title).to eq 'definition_lists'
     end
   end
+
+  describe 'visible text' do
+    it 'finds links by visible text' do
+      browser.goto WatirSpec.url_for('non_control_elements.html')
+
+      expect(browser.link(visible_text: 'all visible')).to exist
+      expect(browser.link(visible_text: /all visible/)).to exist
+      expect(browser.link(visible_text: 'some visible')).to exist
+      expect(browser.link(visible_text: /some visible/)).to exist
+      expect(browser.link(visible_text: 'none visible')).not_to exist
+      expect(browser.link(visible_text: /none visible/)).not_to exist
+
+      expect(browser.link(visible_text: 'Link 2', class: 'external')).to exist
+      expect(browser.link(visible_text: /Link 2/, class: 'external')).to exist
+    end
+
+    it 'raises exception unless value is a String or a RegExp' do
+      browser.goto WatirSpec.url_for('non_control_elements.html')
+      msg = /expected string_or_regexp, got 7\:(Fixnum|Integer)/
+      expect { browser.link(visible_text: 7).exists? }.to raise_exception(TypeError, msg)
+    end
+  end
 end

--- a/spec/watirspec/elements/links_spec.rb
+++ b/spec/watirspec/elements/links_spec.rb
@@ -39,4 +39,17 @@ describe 'Links' do
       expect(count).to be > 0
     end
   end
+
+  describe 'visible text' do
+    it 'finds links by visible text' do
+      browser.goto WatirSpec.url_for('non_control_elements.html')
+      container = browser.div(id: 'visible_text')
+      expect(container.links(visible_text: 'all visible').count).to eq(1)
+      expect(container.links(visible_text: /all visible/).count).to eq(1)
+      expect(container.links(visible_text: 'some visible').count).to eq(1)
+      expect(container.links(visible_text: /some visible/).count).to eq(1)
+      expect(container.links(visible_text: 'none visible').count).to eq(0)
+      expect(container.links(visible_text: /none visible/).count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
When locating links via :visible_text, if possible, we will convert it to Webdrivers's link_text or partial_link_text. This should improve performance for those with a lot of links on the page.

Note:
* I only implemented this for #link and #links. This will not get applied when using #element and #elements.