### PR TITLE
Redo selector builder2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,12 +53,16 @@ Metrics/ModuleLength:
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 18
+  Exclude:
+  - 'lib/watir/locators/element/selector_builder.rb'
+  - 'lib/watir/locators/element/selector_builder/xpath.rb'
 
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
   Max: 105
   Exclude:
     - 'lib/watir/locators/element/locator.rb'
+    - 'lib/watir/locators/element/selector_builder.rb'
     - 'lib/watir/locators/element/selector_builder/xpath.rb'
     - 'lib/watir/browser.rb'
     - 'lib/watir/window.rb'
@@ -67,17 +71,21 @@ Metrics/ClassLength:
     - 'lib/watir/generator/base/spec_extractor.rb'
 
 Metrics/PerceivedComplexity:
-  Max: 9
+  Max: 10
 
 Metrics/CyclomaticComplexity:
-  Max: 9
+  Max: 8
+  Exclude:
+  - 'lib/watir/locators/element/selector_builder.rb'
 
 Metrics/AbcSize:
-  Max: 21
+  Max: 20
   Exclude:
     - 'lib/watir/locators/element/selector_builder.rb'
+    - 'lib/watir/locators/element/selector_builder/xpath.rb'
     - 'lib/watir/locators/element/locator.rb'
     - 'lib/watir/generator/base/generator.rb'
+    - 'lib/watir/generator/base/visitor.rb'
 
 # TODO: fix with Watir 7
 # Configuration parameters: CountKeywordArgs.

--- a/lib/watir/cell_container.rb
+++ b/lib/watir/cell_container.rb
@@ -7,7 +7,7 @@ module Watir
     #
 
     def cell(*args)
-      Cell.new(self, extract_selector(args).merge(tag_name: /^(th|td)$/))
+      Cell.new(self, extract_selector(args))
     end
 
     #
@@ -17,7 +17,7 @@ module Watir
     #
 
     def cells(*args)
-      CellCollection.new(self, extract_selector(args).merge(tag_name: /^(th|td)$/))
+      CellCollection.new(self, extract_selector(args))
     end
   end # CellContainer
 end # Watir

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -91,7 +91,7 @@ module Watir
           selector[:index] = idx
           element = element_class.new(@query_scope, selector)
           if [HTMLElement, Input].include? element.class
-            tag_name = @selector[:tag_name] || element.tag_name.to_sym
+            tag_name = @selector[:tag_name] || element.tag_name
             hash[tag_name] ||= 0
             hash[tag_name] += 1
             selector[:index] = hash[tag_name] - 1

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -59,8 +59,13 @@ module Watir
       end
 
       def build_locator
+        selector_builder = if element_class == Watir::Row
+                             scope_tag_name = @query_scope.selector[:tag_name]
+                             selector_builder_class.new(element_class.attribute_list, scope_tag_name)
+                           else
+                             selector_builder_class.new(element_class.attribute_list)
+                           end
         element_validator = element_validator_class.new
-        selector_builder = selector_builder_class.new(@query_scope, @selector.dup, element_class.attribute_list)
         locator_class.new(@query_scope, @selector.dup, selector_builder, element_validator)
       end
     end

--- a/lib/watir/locators/button/locator.rb
+++ b/lib/watir/locators/button/locator.rb
@@ -9,15 +9,22 @@ module Watir
         end
 
         def matches_values?(element, values_to_match)
-          if values_to_match.key?(:value)
-            copy  = values_to_match.dup
-            value = copy.delete(:value)
+          return super unless values_to_match.key?(:value)
 
-            super(element, copy) &&
-              (fetch_value(element, :value) =~ /#{value}/ || fetch_value(element, :text) =~ /#{value}/)
-          else
-            super
+          copy = values_to_match.dup
+          value = copy.delete(:value)
+
+          everything_except_value = super(element, copy)
+
+          matches_value = fetch_value(element, :value) =~ /#{value}/
+          matches_text = fetch_value(element, :text) =~ /#{value}/
+          if matches_text
+            Watir.logger.deprecate(':value locator key for finding button text',
+                                   'use :text locator',
+                                   ids: ['value_button'])
           end
+
+          everything_except_value && (matches_value || matches_text)
         end
       end
     end

--- a/lib/watir/locators/button/validator.rb
+++ b/lib/watir/locators/button/validator.rb
@@ -2,9 +2,10 @@ module Watir
   module Locators
     class Button
       class Validator < Element::Validator
-        def validate(element, _selector)
+        def validate(element, _tag_name)
           tag_name = element.tag_name.downcase
           return unless %w[input button].include?(tag_name)
+
           # TODO: - Verify this is desired behavior based on https://bugzilla.mozilla.org/show_bug.cgi?id=1290963
           return if tag_name == 'input' && !Watir::Button::VALID_TYPES.include?(element.attribute(:type).downcase)
 

--- a/lib/watir/locators/cell/selector_builder/xpath.rb
+++ b/lib/watir/locators/cell/selector_builder/xpath.rb
@@ -3,22 +3,22 @@ module Watir
     class Cell
       class SelectorBuilder
         class XPath < Element::SelectorBuilder::XPath
-          def add_attributes(selector)
-            attr_expr = attribute_expression(nil, selector)
+          def build(selector)
+            return super if selector.key?(:adjacent)
 
-            expressions = %w[./th ./td]
-            expressions.map! { |e| "#{e}[#{attr_expr}]" } unless attr_expr.empty?
+            wd_locator = super(selector)
 
-            expressions.join(' | ')
+            start_string = default_start
+            tag_string = "[local-name()='th' or local-name()='td']"
+            common_string = wd_locator[:xpath].gsub(start_string, '')
+
+            xpath = "#{start_string}#{tag_string}#{common_string}"
+
+            {xpath: xpath}
           end
 
           def default_start
-            ''
-          end
-
-          def add_tag_name(selector)
-            selector.delete(:tag_name)
-            ''
+            @selector.key?(:adjacent) ? './' : './*'
           end
         end
       end

--- a/lib/watir/locators/element/validator.rb
+++ b/lib/watir/locators/element/validator.rb
@@ -2,15 +2,8 @@ module Watir
   module Locators
     class Element
       class Validator
-        def validate(element, selector)
-          selector_tag_name = selector[:tag_name]
-          element_tag_name = element.tag_name.downcase
-
-          if selector_tag_name
-            return unless element_tag_name =~ /#{selector_tag_name}/
-          end
-
-          element
+        def validate(element, tag_name)
+          element.tag_name.downcase =~ /#{tag_name}/
         end
       end
     end

--- a/lib/watir/locators/row/selector_builder.rb
+++ b/lib/watir/locators/row/selector_builder.rb
@@ -2,9 +2,13 @@ module Watir
   module Locators
     class Row
       class SelectorBuilder < Element::SelectorBuilder
-        def build_wd_selector(selector, values_to_match)
-          xpath_builder.scope_tag_name = @query_scope.selector[:tag_name]
-          super
+        def initialize(valid_attributes, scope_tag_name)
+          @scope_tag_name = scope_tag_name
+          super(valid_attributes)
+        end
+
+        def build_wd_selector(selector)
+          Kernel.const_get("#{self.class.name}::XPath").new.build(selector, @scope_tag_name)
         end
       end
     end

--- a/lib/watir/locators/text_area/selector_builder.rb
+++ b/lib/watir/locators/text_area/selector_builder.rb
@@ -4,7 +4,7 @@ module Watir
       class SelectorBuilder < Element::SelectorBuilder
         private
 
-        def normalize_selector(how, what)
+        def normalize_locator(how, what)
           # We need to iterate through located elements and fetch
           # attribute value using Selenium because XPath doesn't understand
           # difference between IDL vs content attribute.

--- a/lib/watir/locators/text_area/selector_builder/xpath.rb
+++ b/lib/watir/locators/text_area/selector_builder/xpath.rb
@@ -3,11 +3,10 @@ module Watir
     class TextArea
       class SelectorBuilder
         class XPath < Element::SelectorBuilder::XPath
-          private
+          def convert_predicate(key, regexp)
+            return [nil, {key => regexp}] if key == :value
 
-          def convert_regexp_to_contains?
-            # regexp conversion won't work with the complex xpath selector
-            false
+            super
           end
         end
       end

--- a/lib/watir/locators/text_field/locator.rb
+++ b/lib/watir/locators/text_field/locator.rb
@@ -14,10 +14,10 @@ module Watir
           tag_name = element.tag_name.downcase
 
           %i[text value label].each do |key|
-            if rx_selector.key?(key)
-              correct_key = tag_name == 'input' ? :value : :text
-              rx_selector[correct_key] = rx_selector.delete(key)
-            end
+            next unless rx_selector.key?(key)
+
+            correct_key = tag_name == 'input' ? :value : :text
+            rx_selector[correct_key] = rx_selector.delete(key)
           end
 
           super

--- a/lib/watir/locators/text_field/validator.rb
+++ b/lib/watir/locators/text_field/validator.rb
@@ -2,10 +2,10 @@ module Watir
   module Locators
     class TextField
       class Validator < Element::Validator
-        def validate(element, _selector)
-          return unless element.tag_name.casecmp('input').zero?
-
-          element
+        def validate(element, _tag_name)
+          # Zero for Ruby 2.3, Ruby 2.4+ this evaluates true/false
+          result = element.tag_name.casecmp('input')
+          result.zero? || result.eq(true)
         end
       end
     end

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -12,7 +12,7 @@ module Watir
       raise ArgumentError, "invalid argument: #{selector.inspect}" unless selector.is_a? Hash
 
       @source = Radio.new(query_scope, selector)
-      @frame = @source.parent(tag_name: :form)
+      @frame = @source.parent(tag_name: 'form')
     end
 
     #

--- a/lib/watir/row_container.rb
+++ b/lib/watir/row_container.rb
@@ -5,7 +5,7 @@ module Watir
     #
 
     def row(*args)
-      Row.new(self, extract_selector(args).merge(tag_name: 'tr'))
+      Row.new(self, extract_selector(args))
     end
 
     #
@@ -13,7 +13,7 @@ module Watir
     #
 
     def rows(*args)
-      RowCollection.new(self, extract_selector(args).merge(tag_name: 'tr'))
+      RowCollection.new(self, extract_selector(args))
     end
 
     #

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -10,7 +10,7 @@ module LocatorSpecHelper
   def locator(selector, attrs)
     attrs ||= Watir::HTMLElement.attributes
     element_validator = Watir::Locators::Element::Validator.new
-    selector_builder = Watir::Locators::Element::SelectorBuilder.new(driver, selector, attrs)
+    selector_builder = Watir::Locators::Element::SelectorBuilder.new(attrs)
     Watir::Locators::Element::Locator.new(browser, selector, selector_builder, element_validator)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,10 +4,10 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'coveralls'
 require 'simplecov'
 require 'simplecov-console'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    Coveralls::SimpleCov::Formatter,
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::Console,
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
+  Coveralls::SimpleCov::Formatter,
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::Console
 ]
 SimpleCov.start do
   add_filter %r{/spec/}

