### PR TITLE
Add Element#obscured?

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -489,6 +489,21 @@ module Watir
     end
 
     #
+    # Returns true if the element's center point is covered by a non-descendant element.
+    #
+    # @return [Boolean]
+    #
+
+    def obscured?
+      element_call do
+        return true unless present?
+
+        scroll_into_view
+        execute_js(:elementObscured, self)
+      end
+    end
+
+    #
     # Returns given style property of this element.
     #
     # @example

--- a/lib/watir/js_snippets/elementObscured.js
+++ b/lib/watir/js_snippets/elementObscured.js
@@ -1,0 +1,14 @@
+// Original Author: Florent B.
+// Source: https://stackoverflow.com/a/45244889/1200545
+function() {
+    var elem = arguments[0],
+        box = elem.getBoundingClientRect(),
+        cx = box.left + box.width / 2,
+        cy = box.top + box.height / 2,
+        e = document.elementFromPoint(cx, cy);
+    for (; e; e = e.parentElement) {
+        if (e === elem)
+            return false;
+    }
+    return true;
+}

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -874,4 +874,59 @@ describe 'Element' do
       expect { browser.div(id: 'no_such_id').classes }.to raise_unknown_object_exception
     end
   end
+
+  describe '#obscured?' do
+    before { browser.goto WatirSpec.url_for('obscured.html') }
+
+    it 'returns false if element\'s center is not covered' do
+      btn = browser.button(id: 'not_obscured')
+      expect(btn).not_to be_obscured
+      expect { btn.click }.not_to raise_exception
+    end
+
+    it 'returns false if element\'s center is covered by its descendant' do
+      btn = browser.button(id: 'has_descendant')
+      expect(btn).not_to be_obscured
+      expect { btn.click }.not_to raise_exception
+    end
+
+    it 'returns true if element\'s center is covered by a non-descendant' do
+      btn = browser.button(id: 'obscured')
+      expect(btn).to be_obscured
+      not_compliant_on :chrome do
+        expect { btn.click }.to raise_exception(Selenium::WebDriver::Error::ElementClickInterceptedError)
+      end
+      compliant_on :chrome do
+        expect { btn.click }.to raise_exception(Selenium::WebDriver::Error::UnknownError)
+      end
+    end
+
+    it 'returns false if element\'s center is surrounded by non-descendants' do
+      btn = browser.button(id: 'surrounded')
+      expect(btn).not_to be_obscured
+      expect { btn.click }.not_to raise_exception
+    end
+
+    it 'scrolls element into view before checking if obscured' do
+      btn = browser.button(id: 'requires_scrolling')
+      expect(btn).not_to be_obscured
+      expect { btn.click }.not_to raise_exception
+    end
+
+    it 'returns true if element cannot be scrolled into view' do
+      btn = browser.button(id: 'off_screen')
+      expect(btn).to be_obscured
+      expect { btn.click }.to raise_unknown_object_exception
+    end
+
+    it 'returns true if element is hidden' do
+      btn = browser.button(id: 'hidden')
+      expect(btn).to be_obscured
+      expect { btn.click }.to raise_unknown_object_exception
+    end
+
+    it 'raises UnknownObjectException if element does not exist' do
+      expect { browser.button(id: 'does_not_exist').obscured? }.to raise_unknown_object_exception
+    end
+  end
 end

--- a/spec/watirspec/html/obscured.html
+++ b/spec/watirspec/html/obscured.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>Obscured</title>
+  </head>
+  <body>
+    <h1>No Overlap</h1>
+    <button style="height: 100px; width: 100px;" id="not_obscured"></button>
+
+    <h1>Overlap By Descendant</h1>
+    <button style="height: 100px; width: 100px;" id="has_descendant">
+      <div style="height: 90px; width: 90px; background: rgba(0,255,0,.5);">foobar</div>
+    </button>
+
+    <h1>Overlap By Other</h1>
+    <p>
+      <button style="width: 100px; margin: 40px 0;" id="obscured">foobar</button>
+    </p>
+    <div style="position: absolute; height: 100px; width: 100px; background: rgba(255,0,0,.5); margin-left: 40px; margin-top: -120px;"></div>
+
+    <h1>Overlap But Not At Center</h1>
+    <p>
+      <button style="width: 100px; height: 100px;" id="surrounded">foobar</button>
+    </p>
+    <div style="position: absolute; height: 50px; width: 100px; background: rgba(255,0,0,.5); margin-top: -120px;"></div>
+    <div style="position: absolute; height: 50px; width: 100px; background: rgba(255,0,0,.5); margin-top: -60px;"></div>
+    <div style="position: absolute; height: 100px; width: 50px; background: rgba(255,0,0,.5); margin-top: -120px; margin-left: -5px;"></div>
+    <div style="position: absolute; height: 100px; width: 50px; background: rgba(255,0,0,.5); margin-top: -120px;  margin-left: 55px;"></div>
+
+    <button style="position: absolute; width: 0; height: 0; top: -500px; left: -500px; overflow: hidden" id="off_screen">off-screen</button>
+    <button style="display: none;" id="hidden">hidden</button>
+    <button style="position: absolute; top: 5000px;" id="requires_scrolling">requires scrolling</button>
+  </body>
+</html>


### PR DESCRIPTION
Adds a method to check if an element is obscured - ie covered by another element. This allows users to check whether clicking an element will generate an ElementClickInterceptedError (or similar error based on driver).

This means that retrying clicks due to things like temporary overlays, can be changed from:

~~~~~~~~
begin
  browser.link.click
rescue
  retry
end
~~~~~~~~

To:

~~~~~~~~
browser.link.wait_while(&:obscured?).click
~~~~~~~~