### PR TITLE
Text regexp

### DIFF
--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -163,7 +163,7 @@ module Watir
         end
 
         def matches_values?(element, values_to_match)
-          matches = values_to_match.all? do |how, what|
+          values_to_match.all? do |how, what|
             if how == :tag_name && what.is_a?(String)
               element_validator.validate(element, what)
             else
@@ -171,22 +171,6 @@ module Watir
               what == val || val =~ /#{what}/
             end
           end
-
-          text_regexp_deprecation(element, values_to_match, matches) if values_to_match[:text]
-
-          matches
-        end
-
-        def text_regexp_deprecation(element, selector, matches)
-          new_element = Watir::Element.new(@query_scope, element: element)
-          text_content = new_element.execute_js(:getTextContent, element).strip
-          text_content_matches = text_content =~ /#{selector[:text]}/
-          return if matches == !!text_content_matches
-
-          key = @selector.key?(:text) ? 'text' : 'label'
-          selector_text = selector[:text].inspect
-          dep = "Using :#{key} locator with RegExp #{selector_text} to match an element that includes hidden text"
-          Watir.logger.deprecate(dep, ":visible_#{key}", ids: [:text_regexp])
         end
 
         def locate_element(how, what, scope = @query_scope.wd)

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -49,6 +49,8 @@ module Watir
             text = @selector.delete :text
             if !text.is_a?(Regexp)
               "[normalize-space()=#{XpathSupport.escape text}]"
+            elsif simple_regexp?(text)
+              "[contains(text(), '#{text.source}')]"
             else
               @requires_matches[:text] = text
               ''

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -126,30 +126,6 @@ describe 'Div' do
     end
   end
 
-  describe 'Deprecation Warnings' do
-    describe 'text locator with RegExp values' do
-      it 'does not throw deprecation when still matched by text content' do
-        expect { browser.div(text: /some visible/).exists? }.not_to have_deprecated_text_regexp
-      end
-
-      not_compliant_on :watigiri do
-        it 'throws deprecation when no longer matched by text content' do
-          expect { browser.div(text: /some visible$/).exists? }.to have_deprecated_text_regexp
-        end
-      end
-
-      not_compliant_on :watigiri do
-        it 'throws deprecation when begins to be matched by text content' do
-          expect { browser.div(text: /some hidden/).exists? }.to have_deprecated_text_regexp
-        end
-      end
-
-      it 'does not throw deprecation when still not matched by text content' do
-        expect { browser.div(text: /does not exist/).exists? }.not_to have_deprecated_text_regexp
-      end
-    end
-  end
-
   # Manipulation methods
   not_compliant_on :headless do
     describe '#click' do

--- a/spec/watirspec/elements/span_spec.rb
+++ b/spec/watirspec/elements/span_spec.rb
@@ -11,14 +11,11 @@ describe 'Span' do
       expect(browser.span(id: 'lead')).to exist
       expect(browser.span(id: /lead/)).to exist
       expect(browser.span(text: 'Dubito, ergo cogito, ergo sum.')).to exist
+      expect(browser.span(visible_text: /Dubito, ergo cogito, ergo sum/)).to exist
       expect(browser.span(class: 'lead')).to exist
       expect(browser.span(class: /lead/)).to exist
       expect(browser.span(index: 0)).to exist
       expect(browser.span(xpath: "//span[@id='lead']")).to exist
-    end
-
-    it 'visible text is found by regular expression with text locator' do
-      expect(browser.span(text: /Dubito, ergo cogito, ergo sum/)).to exist
     end
 
     it 'returns the first span if given no args' do

--- a/spec/watirspec/elements/strong_spec.rb
+++ b/spec/watirspec/elements/strong_spec.rb
@@ -11,14 +11,11 @@ describe 'Strong' do
       expect(browser.strong(id: 'descartes')).to exist
       expect(browser.strong(id: /descartes/)).to exist
       expect(browser.strong(text: 'Dubito, ergo cogito, ergo sum.')).to exist