--- a/spec/watirspec/adjacent_spec.rb
+++ b/spec/watirspec/adjacent_spec.rb
@@ -17,13 +17,13 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts tag_name argument' do
-      expect(browser.div(id: 'first_sibling').parent(tag_name: :div).id).to eq 'parent'
-      expect(browser.div(id: 'first_sibling').parent(tag_name: :div)).to be_a Watir::Div
+      expect(browser.div(id: 'first_sibling').parent(tag_name: 'div').id).to eq 'parent'
+      expect(browser.div(id: 'first_sibling').parent(tag_name: 'div')).to be_a Watir::Div
     end
 
     it 'accepts custom tag_name argument' do
-      expect(browser.div(id: 'regular_child').parent(tag_name: :grandelement).id).to eq 'custom_grandparent'
-      expect(browser.div(id: 'regular_child').parent(tag_name: :grandelement)).to be_a Watir::HTMLElement
+      expect(browser.div(id: 'regular_child').parent(tag_name: 'grandelement').id).to eq 'custom_grandparent'
+      expect(browser.div(id: 'regular_child').parent(tag_name: 'grandelement')).to be_a Watir::HTMLElement
     end
 
     it 'accepts class_name argument' do
@@ -31,8 +31,8 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts index and tag_name arguments' do
-      expect(browser.div(id: 'first_sibling').parent(tag_name: :div, index: 1).id).to eq 'grandparent'
-      expect(browser.div(id: 'first_sibling').parent(tag_name: :div, index: 1)).to be_a Watir::Div
+      expect(browser.div(id: 'first_sibling').parent(tag_name: 'div', index: 1).id).to eq 'grandparent'
+      expect(browser.div(id: 'first_sibling').parent(tag_name: 'div', index: 1)).to be_a Watir::Div
     end
 
     it 'does not error when no parent element of an index exists' do
@@ -40,7 +40,7 @@ describe 'Adjacent Elements' do
     end
 
     it 'does not error when no parent element of a tag_name exists' do
-      expect(browser.div(id: 'first_sibling').parent(tag_name: :table)).to_not exist
+      expect(browser.div(id: 'first_sibling').parent(tag_name: 'table')).to_not exist
     end
   end
 
@@ -51,13 +51,13 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts a tag name argument' do
-      siblings = browser.div(id: 'second_sibling').siblings(tag_name: :div)
+      siblings = browser.div(id: 'second_sibling').siblings(tag_name: 'div')
       expect(siblings.size).to eq 3
       expect(siblings.all? { |sib| sib.is_a? Watir::Div }).to eq true
     end
 
     it 'accepts custom tag name argument' do
-      siblings = browser.div(id: 'regular_child').siblings(tag_name: :childelement)
+      siblings = browser.div(id: 'regular_child').siblings(tag_name: 'childelement')
       expect(siblings.size).to eq 3
       expect(siblings.all? { |sib| sib.is_a? Watir::HTMLElement }).to eq true
     end
@@ -83,8 +83,8 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts tag_name argument' do
-      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: :div).id).to eq 'second_sibling'
-      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: :div)).to be_a Watir::Div
+      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: 'div').id).to eq 'second_sibling'
+      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: 'div')).to be_a Watir::Div
     end
 
     it 'accepts class_name argument' do
@@ -92,16 +92,16 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts index and tag_name arguments' do
-      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: :div, index: 1).id).to eq 'third_sibling'
-      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: :div, index: 1)).to be_a Watir::Div
+      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: 'div', index: 1).id).to eq 'third_sibling'
+      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: 'div', index: 1)).to be_a Watir::Div
     end
 
     it 'accepts text as Regexp' do
-      expect(browser.div(id: 'first_sibling').following_sibling(text: /t/).id).to eq 'third_sibling'
+      expect(browser.div(id: 'first_sibling').following_sibling(text: /T/).id).to eq 'third_sibling'
     end
 
     it 'accepts text as String' do
-      expect(browser.div(id: 'first_sibling').following_sibling(text: 'text').id).to eq 'third_sibling'
+      expect(browser.div(id: 'first_sibling').following_sibling(text: 'Third').id).to eq 'third_sibling'
     end
 
     it 'does not error when no next sibling of an index exists' do
@@ -109,7 +109,7 @@ describe 'Adjacent Elements' do
     end
 
     it 'does not error when no next sibling of a tag_name exists' do
-      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: :table)).to_not exist
+      expect(browser.div(id: 'first_sibling').following_sibling(tag_name: 'table')).to_not exist
     end
   end
 
@@ -120,8 +120,8 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts tag_name argument' do
-      expect(browser.div(id: 'second_sibling').following_siblings(tag_name: :div).size).to eq 1
-      expect(browser.div(id: 'second_sibling').following_siblings(tag_name: :div).first).to be_a Watir::Div
+      expect(browser.div(id: 'second_sibling').following_siblings(tag_name: 'div').size).to eq 1
+      expect(browser.div(id: 'second_sibling').following_siblings(tag_name: 'div').first).to be_a Watir::Div
     end
 
     it 'accepts class_name argument for single class' do
@@ -147,8 +147,8 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts tag_name argument' do
-      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: :div).id).to eq 'second_sibling'
-      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: :div)).to be_a Watir::Div
+      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: 'div').id).to eq 'second_sibling'
+      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: 'div')).to be_a Watir::Div
     end
 
     it 'accepts class_name argument' do
@@ -156,8 +156,8 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts index and tag_name arguments' do
-      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: :div, index: 1).id).to eq 'first_sibling'
-      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: :div, index: 1)).to be_a Watir::Div
+      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: 'div', index: 1).id).to eq 'first_sibling'
+      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: 'div', index: 1)).to be_a Watir::Div
     end
 
     it 'does not error when no next sibling of an index exists' do
@@ -165,7 +165,7 @@ describe 'Adjacent Elements' do
     end
 
     it 'does not error when no next sibling of a tag_name exists' do
-      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: :table)).to_not exist
+      expect(browser.div(id: 'third_sibling').previous_sibling(tag_name: 'table')).to_not exist
     end
   end
 
@@ -176,8 +176,8 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts tag_name argument' do
-      expect(browser.div(id: 'second_sibling').previous_siblings(tag_name: :div).size).to eq 1
-      expect(browser.div(id: 'second_sibling').previous_siblings(tag_name: :div).first).to be_a Watir::Div
+      expect(browser.div(id: 'second_sibling').previous_siblings(tag_name: 'div').size).to eq 1
+      expect(browser.div(id: 'second_sibling').previous_siblings(tag_name: 'div').first).to be_a Watir::Div
     end
 
     it 'accepts class_name argument' do
@@ -198,13 +198,13 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts tag_name argument' do
-      expect(browser.div(id: 'parent').child(tag_name: :span).id).to eq 'between_siblings1'
-      expect(browser.div(id: 'parent').child(tag_name: :span)).to be_a Watir::Span
+      expect(browser.div(id: 'parent').child(tag_name: 'span').id).to eq 'between_siblings1'
+      expect(browser.div(id: 'parent').child(tag_name: 'span')).to be_a Watir::Span
     end
 
     it 'accepts custom tag_name argument' do
-      expect(browser.element(id: 'custom_parent').child(tag_name: :childelement).id).to eq 'custom_child'
-      expect(browser.element(id: 'custom_parent').child(tag_name: :childelement)).to be_a Watir::HTMLElement
+      expect(browser.element(id: 'custom_parent').child(tag_name: 'childelement').id).to eq 'custom_child'
+      expect(browser.element(id: 'custom_parent').child(tag_name: 'childelement')).to be_a Watir::HTMLElement
     end
 
     it 'accepts class_name argument' do
@@ -212,8 +212,8 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts index and tag_name arguments' do
-      expect(browser.div(id: 'parent').child(tag_name: :div, index: 1).id).to eq 'second_sibling'
-      expect(browser.div(id: 'parent').child(tag_name: :div, index: 1)).to be_a Watir::Div
+      expect(browser.div(id: 'parent').child(tag_name: 'div', index: 1).id).to eq 'second_sibling'
+      expect(browser.div(id: 'parent').child(tag_name: 'div', index: 1)).to be_a Watir::Div
     end
 
     it 'does not error when no next sibling of an index exists' do
@@ -221,7 +221,7 @@ describe 'Adjacent Elements' do
     end
 
     it 'does not error when no next sibling of a tag_name exists' do
-      expect(browser.div(id: 'parent').child(tag_name: :table)).to_not exist
+      expect(browser.div(id: 'parent').child(tag_name: 'table')).to_not exist
     end
   end
 
@@ -232,13 +232,13 @@ describe 'Adjacent Elements' do
     end
 
     it 'accepts tag_name argument' do
