### PR TITLE
Fix for Psych::DisallowedClass: Tried to load unspecified class: Time

### DIFF
--- a/lib/watir/cookies.rb
+++ b/lib/watir/cookies.rb
@@ -115,7 +115,7 @@ module Watir
     #
 
     def load(file = '.cookies')
-      YAML.safe_load(IO.read(file), [::Symbol]).each do |c|
+      YAML.safe_load(IO.read(file), [::Symbol, ::Time]).each do |c|
         add(c.delete(:name), c.delete(:value), c)
       end
     end


### PR DESCRIPTION
Fixes #790 (Can not load cookies - Psych::DisallowedClass: Tried to load unspecified class: Time)