### PR TITLE
Use javascript to get tag_name for ElementCollection elements

### DIFF
--- a/spec/watirspec/elements/collections_spec.rb
+++ b/spec/watirspec/elements/collections_spec.rb
@@ -17,6 +17,14 @@ describe 'Collections' do
     expect(collection.all? { |el| el.is_a? Watir::Span }).to eq true
   end
 
+  it 'returns correct subtype of elements without tag_name' do
+    browser.goto(WatirSpec.url_for('collections.html'))
+    collection = browser.span(id: 'a_span').elements
+    collection.locate
+    expect(collection.first).to be_a Watir::Div
+    expect(collection.last).to be_a Watir::Span
+  end
+
   it 'can contain more than one type of element' do
     browser.goto(WatirSpec.url_for('nested_elements.html'))
     collection = browser.div(id: 'parent').children
@@ -70,5 +78,29 @@ describe 'Collections' do
     browser.refresh
     expect(elements[1]).to be_stale
     expect { elements[1] }.to_not raise_unknown_object_exception
+  end
+
+  it 'does not retrieve tag_name on elements when specifying tag_name' do
+    browser.goto(WatirSpec.url_for('collections.html'))
+    collection = browser.span(id: 'a_span').spans
+
+    expect_any_instance_of(Selenium::WebDriver::Element).to_not receive(:tag_name)
+    collection.locate
+  end
+
+  it 'does not retrieve tag_name on elements without specifying tag_name' do
+    browser.goto(WatirSpec.url_for('collections.html'))
+    collection = browser.span(id: 'a_span').elements
+
+    expect_any_instance_of(Selenium::WebDriver::Element).to_not receive(:tag_name)
+    collection.locate
+  end
+
+  it 'does not execute_script to retrieve tag_names when specifying tag_name' do
+    browser.goto(WatirSpec.url_for('collections.html'))
+    collection = browser.span(id: 'a_span').spans
+
+    expect(browser.wd).to_not receive(:execute_script)
+    collection.locate
   end
 end


### PR DESCRIPTION
When the `selector` does not contain `:tag_name`, we are currently querying the `tag_name` from the element. This causes `N` wire calls which, depending on how many elements there are, can take a while when testing remotely.

The idea is to us the javascript executor to retrieve all the tags once. In doing so, we do miss out on the added benefit of `element_call` which `#tag_name` uses, but that shouldn't be an issue as we have already located the elements.

The only concern I could think of was with elements going stale between retrieving them and then performing javascript on them, but this should be a rare scenario. This is mitigated by the rescue and retry. Theoretically there is a chance for an infinite loop on the retry, but the likelihood of that is near impossible in normal conditions.