-      children = browser.div(id: 'parent').children(tag_name: :div)
+      children = browser.div(id: 'parent').children(tag_name: 'div')
       expect(children.size).to eq 3
       expect(children.all? { |child| child.is_a? Watir::Div }).to eq true
     end
 
     it 'accepts custom tag_name argument' do
-      children = browser.element(id: 'custom_parent').children(tag_name: :childelement)
+      children = browser.element(id: 'custom_parent').children(tag_name: 'childelement')
       expect(children.size).to eq 3
       expect(children.all? { |child| child.is_a? Watir::HTMLElement }).to eq true
     end

--- a/spec/watirspec/element_hidden_spec.rb
+++ b/spec/watirspec/element_hidden_spec.rb
@@ -72,7 +72,7 @@ describe Watir::Locators::Element::Locator do
 
     it 'raises exception when value is not Boolean' do
       element = browser.body.element(visible: 'true')
-      msg = 'expected TrueClass or FalseClass, got "true":String'
+      msg = 'expected boolean, got "true":String'
       expect { element.exists? }.to raise_exception(TypeError, msg)
     end
   end

--- a/spec/watirspec/elements/checkbox_spec.rb
+++ b/spec/watirspec/elements/checkbox_spec.rb
@@ -11,6 +11,8 @@ describe 'CheckBox' do
     it 'returns true if the checkbox button exists' do
       expect(browser.checkbox(id: 'new_user_interests_books')).to exist
       expect(browser.checkbox(id: /new_user_interests_books/)).to exist
+      expect(browser.checkbox(label: 'Cars')).to exist
+      expect(browser.checkbox(label: /Cars/)).to exist
       expect(browser.checkbox(name: 'new_user_interests')).to exist
       expect(browser.checkbox(name: /new_user_interests/)).to exist
       expect(browser.checkbox(value: 'books')).to exist