+      expect(browser.strong(visible_text: 'Dubito, ergo cogito, ergo sum.')).to exist
       expect(browser.strong(class: 'descartes')).to exist
       expect(browser.strong(class: /descartes/)).to exist
       expect(browser.strong(index: 0)).to exist
       expect(browser.strong(xpath: "//strong[@id='descartes']")).to exist
-    end
-
-    it 'visible text is found by regular expression with text locator' do
-      expect(browser.strong(text: /Dubito, ergo cogito, ergo sum/)).to exist
     end
 
     it 'returns the first strong if given no args' do

--- a/spec/watirspec/selector_builder/button_spec.rb
+++ b/spec/watirspec/selector_builder/button_spec.rb
@@ -91,6 +91,13 @@ describe Watir::Locators::Button::SelectorBuilder do
         @data_locator = 'Benjamin'
       end
 
+      it 'Simple Regexp for text' do
+        @selector = {text: /n 2/}
+        @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]" \
+"[contains(text(), 'n 2') or contains(@value, 'n 2')]"}
+        @data_locator = 'Benjamin'
+      end
+
       it 'Simple Regexp for value' do
         @selector = {text: /Prev/}
         @wd_locator = {xpath: ".//*[local-name()='button' or (local-name()='input' and #{default_types})]" \

--- a/spec/watirspec/selector_builder/cell_spec.rb
+++ b/spec/watirspec/selector_builder/cell_spec.rb
@@ -33,6 +33,13 @@ describe Watir::Locators::Cell::SelectorBuilder do
       @data_locator = 'first cell'
     end
 
+    it 'with simple Regexp as text' do
+      browser.goto(WatirSpec.url_for('tables.html'))
+      @selector = {text: /934/}
+      @wd_locator = {xpath: "./*[local-name()='th' or local-name()='td'][contains(text(), '934')]"}
+      @data_locator = 'before tax'
+    end
+
     context 'with multiple locators' do
       before(:each) do
         browser.goto(WatirSpec.url_for('tables.html'))

--- a/spec/watirspec/selector_builder/element_spec.rb
+++ b/spec/watirspec/selector_builder/element_spec.rb
@@ -100,7 +100,7 @@ describe Watir::Locators::Element::SelectorBuilder do
         @data_locator = 'first div'
       end
 
-      it 'with Regexp contains' do
+      it 'with simple Regexp contains' do
         @selector = {tag_name: /div/}
         @wd_locator = {xpath: ".//*[contains(local-name(), 'div')]"}
         @data_locator = 'first div'
@@ -299,6 +299,12 @@ describe Watir::Locators::Element::SelectorBuilder do
       it 'with caption attribute' do
         @selector = {caption: 'Add user'}
         @wd_locator = {xpath: ".//*[normalize-space()='Add user']"}
+        @data_locator = 'add user'
+      end
+
+      it 'with simpleRegexp contains' do
+        @selector = {text: /Add/}
+        @wd_locator = {xpath: ".//*[contains(text(), 'Add')]"}
         @data_locator = 'add user'
       end
 
@@ -502,12 +508,6 @@ describe Watir::Locators::Element::SelectorBuilder do
         @selector = {class: /^her/}
         @wd_locator = {xpath: './/*[@class]'}
         @remaining = {class: [/^her/]}
-      end
-
-      it 'text with any Regexp' do
-        @selector = {text: /Add/}
-        @wd_locator = {xpath: './/*'}
-        @remaining = {text: /Add/}
       end
 
       it 'index' do

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -5,7 +5,6 @@ if defined?(RSpec)
                             use_capabilities
                             visible_text
                             link_text
-                            text_regexp
                             stale_visible
                             stale_present
                             select_by


### PR DESCRIPTION
So this one has to remove support for locating visible text with a regular expression 
I'm thinking it should wait until whenever we remove the deprecations in Watir 7?