--- a/spec/watirspec/elements/date_time_field_spec.rb
+++ b/spec/watirspec/elements/date_time_field_spec.rb
@@ -15,7 +15,12 @@ describe 'DateTimeField' do
       expect(browser.date_time_field(text: '')).to exist
       expect(browser.date_time_field(text: //)).to exist
       expect(browser.date_time_field(index: 0)).to exist
-      expect(browser.date_time_field(xpath: "//input[@id='html5_datetime-local']")).to exist
+
+      # Firefox validates attribute "type" as "text" not "datetime-local"
+      not_compliant_on :firefox do
+        expect(browser.date_time_field(xpath: "//input[@id='html5_datetime-local']")).to exist
+      end
+
       expect(browser.date_time_field(label: 'HTML5 Datetime Local')).to exist
       expect(browser.date_time_field(label: /Local$/)).to exist
     end

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -5,7 +5,6 @@ describe 'Div' do
     browser.goto(WatirSpec.url_for('non_control_elements.html'))
   end
 
-  # Exists method
   describe '#exists?' do
     it 'returns true if the element exists' do
       expect(browser.div(id: 'header')).to exist

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -105,13 +105,13 @@ describe 'Element' do
 
     it 'raises exception unless value is a String or a RegExp' do
       browser.goto WatirSpec.url_for('non_control_elements.html')
-      msg = /expected String or Regexp, got 7\:(Fixnum|Integer)/
+      msg = /expected string_or_regexp, got 7\:(Fixnum|Integer)/
       expect { browser.link(visible_text: 7).exists? }.to raise_exception(TypeError, msg)
     end
 
     it 'raises exception unless key is valid' do
       browser.goto WatirSpec.url_for('non_control_elements.html')
-      msg = 'Unable to build XPath using 7'
+      msg = /Unable to build XPath using 7:(Fixnum|Integer)/
       expect { browser.link(7 => /foo/).exists? }.to raise_exception(Watir::Exception::Error, msg)
     end
   end
@@ -459,23 +459,29 @@ describe 'Element' do
     end
 
     it 'raises if both :xpath and :css are given' do
-      expect { browser.div(xpath: '//div', css: 'div').exists? }.to raise_error(ArgumentError)
+      msg = ':xpath and :css cannot be combined ({:xpath=>"//div", :css=>"div"})'
+      expect { browser.div(xpath: '//div', css: 'div').exists? }
+        .to raise_exception Watir::Exception::LocatorException, msg
     end
 
     it "doesn't raise when selector has with :xpath has :index" do
       expect(browser.div(xpath: '//div', index: 1)).to exist
     end
 
-    it 'raises ArgumentError error if selector hash with :xpath has multiple entries' do
-      expect { browser.div(xpath: '//div', class: 'foo').exists? }.to raise_error(ArgumentError)
+    it 'raises LocatorException error if selector hash with :xpath has multiple entries' do
+      msg = 'xpath cannot be combined with all of these locators ({:class=>"foo", :tag_name=>"div"})'
+      expect { browser.div(xpath: '//div', class: 'foo').exists? }
+        .to raise_exception Watir::Exception::LocatorException, msg
     end
 
     it "doesn't raise when selector has with :css has :index" do
       expect(browser.div(css: 'div', index: 1)).to exist
     end
 
-    it 'raises ArgumentError error if selector hash with :css has multiple entries' do
-      expect { browser.div(css: 'div', class: 'foo').exists? }.to raise_error(ArgumentError)
+    it 'raises LocatorException error if selector hash with :css has multiple entries' do
+      msg = 'css cannot be combined with all of these locators ({:class=>"foo", :tag_name=>"div"})'
+      expect { browser.div(css: 'div', class: 'foo').exists? }
+        .to raise_exception Watir::Exception::LocatorException, msg
     end
 
     it 'finds element by Selenium name locator' do

--- a/spec/watirspec/elements/span_spec.rb
+++ b/spec/watirspec/elements/span_spec.rb
@@ -11,11 +11,14 @@ describe 'Span' do
       expect(browser.span(id: 'lead')).to exist
       expect(browser.span(id: /lead/)).to exist
       expect(browser.span(text: 'Dubito, ergo cogito, ergo sum.')).to exist
-      expect(browser.span(text: /Dubito, ergo cogito, ergo sum/)).to exist
       expect(browser.span(class: 'lead')).to exist
       expect(browser.span(class: /lead/)).to exist
       expect(browser.span(index: 0)).to exist
       expect(browser.span(xpath: "//span[@id='lead']")).to exist
+    end
+
+    it 'visible text is found by regular expression with text locator' do
+      expect(browser.span(text: /Dubito, ergo cogito, ergo sum/)).to exist
     end
 
     it 'returns the first span if given no args' do

--- a/spec/watirspec/elements/strong_spec.rb
+++ b/spec/watirspec/elements/strong_spec.rb
@@ -11,11 +11,14 @@ describe 'Strong' do
       expect(browser.strong(id: 'descartes')).to exist
       expect(browser.strong(id: /descartes/)).to exist
       expect(browser.strong(text: 'Dubito, ergo cogito, ergo sum.')).to exist
-      expect(browser.strong(text: /Dubito, ergo cogito, ergo sum/)).to exist
       expect(browser.strong(class: 'descartes')).to exist
       expect(browser.strong(class: /descartes/)).to exist
       expect(browser.strong(index: 0)).to exist
       expect(browser.strong(xpath: "//strong[@id='descartes']")).to exist
+    end
+
+    it 'visible text is found by regular expression with text locator' do
+      expect(browser.strong(text: /Dubito, ergo cogito, ergo sum/)).to exist
     end
 
     it 'returns the first strong if given no args' do

--- a/spec/watirspec/elements/table_nesting_spec.rb
+++ b/spec/watirspec/elements/table_nesting_spec.rb
@@ -7,7 +7,7 @@ describe 'Table' do
 
   # not a selenium bug - IE seems unable to deal with the invalid nesting
   not_compliant_on :internet_explorer do
-    it 'returns the correct number of rows under a table' do
+    it 'returns the correct number of rows under a table element' do
       tables = browser.div(id: 'table-rows-test').tables(id: /^tbl/)
       expect(tables.length).to be > 0
 

--- a/spec/watirspec/elements/table_spec.rb
+++ b/spec/watirspec/elements/table_spec.rb
@@ -103,6 +103,7 @@ describe 'Table' do
 
     it 'finds rows belonging to this table' do
       expect(table.row(id: 'outer_last')).to exist
+      table.row(text: 'Table 1, Row 1, Cell 1').locate
       expect(table.row(text: /Table 1, Row 1, Cell 1/)).to exist
     end
 

--- a/spec/watirspec/elements/text_field_spec.rb
+++ b/spec/watirspec/elements/text_field_spec.rb
@@ -14,8 +14,6 @@ describe 'TextField' do
       expect(browser.text_field(name: /new_user_email/)).to exist
       expect(browser.text_field(value: 'Developer')).to exist
       expect(browser.text_field(value: /Developer/)).to exist
-      expect(browser.text_field(text: 'Developer')).to exist
-      expect(browser.text_field(text: /Developer/)).to exist
       expect(browser.text_field(class: 'name')).to exist
       expect(browser.text_field(class: /name/)).to exist
       expect(browser.text_field(index: 0)).to exist
@@ -35,6 +33,11 @@ describe 'TextField' do
 
       expect(browser.text_field(visible_label: /With text/)).to exist
       expect(browser.text_field(visible_label: /With hidden text/)).not_to exist
+    end
+
+    it 'locates value of text_field using text locator' do
+      expect(browser.text_field(text: 'Developer')).to exist
+      expect(browser.text_field(text: /Developer/)).to exist
     end
 
     it 'returns the first text field if given no args' do

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -4,23 +4,25 @@
     <title>Forms with input elements</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="description" content="this is a test page for forms with input elements" />
-    <link rel="stylesheet" href="watirspec.css" type="text/css" media="screen" title="no title" charset="utf-8">
+    <link rel="stylesheet" href="watirspec.css" type="text/css" media="screen" title="no title" charset="utf-8" data-locator="link">
     <script src="javascript/helpers.js" type="text/javascript" charset="utf-8"></script>
   </head>
-  <body onload="document.user_new.new_user_first_name.focus()">
-    <div id="messages" class="multiple classes here"></div>
+  <body data-locator="body" onload="document.user_new.new_user_first_name.focus()">
+  <div id="messages" class="multiple classes here" random="foo" data-locator="first div"></div>
+  <div id="there" class="multiple classes there" data-locator="second div"></div>
     <h1><a href="">User administration</a></h1>
-    <h2 style="background-color: gray;">Add user</h2>
-    <form enctype="multipart/form-data" action="post_to_me" method="post" name="user_new" id="new_user" class="user" onsubmit="WatirSpec.addMessage('submit'); return false;">
+    <h2 data-locator="add user" style="background-color: gray;">Add user</h2>
+    <form enctype="multipart/form-data" action="post_to_me" method="post" name="user_new" id="new_user" class="user"
+          data-locator="form" onsubmit="WatirSpec.addMessage('submit'); return false;">
         <fieldset>
-            <input type="hidden" /> <!-- Ensure it's not included in #text_field -->
+            <input type="hidden" data-locator="input nameless"/> <!-- Ensure it's not included in #text_field -->
             <legend>Personal information</legend>
             <label for="new_user_first_name" id="first_label" onclick="WatirSpec.addMessage('label')">First name</label>
-            <input name="new_user_first_name" id="new_user_first_name" class="name" /> <br />
+            <input name="new_user_first_name" id="new_user_first_name" class="name" data-locator="input name"/> <br />
             <label for="new_user_last_name">Last name</label>
             <input type="no_such_type" name="new_user_last_name" id="new_user_last_name" class="name" /> <br />
             <label for="new_user_email">Email address</label>
-            <input type="text" name="new_user_email" id="new_user_email" /> <br />
+            <input type="text" name="new_user_email" id="new_user_email" data-locator="first text"/> <br />
             <label for="new_user_email_confirm">Email address (confirmation)</label>
             <input type="Text" name="new_user_email_confirm" id="new_user_email_confirm" /> <br />
             <label for="new_user_country">Country</label>
@@ -33,11 +35,11 @@
                 <optgroup label="other">
                   <option value="4">United Kingdom</option>
                   <option value="5">USA</option>
-                  <option label="Germany" />
+                  <option label="Germany" data-locator="Berliner" />
               </optgroup>
             </select> <br />
             <label for="new_user_occupation">Occupation</label>
-            <input type="text" name="new_user_occupation" id="new_user_occupation" value="Developer" onfocus="document.getElementById('onfocus_test').innerHTML = 'changed by onfocus event'"/> <br />
+            <input type="text" class="c" name="new_user_occupation" data-locator="dev" id="new_user_occupation" value="Developer" onfocus="document.getElementById('onfocus_test').innerHTML = 'changed by onfocus event'"/> <br />
             <label>Without for <input /></label>
             <label>With<span style="display:none;"> hidden</span> text<input /></label>
             <label for="new_user_species">Species</label>
@@ -45,8 +47,8 @@
             <label for="new_user_code">Personal code</label>
             <input type="text" title="Your personal code" name="new_user_code" id="new_user_code" value="HE2FF8" readonly="readonly" /> <br  />
             <label for="good_luck">Good Luck</label>
-            <input type="text" title="Good Luck" name="good_luck" id="good_luck" disabled="disabled" readonly="readonly" /> <br  />
-            <input type="col" id="unknown_text_field" /> <br />
+            <input type="text" title="Good Luck" name="good_luck" id="good_luck" disabled="disabled" readonly="readonly" data-locator="Good Luck" /> <br  />
+            <input type="col" id="unknown_text_field" data-locator="unknown" /> <br />
             <label for="new_user_languages">Languages</label>
             <select name="new_user_languages" id="new_user_languages" multiple="multiple" onchange="WatirSpec.addMessage('changed language');">
                 <option id="danish" value="1">Danish</option>
@@ -79,7 +81,7 @@
             <label for="html5_time">HTML5 Time</label>
             <input type="time" id="html5_time" name="html5_time" />
             <label for="number">Age</label>
-            <input type="number" value="42" name="number" id="number">
+            <input type="number" value="42" name="number" id="number" data-locator="42">
         </fieldset>
         <fieldset>
             <legend>Login information</legend>
@@ -98,7 +100,7 @@
             <legend>Interests</legend>
             <input type="checkbox" tabindex="1" name="new_user_interests" id="new_user_interests_books" value="books" checked="checked" /> <label for="new_user_interests_books">Books</label>
             <input type="checkbox" tabindex="2" name="new_user_interests" value="bowling" /> <label>Bowling</label>
-            <input type="checkbox" tabindex="3" name="new_user_interests" id="new_user_interests_cars" value="cars" /> <label for="new_user_interests_cars">Cars</label>
+            <input type="checkbox" tabindex="3" name="new_user_interests" id="new_user_interests_cars" value="cars" data-locator="cars" /> <label for="new_user_interests_cars">Cars</label>
             <input type="checkbox" tabindex="4" name="new_user_interests" id="new_user_interests_dancing" value="dancing" class="fun" title="Dancing is fun!" /> <label for="new_user_interests_dancing">Dancing</label>
             <input type="checkbox" tabindex="5" name="new_user_interests" id="new_user_interests_dentistry" value="dentistry" disabled="disabled" /> <label for="new_user_interests_dentistry">Dentistry</label>
             <input type="hidden" name="new_user_interests" id="new_user_interests_dolls" value="dolls" class="fun" />
@@ -125,13 +127,13 @@
         </fieldset>
         <fieldset>
             <legend>Actions</legend>
-            <input type="submit" title="Submit the form" name="new_user_submit" id="new_user_submit" value="Submit" />
-            <input type="reset" name="new_user_reset" id="new_user_reset" value="Reset" />
-            <input type="button" name="new_user_button" id="new_user_button" alt="Create a new user" value="Button" onclick="this.value = 'new_value_set_by_onclick_event'" />
-            <input type="BuTTon" name="new_user_button_preview" id="new_user_button_preview" alt="Create a new user" value="Preview" />
-            <button name="new_user_button_2" value="button_2">Button 2</button>
-            <input type="image" class="image" name="new_user_image" src="images/button.png" alt="Submittable button" />
-            <input type="submit" name="new_user_submit_disabled" id="disabled_button" value="Disabled" disabled="disabled" />
+            <input type="submit" title="Submit the form" name="new_user_submit" data-locator="user submit" id="new_user_submit" value="Submit" />
+            <input type="reset" name="new_user_reset" id="new_user_reset" value="Reset" data-locator="reset" />
+            <input type="button" name="new_user_button" id="new_user_button" data-locator="new user" alt="Create a new user" value="Button" onclick="this.value = 'new_value_set_by_onclick_event'" />
+            <input type="BuTTon" name="new_user_button_preview" id="new_user_button_preview" alt="Create a new user" value="Preview" data-locator="preview"/>
+            <button name="new_user_button_2" value="button_2" data-locator="Benjamin">Button 2</button>
+            <input type="image" class="image" name="new_user_image" src="images/button.png" alt="Submittable button" data-locator="submittable button"/>
+            <input type="submit" name="new_user_submit_disabled" id="disabled_button" value="Disabled" disabled="disabled" data-locator="disabled" />
             <input type="checkbox" name="new_user_submit_disabled" id="toggle_button_checkbox" onclick="var elem = document.getElementById('disabled_button'); elem.disabled = !elem.disabled" />
         </fieldset>
     </form>
@@ -163,7 +165,7 @@
   <div id="wants_newsletter" style="display: none;"></div>
   <div id="onfocus_test"></div>
 
-  <div id="contenteditable" contenteditable="true">Foo</div>
+  <div id="contenteditable" contenteditable="true" class="content" data-locator="content">Foo</div>
 
   <!-- option disappears onchange -->
   <select id="obsolete" onchange="this.innerHTML = '';">

--- a/spec/watirspec/html/nested_elements.html
+++ b/spec/watirspec/html/nested_elements.html
@@ -7,11 +7,11 @@
 
 <body>
     <span id="grandparent_span">
-        <div id="grandparent">
-            <span class="parent" id="parent_span">
-                <div id="parent">
-                    <div id="first_sibling">
-                        <span id="child_span">
+        <div id="grandparent" class="ancestor" data-locator="grandparent">
+            <span class="parent" class="ancestor" id="parent_span" data-locator="grandparent span">
+                <div id="parent" class="ancestor" data-locator="parent">
+                    <div id="first_sibling" data-locator="first sibling">
+                        <span id="child_span" data-locator="child span">
                             <div id="oldest_child">
                                 <span id="grandson_span">
                                     <div id="first_grandson"></div>
@@ -22,10 +22,10 @@
                             <div id="youngest_child"></div>
                         </span>
                     </div>
-                    <span class="a" id="between_siblings1"></span>
-                    <div class="b" id="second_sibling"></div>
-                    <span class="a" id="between_siblings2"></span>
-                    <div class="a b" id="third_sibling">text</div>
+                    <span class="a" id="between_siblings1" data-locator="between_siblings1"></span>
+                    <div class="b" id="second_sibling" data-locator="second_sibling">Second</div>
+                    <span class="a" id="between_siblings2" data-locator="between_siblings2"></span>
+                    <div class="a b" id="third_sibling" data-locator="third_sibling">Third</div>
                 </div>
             </span>
         </div>

--- a/spec/watirspec/html/tables.html
+++ b/spec/watirspec/html/tables.html
@@ -9,12 +9,12 @@
         <div id="messages"></div>
         <h1>Tables</h1>
         <h2>Semantic table</h2>
-        <table cellspacing="0" cellpadding="5" rules="groups" frame="box" border="1" id="axis_example" summary="Hugh Laurie made more money than Gregory House in both March and April of 2008.">
+        <table cellspacing="0" data-locator="top table" cellpadding="5" rules="groups" frame="box" border="1" id="axis_example" summary="Hugh Laurie made more money than Gregory House in both March and April of 2008.">
             <caption>Income tax information for Gregory House and Hugh Laurie</caption>
             <colgroup width="25%" align="left"></colgroup>
             <colgroup width="25%" span="3" align="right"></colgroup>
             <thead id="tax_headers">
-                <tr style="border-bottom: 1px solid black;" class="dark" id="thead_row_1">
+                <tr style="border-bottom: 1px solid black;" class="dark" id="thead_row_1" data-locator="thead row">
                     <th></th>
                     <th id="before_tax" axis="cash" abbr="Before tax">Before income tax</th>
                     <th id="tax" axis="cash" abbr="Tax">Income tax</th>
@@ -22,7 +22,7 @@
                 </tr>
             </thead>
             <tfoot id="tax_totals">
-                <tr class="dark" id="tfoot_row_1">
+                <tr class="dark" id="tfoot_row_1" data-locator="tfoot row">
                     <th axis="sum">Sum</th>
                     <td headers="before_tax">24 349</td>
                     <td headers="tax">5 577</td>
@@ -30,20 +30,20 @@
                 </tr>
             </tfoot>
             <tbody id="first">
-                <tr id="march">
+                <tr id="march" data-locator="tbody row">
                     <th id="d1" axis="date" scope="rowgroup">March 2008</th>
                     <th></th>
                     <th></th>
                     <th></th>
                 </tr>
-                <tr id="gregory">
-                    <td id="p1" abbr="Dr. House">Gregory House</td>
-                    <td headers="before_tax p1 d1">5 934</td>
-                    <td headers="tax p1 d1">1 347</td>
-                    <td headers="after_tax p1 d1">4 587</td>
+                <tr id="gregory" class="brick" data-locator="House row">
+                    <td id="p1" abbr="Dr. House"data-locator="first cell">Gregory House</td>
+                    <td headers="before_tax p1 d1" data-locator="before tax">5 934</td>
+                    <td headers="tax p1 d1" data-locator="tax">1 347</td>
+                    <td id="last" headers="after_tax p1 d1" data-locator="after tax">4 587</td>
                 </tr>
                 <tr id="hugh">
-                    <td id="p2" abbr="Laurie">Hugh Laurie</td>
+                    <td id="p2" abbr="Laurie" data-locator="hugh">Hugh Laurie</td>
                     <td headers="before_tax p2 d1">6 300</td>
                     <td headers="tax p2 d1">1 479</td>
                     <td headers="after_tax p2 d1">4 821</td>
@@ -72,7 +72,7 @@
         </table>
         <h2>Table inside a table</h2>
         <table border="1" id="outer">
-            <tr id="outer_first">
+            <tr id="outer_first" data-locator="first row">
                 <td>
                     Table 1, Row 1, Cell 1
                 </td>

--- a/spec/watirspec/selector_builder/button_spec.rb
+++ b/spec/watirspec/selector_builder/button_spec.rb
@@ -1,0 +1,147 @@
+require 'watirspec_helper'
+
+describe Watir::Locators::Button::SelectorBuilder do
+  let(:attributes) { Watir::HTMLElement.attribute_list }
+  let(:scope_tag_name) { nil }
+  let(:selector_builder) { described_class.new(attributes) }
+  let(:default_types) do
+    "translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='button' or" \
+" translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='reset' or"\
+" translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='submit' or"\
+" translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='image'"
+  end
+
+  describe '#build' do
+    after(:each) do |example|
+      next if example.metadata[:skip_after]
+
+      @query_scope ||= browser
+      built = selector_builder.build(@selector)
+      expect(built).to eq [@wd_locator, (@remaining || {})]
+
+      next unless @data_locator || @tag_name
+
+      expect { @located = @query_scope.wd.first(@wd_locator) }.not_to raise_exception
+
+      if @data_locator
+        expect(@located.attribute('data-locator')).to eq(@data_locator)
+      else
+        expect {
+          expect(@located.tag_name).to eq @tag_name
+        }.not_to raise_exception
+      end
+    end
+
+    it 'without any arguments' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      @selector = {}
+      @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]"}
+      @data_locator = 'user submit'
+    end
+
+    context 'with type' do
+      before(:each) { browser.goto(WatirSpec.url_for('forms_with_input_elements.html')) }
+
+      it 'false locates button elements' do
+        @selector = {type: false}
+        @wd_locator = {xpath: ".//*[local-name()='button']"}
+        @data_locator = 'Benjamin'
+      end
+
+      it 'true locates input elements' do
+        @selector = {type: true}
+        @wd_locator = {xpath: ".//*[(local-name()='input' and #{default_types})]"}
+        @data_locator = 'user submit'
+      end
+
+      it 'locates input element with specified type' do
+        @selector = {type: 'reset'}
+        reset_only = "translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='reset'"
+        @wd_locator = {xpath: ".//*[(local-name()='input' and #{reset_only})]"}
+        @data_locator = 'reset'
+      end
+
+      it 'raises exception when a non-button type input is specified', skip_after: true do
+        selector = {type: 'checkbox'}
+        msg = 'Button Elements can not be located by input type: checkbox'
+        expect { selector_builder.build(selector) }
+          .to raise_exception Watir::Exception::LocatorException, msg
+      end
+    end
+
+    context 'with xpath or css' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'returns tag name and type to the locator' do
+        @selector = {xpath: '#disabled_button', tag_name: 'input', type: 'submit'}
+        @wd_locator = {xpath: '#disabled_button'}
+        @remaining = {tag_name: 'input', type: 'submit'}
+      end
+    end
+
+    context 'with text' do
+      before(:each) { browser.goto(WatirSpec.url_for('forms_with_input_elements.html')) }
+
+      it 'String for text' do
+        @selector = {text: 'Button 2'}
+        @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]" \
+"[normalize-space()='Button 2' or @value='Button 2']"}
+        @data_locator = 'Benjamin'
+      end
+
+      it 'Simple Regexp for value' do
+        @selector = {text: /Prev/}
+        @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]" \
+"[contains(text(), 'Prev') or contains(@value, 'Prev')]"}
+        @data_locator = 'preview'
+      end
+
+      it 'returns complicated Regexp to the locator' do
+        @selector = {text: /^foo$/}
+        @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]"}
+        @remaining = {text: /^foo$/}
+      end
+    end
+
+    context 'with value' do
+      before(:each) { browser.goto(WatirSpec.url_for('forms_with_input_elements.html')) }
+
+      it 'String for value' do
+        @selector = {value: 'Preview'}
+        @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]" \
+"[normalize-space()='Preview' or @value='Preview']"}
+        @data_locator = 'preview'
+      end
+
+      it 'Simple Regexp for text' do
+        @selector = {value: /2/}
+        @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]" \
+"[contains(text(), '2') or contains(@value, '2')]"}
+        @data_locator = 'Benjamin'
+      end
+    end
+
+    context 'with multiple locators' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'locates using class and attributes' do
+        @selector = {class: 'image', name: 'new_user_image', src: true}
+        @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]" \
+"[contains(concat(' ', @class, ' '), ' image ')][@name='new_user_image' and @src]"}
+        @data_locator = 'submittable button'
+      end
+    end
+
+    it 'delegates adjacent to Element SelectorBuilder' do
+      @query_scope = browser.element(id: 'new_user_button').locate
+
+      @selector = {adjacent: :ancestor, index: 2}
+      @wd_locator = {xpath: './ancestor::*[3]'}
+      @data_locator = 'body'
+    end
+  end
+end

--- a/spec/watirspec/selector_builder/cell_spec.rb
+++ b/spec/watirspec/selector_builder/cell_spec.rb
@@ -1,0 +1,57 @@
+require 'watirspec_helper'
+
+describe Watir::Locators::Cell::SelectorBuilder do
+  let(:attributes) { Watir::HTMLElement.attribute_list }
+  let(:selector_builder) { described_class.new(attributes) }
+
+  describe '#build' do
+    after(:each) do |example|
+      next if example.metadata[:skip_after]
+
+      @query_scope ||= browser.element(id: 'gregory').locate
+
+      built = selector_builder.build(@selector)
+      expect(built).to eq [@wd_locator, (@remaining || {})]
+
+      next unless @data_locator || @tag_name
+
+      expect { @located = @query_scope.wd.first(@wd_locator) }.not_to raise_exception
+
+      if @data_locator
+        expect(@located.attribute('data-locator')).to eq(@data_locator)
+      else
+        expect {
+          expect(@located.tag_name).to eq @tag_name
+        }.not_to raise_exception
+      end
+    end
+
+    it 'without any arguments' do
+      browser.goto(WatirSpec.url_for('tables.html'))
+      @selector = {}
+      @wd_locator = {xpath: "./*[local-name()='th' or local-name()='td']"}
+      @data_locator = 'first cell'
+    end
+
+    context 'with multiple locators' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('tables.html'))
+      end
+
+      it 'attribute and text' do
+        @selector = {headers: /before_tax/, text: '5 934'}
+        @wd_locator = {xpath: "./*[local-name()='th' or local-name()='td']" \
+"[contains(@headers, 'before_tax')][normalize-space()='5 934']"}
+        @data_locator = 'before tax'
+      end
+    end
+
+    it 'delegates adjacent to Element SelectorBuilder' do
+      @query_scope = browser.element(id: 'p3').locate
+
+      @selector = {adjacent: :ancestor, index: 2}
+      @wd_locator = {xpath: './ancestor::*[3]'}
+      @data_locator = 'top table'
+    end
+  end
+end

--- a/spec/watirspec/selector_builder/element_spec.rb
+++ b/spec/watirspec/selector_builder/element_spec.rb
@@ -1,0 +1,561 @@
+require 'watirspec_helper'
+
+describe Watir::Locators::Element::SelectorBuilder do
+  let(:selector_builder) { described_class.new(@attributes) }
+
+  describe '#build' do
+    after(:each) do |example|
+      next if example.metadata[:skip_after]
+
+      @attributes ||= Watir::HTMLElement.attribute_list
+      @query_scope ||= browser
+      built = selector_builder.build(@selector)
+      expect(built).to eq [@wd_locator, (@remaining || {})]
+
+      next unless @data_locator || @tag_name
+
+      expect { @located = @query_scope.wd.first(@wd_locator) }.not_to raise_exception
+
+      if @data_locator
+        expect(@located.attribute('data-locator')).to eq(@data_locator)
+      else
+        expect {
+          expect(@located.tag_name).to eq @tag_name
+        }.not_to raise_exception
+      end
+    end
+
+    it 'without any arguments' do
+      @selector = {}
+      @wd_locator = {xpath: './/*'}
+      @tag_name = 'html'
+    end
+
+    context 'with xpath or css' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'locates with xpath only' do
+        @selector = {xpath: './/div'}
+        @wd_locator = @selector.dup
+        @data_locator = 'first div'
+      end
+
+      it 'locates with css only' do
+        @selector = {css: 'div'}
+        @wd_locator = @selector.dup
+        @data_locator = 'first div'
+      end
+
+      it 'raises exception when using xpath & css', skip_after: true do
+        selector = {xpath: './/*', css: 'div'}
+        msg = ':xpath and :css cannot be combined ({:xpath=>".//*", :css=>"div"})'
+        expect { selector_builder.build(selector) }.to raise_exception Watir::Exception::LocatorException, msg
+      end
+
+      it 'raises exception when combining with xpath', skip_after: true do
+        selector = {xpath: './/*', foo: 'div'}
+        msg = 'xpath cannot be combined with all of these locators ({:foo=>"div"})'
+        expect { selector_builder.build(selector) }.to raise_exception Watir::Exception::LocatorException, msg
+      end
+
+      it 'raises exception when combining with css', skip_after: true do
+        selector = {css: 'div', foo: 'div'}
+        msg = 'css cannot be combined with all of these locators ({:foo=>"div"})'
+        expect { selector_builder.build(selector) }.to raise_exception Watir::Exception::LocatorException, msg
+      end
+
+      it 'raises exception when not a String', skip_after: true do
+        selector = {xpath: 7}
+        msg = /expected String, got 7:(Fixnum|Integer)/
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+
+      xcontext 'Ideal Behavior' do
+        it 'xpath' do
+          selector = {xpath: ".//*[@id='foo']", tag_name: 'div'}
+          expected = {xpath: ".//*[local-name()='div'][@id='foo']"}
+
+          expect_built(selector, expected)
+        end
+
+        it 'css' do
+          selector = {css: '.bar', tag_name: 'div'}
+          expected = {css: 'div.bar'}
+
+          expect_built(selector, expected)
+        end
+      end
+    end
+
+    context 'with tag_name' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'with String equals' do
+        @selector = {tag_name: 'div'}
+        @wd_locator = {xpath: ".//*[local-name()='div']"}
+        @data_locator = 'first div'
+      end
+
+      it 'with Regexp contains' do
+        @selector = {tag_name: /div/}
+        @wd_locator = {xpath: ".//*[contains(local-name(), 'div')]"}
+        @data_locator = 'first div'
+      end
+
+      it 'with Symbol' do
+        @selector = {tag_name: :div}
+        @wd_locator = {xpath: ".//*[local-name()='div']"}
+        @data_locator = 'first div'
+      end
+
+      it 'raises exception when not a String or Regexp', skip_after: true do
+        selector = {tag_name: 7}
+        msg = /expected string_or_regexp, got 7:(Fixnum|Integer)/
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+    end
+
+    context 'with class names' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'class_name is converted to class' do
+        @selector = {class_name: 'user'}
+        @wd_locator = {xpath: ".//*[contains(concat(' ', @class, ' '), ' user ')]"}
+        @data_locator = 'form'
+      end
+
+      # TODO: This functionality is deprecated with "class_array"
+      it 'values with spaces' do
+        @selector = {class_name: 'multiple classes here'}
+        @wd_locator = {xpath: ".//*[contains(concat(' ', @class, ' '), ' multiple classes here ')]"}
+        @data_locator = 'first div'
+      end
+
+      it 'single String concatenates' do
+        @selector = {class: 'user'}
+        @wd_locator = {xpath: ".//*[contains(concat(' ', @class, ' '), ' user ')]"}
+        @data_locator = 'form'
+      end
+
+      it 'Array of String concatenates with and' do
+        @selector = {class: %w[multiple here]}
+        @wd_locator = {xpath: ".//*[contains(concat(' ', @class, ' '), ' multiple ') and " \
+"contains(concat(' ', @class, ' '), ' here ')]"}
+        @data_locator = 'first div'
+      end
+
+      it 'single Regexp contains' do
+        @selector = {class_name: /use/}
+        @wd_locator = {xpath: ".//*[contains(@class, 'use')]"}
+        @data_locator = 'form'
+      end
+
+      it 'Array of Regexp contains with and' do
+        @selector = {class: [/mult/, /her/]}
+        @wd_locator = {xpath: ".//*[contains(@class, 'mult') and contains(@class, 'her')]"}
+        @data_locator = 'first div'
+      end
+
+      it 'single negated String concatenates with not' do
+        @selector = {class: '!multiple'}
+        @wd_locator = {xpath: ".//*[not(contains(concat(' ', @class, ' '), ' multiple '))]"}
+        @tag_name = 'html'
+      end
+
+      it 'single Boolean true provides the at' do
+        @selector = {class: true}
+        @wd_locator = {xpath: './/*[@class]'}
+        @data_locator = 'first div'
+      end
+
+      it 'single Boolean false provides the not atat' do
+        @selector = {class: false}
+        @wd_locator = {xpath: './/*[not(@class)]'}
+        @tag_name = 'html'
+      end
+
+      it 'Array of mixed String, Regexp and Boolean contains and concatenates with and and not' do
+        @selector = {class: [/mult/, 'classes', '!here']}
+        @wd_locator = {xpath: ".//*[contains(@class, 'mult') and contains(concat(' ', @class, ' '), ' classes ') " \
+"and not(contains(concat(' ', @class, ' '), ' here '))]"}
+        @data_locator = 'second div'
+      end
+
+      it 'raises exception when not a String or Regexp or Array', skip_after: true do
+        selector = {class: 7}
+        msg = /expected one of \[String, Regexp, TrueClass, FalseClass\], got 7:(Fixnum|Integer)/
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+
+      it 'raises exception when Array values are not a String or Regexp', skip_after: true do
+        selector = {class: [7]}
+        msg = /expected string_or_regexp, got 7:(Fixnum|Integer)/
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+
+      it 'raises exception when class and class_name are both used', skip_after: true do
+        selector = {class: 'foo', class_name: 'bar'}
+        msg = 'Can not use both :class and :class_name locators'
+        expect { selector_builder.build(selector) }.to raise_exception Watir::Exception::LocatorException, msg
+      end
+
+      it 'raises exception when class array is empty', skip_after: true do
+        selector = {class: []}
+        msg = 'Can not locate elements with an empty Array for :class'
+        expect { selector_builder.build(selector) }.to raise_exception Watir::Exception::LocatorException, msg
+      end
+    end
+
+    context 'with attributes as predicates' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'with href attribute' do
+        @selector = {href: 'watirspec.css'}
+        @wd_locator = {xpath: ".//*[normalize-space(@href)='watirspec.css']"}
+        @data_locator = 'link'
+      end
+
+      it 'with string attribute' do
+        @selector = {'name' => 'user_new'}
+        @wd_locator = {xpath: ".//*[@name='user_new']"}
+        @data_locator = 'form'
+      end
+
+      it 'with String equals' do
+        @selector = {name: 'user_new'}
+        @wd_locator = {xpath: ".//*[@name='user_new']"}
+        @data_locator = 'form'
+      end
+
+      it 'with TrueClass no equals' do
+        @selector = {tag_name: 'input', name: true}
+        @wd_locator = {xpath: ".//*[local-name()='input'][@name]"}
+        @data_locator = 'input name'
+      end
+
+      it 'with FalseClass not with no equals' do
+        @selector = {tag_name: 'input', name: false}
+        @wd_locator = {xpath: ".//*[local-name()='input'][not(@name)]"}
+        @data_locator = 'input nameless'
+      end
+
+      it 'with multiple attributes: no equals and not with no equals and equals' do
+        @selector = {readonly: true, foo: false, id: 'good_luck'}
+        @wd_locator = {xpath: ".//*[@readonly and not(@foo) and @id='good_luck']"}
+        @data_locator = 'Good Luck'
+      end
+
+      it 'raises exception when attribute value is not a Boolean, String or Regexp', skip_after: true do
+        selector = {foo: 7}
+        msg = /expected one of \[String, Regexp, TrueClass, FalseClass\], got 7:(Fixnum|Integer)/
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+
+      it 'raises exception when attribute key is not a String or Regexp', skip_after: true do
+        selector = {7 => 'foo'}
+        msg = /Unable to build XPath using 7:(Fixnum|Integer)/
+        expect { selector_builder.build(selector) }.to raise_exception Watir::Exception::LocatorException, msg
+      end
+    end
+
+    context 'with attributes as partials' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'with Regexp' do
+        @selector = {name: /user/}
+        @wd_locator = {xpath: ".//*[contains(@name, 'user')]"}
+        @data_locator = 'form'
+      end
+
+      it 'with multiple Regexp attributes separated by and' do
+        @selector = {readonly: /read/, id: /good/}
+        @wd_locator = {xpath: ".//*[contains(@readonly, 'read') and contains(@id, 'good')]"}
+        @data_locator = 'Good Luck'
+      end
+    end
+
+    context 'with text' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'String uses normalize space equals' do
+        @selector = {text: 'Add user'}
+        @wd_locator = {xpath: ".//*[normalize-space()='Add user']"}
+        @data_locator = 'add user'
+      end
+
+      # Deprecated with :caption
+      it 'with caption attribute' do
+        @selector = {caption: 'Add user'}
+        @wd_locator = {xpath: ".//*[normalize-space()='Add user']"}
+        @data_locator = 'add user'
+      end
+
+      it 'raises exception when text is not a String or Regexp', skip_after: true do
+        selector = {text: 7}
+        msg = /expected string_or_regexp, got 7:(Fixnum|Integer)/
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+    end
+
+    context 'with labels' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'locates the element associated with the label element located by the text of the provided label key' do
+        @selector = {label: 'Cars'}
+        @wd_locator = {xpath: ".//*[(@id=//label[normalize-space()='Cars']/@for "\
+"or parent::label[normalize-space()='Cars'])]"}
+        @data_locator = 'cars'
+      end
+
+      it 'does not use the label element when label is a valid attribute' do
+        @attributes ||= Watir::Option.attribute_list
+
+        @selector = {tag_name: 'option', label: 'Germany'}
+        @wd_locator = {xpath: ".//*[local-name()='option'][@label='Germany']"}
+        @data_locator = 'Berliner'
+      end
+    end
+
+    context 'with adjacent locators' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('nested_elements.html'))
+      end
+
+      it 'raises exception when not a Symbol', skip_after: true do
+        selector = {adjacent: 'foo', index: 0}
+        msg = 'expected Symbol, got "foo":String'
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+
+      it 'raises exception when not a valid value', skip_after: true do
+        selector = {adjacent: :foo, index: 0}
+        msg = 'Unable to process adjacent locator with foo'
+        expect { selector_builder.build(selector) }.to raise_exception Watir::Exception::LocatorException, msg
+      end
+
+      describe '#parent' do
+        it 'with no other arguments' do
+          @query_scope = browser.div(id: 'first_sibling')
+          @selector = {adjacent: :ancestor, index: 0}
+          @wd_locator = {xpath: './ancestor::*[1]'}
+          @data_locator = 'parent'
+        end
+
+        it 'with index' do
+          @query_scope = browser.div(id: 'first_sibling')
+          @selector = {adjacent: :ancestor, index: 2}
+          @wd_locator = {xpath: './ancestor::*[3]'}
+          @data_locator = 'grandparent'
+        end
+
+        it 'with multiple locators' do
+          @query_scope = browser.div(id: 'first_sibling')
+          @selector = {adjacent: :ancestor, id: true, tag_name: 'div', class: 'ancestor', index: 1}
+          @wd_locator = {xpath: "./ancestor::*[local-name()='div']"\
+"[contains(concat(' ', @class, ' '), ' ancestor ')][@id][2]"}
+          @data_locator = 'grandparent'
+        end
+
+        it 'raises an exception if text locator is used', skip_after: true do
+          selector = {adjacent: :ancestor, index: 0, text: 'Foo'}
+          msg = 'Can not find parent element with text locator'
+          expect { selector_builder.build(selector) }
+            .to raise_exception Watir::Exception::LocatorException, msg
+        end
+      end
+
+      describe '#following_sibling' do
+        it 'with no other arguments' do
+          @query_scope = browser.div(id: 'first_sibling')
+          @selector = {adjacent: :following, index: 0}
+          @wd_locator = {xpath: './following-sibling::*[1]'}
+          @data_locator = 'between_siblings1'
+        end
+
+        it 'with index' do
+          @query_scope = browser.div(id: 'first_sibling')
+          @selector = {adjacent: :following, index: 2}
+          @wd_locator = {xpath: './following-sibling::*[3]'}
+          @data_locator = 'between_siblings2'
+        end
+
+        it 'with multiple locators' do
+          @query_scope = browser.div(id: 'first_sibling')
+          @selector = {adjacent: :following, tag_name: 'div', class: 'b', index: 0, id: true}
+          @wd_locator = {xpath: "./following-sibling::*[local-name()='div']"\
+"[contains(concat(' ', @class, ' '), ' b ')][@id][1]"}
+          @data_locator = 'second_sibling'
+        end
+
+        it 'with text' do
+          @query_scope = browser.div(id: 'first_sibling')
+          @selector = {adjacent: :following, text: 'Third', index: 0}
+          @wd_locator = {xpath: "./following-sibling::*[normalize-space()='Third'][1]"}
+          @data_locator = 'third_sibling'
+        end
+      end
+
+      describe '#previous_sibling' do
+        it 'with no other arguments' do
+          @query_scope = browser.div(id: 'third_sibling')
+          @selector = {adjacent: :preceding, index: 0}
+          @wd_locator = {xpath: './preceding-sibling::*[1]'}
+          @data_locator = 'between_siblings2'
+        end
+
+        it 'with index' do
+          @query_scope = browser.div(id: 'third_sibling')
+          @selector = {adjacent: :preceding, index: 2}
+          @wd_locator = {xpath: './preceding-sibling::*[3]'}
+          @data_locator = 'between_siblings1'
+        end
+
+        it 'with multiple locators' do
+          @query_scope = browser.div(id: 'third_sibling')
+          @selector = {adjacent: :preceding, tag_name: 'div', class: 'b', id: true, index: 0}
+          @wd_locator = {xpath: "./preceding-sibling::*[local-name()='div']"\
+"[contains(concat(' ', @class, ' '), ' b ')][@id][1]"}
+          @data_locator = 'second_sibling'
+        end
+
+        it 'with text' do
+          @query_scope = browser.div(id: 'third_sibling')
+          @selector = {adjacent: :preceding, text: 'Second', index: 0}
+          @wd_locator = {xpath: "./preceding-sibling::*[normalize-space()='Second'][1]"}
+          @data_locator = 'second_sibling'
+        end
+      end
+
+      describe '#child' do
+        it 'with no other arguments' do
+          @query_scope = browser.div(id: 'first_sibling')
+          @selector = {adjacent: :child, index: 0}
+          @wd_locator = {xpath: './child::*[1]'}
+          @data_locator = 'child span'
+        end
+
+        it 'with index' do
+          @query_scope = browser.div(id: 'parent')
+          @selector = {adjacent: :child, index: 2}
+          @wd_locator = {xpath: './child::*[3]'}
+          @data_locator = 'second_sibling'
+        end
+
+        it 'with multiple locators' do
+          @query_scope = browser.div(id: 'parent')
+          @selector = {adjacent: :child, tag_name: 'div', class: 'b', id: true, index: 0}
+          @wd_locator = {xpath: "./child::*[local-name()='div']"\
+"[contains(concat(' ', @class, ' '), ' b ')][@id][1]"}
+          @data_locator = 'second_sibling'
+        end
+
+        it 'with text' do
+          @query_scope = browser.div(id: 'parent')
+          @selector = {adjacent: :child, text: 'Second', index: 0}
+          @wd_locator = {xpath: "./child::*[normalize-space()='Second'][1]"}
+          @data_locator = 'second_sibling'
+        end
+      end
+    end
+
+    context 'with multiple locators' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'locates using tag name, class, attributes and text' do
+        @selector = {tag_name: 'div', class: 'content', contenteditable: 'true', text: 'Foo'}
+        @wd_locator = {xpath: ".//*[local-name()='div'][contains(concat(' ', @class, ' '), ' content ')]" \
+"[@contenteditable='true'][normalize-space()='Foo']"}
+        @data_locator = 'content'
+      end
+    end
+
+    context 'returns locators that can not be directly translated' do
+      it 'attribute with complicated Regexp at beginning' do
+        @selector = {action: /^post/}
+        @wd_locator = {xpath: './/*[@action]'}
+        @remaining = {action: /^post/}
+      end
+
+      it 'attribute with complicated Regexp at end' do
+        @selector = {action: /me$/}
+        @wd_locator = {xpath: './/*[@action]'}
+        @remaining = {action: /me$/}
+      end
+
+      it 'class with complicated Regexp' do
+        @selector = {class: /^her/}
+        @wd_locator = {xpath: './/*[@class]'}
+        @remaining = {class: [/^her/]}
+      end
+
+      it 'text with any Regexp' do
+        @selector = {text: /Add/}
+        @wd_locator = {xpath: './/*'}
+        @remaining = {text: /Add/}
+      end
+
+      it 'index' do
+        @selector = {tag_name: 'div', index: 1}
+        @wd_locator = {xpath: ".//*[local-name()='div']"}
+        @remaining = {index: 1}
+      end
+
+      it 'visible' do
+        @selector = {tag_name: 'div', visible: true}
+        @wd_locator = {xpath: ".//*[local-name()='div']"}
+        @remaining = {visible: true}
+      end
+
+      it 'not visible' do
+        @selector = {tag_name: 'span', visible: false}
+        @wd_locator = {xpath: ".//*[local-name()='span']"}
+        @remaining = {visible: false}
+      end
+
+      it 'visible text' do
+        @selector = {tag_name: 'span', visible_text: 'foo'}
+        @wd_locator = {xpath: ".//*[local-name()='span']"}
+        @remaining = {visible_text: 'foo'}
+      end
+
+      it 'does not return index if it is zero' do
+        @selector = {tag_name: 'div', index: 0}
+        @wd_locator = {xpath: ".//*[local-name()='div']"}
+      end
+
+      it 'raises exception when index is not an Integer', skip_after: true do
+        selector = {index: 'foo'}
+        msg = 'expected Integer, got "foo":String'
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+
+      it 'raises exception when visible is not boolean', skip_after: true do
+        selector = {visible: 'foo'}
+        msg = 'expected boolean, got "foo":String'
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+
+      it 'raises exception when visible text is not a String or Regexp', skip_after: true do
+        selector = {visible_text: 7}
+        msg = /expected string_or_regexp, got 7:(Fixnum|Integer)/
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+    end
+  end
+end

--- a/spec/watirspec/selector_builder/row_spec.rb
+++ b/spec/watirspec/selector_builder/row_spec.rb
@@ -1,0 +1,105 @@
+require 'watirspec_helper'
+
+describe Watir::Locators::Row::SelectorBuilder do
+  let(:attributes) { Watir::HTMLElement.attribute_list }
+  let(:selector_builder) { described_class.new(attributes, @scope_tag_name) }
+
+  describe '#build' do
+    after(:each) do |example|
+      next if example.metadata[:skip_after]
+
+      @scope_tag_name ||= @query_scope.tag_name
+
+      built = selector_builder.build(@selector)
+      expect(built).to eq [@wd_locator, (@remaining || {})]
+
+      next unless @data_locator || @tag_name
+
+      expect { @located = @query_scope.wd.first(@wd_locator) }.not_to raise_exception
+
+      if @data_locator
+        expect(@located.attribute('data-locator')).to eq(@data_locator)
+      else
+        expect {
+          expect(@located.tag_name).to eq @tag_name
+        }.not_to raise_exception
+      end
+    end
+
+    context 'with query scopes' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('tables.html'))
+      end
+
+      it 'with only table query scope' do
+        @query_scope = browser.element(id: 'outer').locate
+        @selector = {}
+        @wd_locator = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+"./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']"}
+        @data_locator = 'first row'
+      end
+
+      it 'with tbody query scope' do
+        @query_scope = browser.element(id: 'first').locate
+        @selector = {}
+        @wd_locator = {xpath: "./*[local-name()='tr']"}
+        @data_locator = 'tbody row'
+      end
+
+      it 'with thead query scope' do
+        @query_scope = browser.element(id: 'tax_headers').locate
+        @selector = {}
+        @wd_locator = {xpath: "./*[local-name()='tr']"}
+        @data_locator = 'thead row'
+      end
+
+      it 'with tfoot query scope' do
+        @query_scope = browser.element(id: 'tax_totals').locate
+        @selector = {}
+        @wd_locator = {xpath: "./*[local-name()='tr']"}
+        @data_locator = 'tfoot row'
+      end
+    end
+
+    context 'with multiple locators' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('tables.html'))
+        @query_scope = browser.table.locate
+      end
+
+      it 'attribute and class' do
+        @selector = {id: 'gregory', class: /brick/}
+        @wd_locator = {xpath: "./*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
+"./*[local-name()='tbody']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
+"./*[local-name()='thead']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
+"./*[local-name()='tfoot']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory']"}
+        @data_locator = 'House row'
+      end
+    end
+
+    context 'returns locators that can not be directly translated' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('tables.html'))
+        @query_scope = browser.table(id: 'outer').locate
+      end
+
+      it 'any text value' do
+        @selector = {text: 'Gregory'}
+        @wd_locator = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+"./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']"}
+        @remaining = {text: 'Gregory'}
+      end
+    end
+
+    it 'delegates adjacent to Element SelectorBuilder' do
+      browser.goto(WatirSpec.url_for('tables.html'))
+
+      @scope_tag_name = 'table'
+      @query_scope = browser.element(id: 'gregory').locate
+
+      @selector = {adjacent: :ancestor, index: 1}
+      @wd_locator = {xpath: './ancestor::*[2]'}
+      @data_locator = 'top table'
+    end
+  end
+end

--- a/spec/watirspec/selector_builder/text_spec.rb
+++ b/spec/watirspec/selector_builder/text_spec.rb
@@ -1,0 +1,135 @@
+require 'watirspec_helper'
+
+describe Watir::Locators::TextField::SelectorBuilder do
+  let(:attributes) { Watir::HTMLElement.attribute_list }
+  let(:scope_tag_name) { nil }
+  let(:selector_builder) { described_class.new(attributes) }
+  let(:negative_types) do
+    "translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='file' and "\
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='radio' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='checkbox' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='submit' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='reset' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='image' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='button' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='hidden' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='range' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='color' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='date' and " \
+"translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')!='datetime-local'"
+  end
+
+  describe '#build' do
+    after(:each) do |example|
+      next if example.metadata[:skip_after]
+
+      @query_scope ||= browser
+
+      built = selector_builder.build(@selector)
+      expect(built).to eq [@wd_locator, (@remaining || {})]
+
+      next unless @data_locator || @tag_name
+
+      expect { @located = @query_scope.wd.first(@wd_locator) }.not_to raise_exception
+
+      if @data_locator
+        expect(@located.attribute('data-locator')).to eq(@data_locator)
+      else
+        expect {
+          expect(@located.tag_name).to eq @tag_name
+        }.not_to raise_exception
+      end
+    end
+
+    it 'without any arguments' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      @selector = {}
+      @wd_locator = {xpath: ".//*[local-name()='input'][not(@type) or (#{negative_types})]"}
+      @data_locator = 'input name'
+    end
+
+    context 'with type' do
+      before(:each) { browser.goto(WatirSpec.url_for('forms_with_input_elements.html')) }
+
+      it 'specified text field type that is text' do
+        @selector = {type: 'text'}
+        @wd_locator = {xpath: ".//*[local-name()='input']" \
+"[translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='text']"}
+        @data_locator = 'first text'
+      end
+
+      it 'specified text field type that is not text' do
+        @selector = {type: 'number'}
+        @wd_locator = {xpath: ".//*[local-name()='input']" \
+"[translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='number']"}
+        @data_locator = '42'
+      end
+
+      it 'true locates text field with a type specified' do
+        @selector = {type: true}
+        @wd_locator = {xpath: ".//*[local-name()='input'][#{negative_types}]"}
+        @data_locator = 'input name'
+      end
+
+      it 'false locates text field without type specified' do
+        @selector = {type: false}
+        @wd_locator = {xpath: ".//*[local-name()='input']" \
+"[not(translate(@type,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'))]"}
+        @data_locator = 'input name'
+      end
+
+      it 'raises exception when a non-text field type input is specified', skip_after: true do
+        selector = {type: 'checkbox'}
+        msg = 'TextField Elements can not be located by type: checkbox'
+        expect { selector_builder.build(selector) }
+          .to raise_exception Watir::Exception::LocatorException, msg
+      end
+    end
+
+    context 'with text' do
+      before(:each) { browser.goto(WatirSpec.url_for('forms_with_input_elements.html')) }
+
+      it 'String for value' do
+        @selector = {text: 'Developer'}
+        @wd_locator = {xpath: ".//*[local-name()='input'][not(@type) or (#{negative_types})]" \
+"[@value='Developer']"}
+        @data_locator = 'dev'
+      end
+
+      it 'Simple Regexp for value' do
+        @selector = {text: /Dev/}
+        @wd_locator = {xpath: ".//*[local-name()='input'][not(@type) or (#{negative_types})]" \
+"[contains(@value, 'Dev')]"}
+        @data_locator = 'dev'
+      end
+
+      it 'returns complicated Regexp to the locator as a value' do
+        @selector = {text: /^foo$/}
+        @wd_locator = {xpath: ".//*[local-name()='input'][not(@type) or (#{negative_types})]"}
+        @remaining = {value: /^foo$/}
+      end
+    end
+
+    context 'with multiple locators' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'locates using tag name, class, attributes and text' do
+        @selector = {text: 'Developer', class: /c/, id: true}
+        @wd_locator = {xpath: ".//*[local-name()='input'][not(@type) or (#{negative_types})]" \
+"[contains(@class, 'c')][@id][@value='Developer']"}
+        @data_locator = 'dev'
+      end
+
+      it 'delegates adjacent to Element SelectorBuilder' do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+        @query_scope = browser.element(id: 'new_user_email').locate
+
+        @selector = {adjacent: :ancestor, index: 1}
+        @wd_locator = {xpath: './ancestor::*[2]'}
+        @data_locator = 'form'
+      end
+    end
+  end
+end

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -1,6 +1,8 @@
 require 'watirspec'
 require 'spec_helper'
 
+Watir.default_timeout = 8
+
 if ENV['SELENIUM_STATS'] == 'true'
   require 'selenium_statistics'
   at_exit { SeleniumStatistics.print_results }


### PR DESCRIPTION
Ok, this is an overhaul/replacement of #793. It does *not* include any additional functionality. In fact, it removes a performance tweak that has been shown to not be entirely accurate. It does manage the Separation of Concerns from the previous PR, and will make it very easy to improve text matching, regular expression matching, and indexes with XPath  to minimize unnecessary extra matching calls.

It does add a ton of specs for proper building of element Selectors. It then does an actual lookup using the XPath defined to ensure that it is finding the expected element (I added `data-locator` attributes to specify what I expected when writing the specs.

For instance, `id: /foob?/` should match `<div id='foo'>`, but our current implementation does not. Rather than fixing it in this PR, I removed it because it is only a performance tweak, and this refactor should allow for a better, more comprehensive solution.

I'd like to deprecate two things with this PR:
1. Using `:caption` locator to find text. This currently works for all elements, and I don't see why it is useful on any
2. Using `'text'` locator to find text, rather than `:text`

I'd also kind of like to prevent using symbols for tag_names, since that's kind of weird, but I didn't specifically add that this time.

Another issue is I can't figure out how to mock out the StaleElement code. The existing spec only works because the current code is making a completely unnecessary matching call after finding the right element with XPath. This is what caused the coverage drop. I should probably think more about it before merging.

Note that this does not pass rubocop as is. I split out all of the conditionals onto separate lines to make sure code coverage is 100% and no extraneous branches exist. Both selector_builder specs and our elements specs independently exercise 100% of this code, which is what I'm going for. I propose we keep the structure this way for any spec removal we do before merging this into master.