### PR TITLE
add support for index by XPath on all elements

### DIFF
--- a/lib/watir/locators/button/selector_builder/xpath.rb
+++ b/lib/watir/locators/button/selector_builder/xpath.rb
@@ -56,10 +56,6 @@ module Watir
             end
           end
 
-          def use_index?
-            false
-          end
-
           def predicate_conversion(key, regexp)
             res = key == :text ? super(:contains_text, regexp) : super
             @requires_matches[key] = @requires_matches.delete(:contains_text) if @requires_matches.key?(:contains_text)

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -135,13 +135,12 @@ module Watir
           end
 
           # TODO: Remove this on refactor of index
-          # rubocop:disable Metrics/CyclomaticComplexity:
           def add_index(xpath, index)
             if @adjacent
               "#{xpath}[#{index + 1}]"
-            elsif index&.positive? && @requires_matches.empty? && use_index?
+            elsif index&.positive? && @requires_matches.empty?
               "(#{xpath})[#{index + 1}]"
-            elsif index&.negative? && @requires_matches.empty? && use_index?
+            elsif index&.negative? && @requires_matches.empty?
               last_value = 'last()'
               last_value << (index + 1).to_s if index < -1
               "(#{xpath})[#{last_value}]"
@@ -149,11 +148,6 @@ module Watir
               @requires_matches[:index] = index
               xpath
             end
-          end
-          # rubocop:enable Metrics/CyclomaticComplexity:
-
-          def use_index?
-            true
           end
 
           def deprecate_class_array(class_name)

--- a/lib/watir/locators/text_field/selector_builder/xpath.rb
+++ b/lib/watir/locators/text_field/selector_builder/xpath.rb
@@ -21,10 +21,6 @@ module Watir
             super
           end
 
-          def use_index?
-            false
-          end
-
           def type_string(type)
             if type.eql?(true)
               "[#{negative_type_text}]"

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -88,7 +88,7 @@
             <label for="new_user_username">Username (max 20 characters)</label>
             <input type="text" name="new_user_username" id="new_user_username" maxlength="20" size="20" onkeyup="document.getElementById('current_length').innerHTML = this.value.length"/> <span id="current_length">0</span><br />
             <label for="new_user_password">Password</label>
-            <input type="password" name="new_user_password" id="new_user_password" /> <br />
+            <input type="password" name="new_user_password" id="new_user_password" data-locator="last text"/> <br />
             <label for="new_user_role">Role</label>
             <select name="new_user_role" id="new_user_role" disabled="disabled">
                 <option>Administrator</option>
@@ -156,7 +156,7 @@
     </form>
 
   <!-- testing popup windows  -->
-  <input type="button" name="new_popup_window" value="Open window" id="new_popup_window" onclick="window.open('tables.html')">
+  <input type="button" name="new_popup_window" value="Open window" id="new_popup_window" data-locator="last button" onclick="window.open('tables.html')">
 
   <!-- used for testing javascript events and styles -->
   <div id="changed_language" style="visibility: hidden;">

--- a/spec/watirspec/html/tables.html
+++ b/spec/watirspec/html/tables.html
@@ -80,7 +80,7 @@
                     Table 1, Row 1, Cell 2
                 </td>
             </tr>
-            <tr id="outer_second">
+            <tr id="outer_second" data-locator="middle row">
                 <td id="t1_r2_c1">
                     Table 1, Row 2, Cell 1
                 </td>
@@ -98,7 +98,7 @@
                     </table>
                 </td>
             </tr>
-            <tr id="outer_last">
+            <tr id="outer_last" data-locator="last row">
                 <td>
                     Table 1, Row 3, Cell 1
                 </td>

--- a/spec/watirspec/selector_builder/button_spec.rb
+++ b/spec/watirspec/selector_builder/button_spec.rb
@@ -175,6 +175,44 @@ describe Watir::Locators::Button::SelectorBuilder do
       end
     end
 
+    context 'with index' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'positive' do
+        @selector = {index: 3}
+        @wd_locator = {xpath: "(.//*[(local-name()='button') or (local-name()='input' and (#{default_types}))])[4]"}
+        @data_locator = 'preview'
+      end
+
+      it 'negative' do
+        @selector = {index: -4}
+        @wd_locator = {xpath: "(.//*[(local-name()='button') or " \
+"(local-name()='input' and (#{default_types}))])[last()-3]"}
+        @data_locator = 'submittable button'
+      end
+
+      it 'last' do
+        @selector = {index: -1}
+        @wd_locator = {xpath: "(.//*[(local-name()='button') or " \
+"(local-name()='input' and (#{default_types}))])[last()]"}
+        @data_locator = 'last button'
+      end
+
+      it 'does not return index if it is zero' do
+        @selector = {index: 0}
+        @wd_locator = {xpath: ".//*[(local-name()='button') or (local-name()='input' and (#{default_types}))]"}
+        @data_locator = 'user submit'
+      end
+
+      it 'raises exception when index is not an Integer', skip_after: true do
+        selector = {index: 'foo'}
+        msg = 'expected Integer, got "foo":String'
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+    end
+
     context 'with multiple locators' do
       before(:each) do
         browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))

--- a/spec/watirspec/selector_builder/cell_spec.rb
+++ b/spec/watirspec/selector_builder/cell_spec.rb
@@ -33,6 +33,42 @@ describe Watir::Locators::Cell::SelectorBuilder do
       @data_locator = 'first cell'
     end
 
+    context 'with index' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('tables.html'))
+      end
+
+      it 'positive' do
+        @selector = {index: 3}
+        @wd_locator = {xpath: "(./*[local-name()='th' or local-name()='td'])[4]"}
+        @data_locator = 'after tax'
+      end
+
+      it 'negative' do
+        @selector = {index: -3}
+        @wd_locator = {xpath: "(./*[local-name()='th' or local-name()='td'])[last()-2]"}
+        @data_locator = 'before tax'
+      end
+
+      it 'last' do
+        @selector = {index: -1}
+        @wd_locator = {xpath: "(./*[local-name()='th' or local-name()='td'])[last()]"}
+        @data_locator = 'after tax'
+      end
+
+      it 'does not return index if it is zero' do
+        @selector = {index: 0}
+        @wd_locator = {xpath: "./*[local-name()='th' or local-name()='td']"}
+        @data_locator = 'first cell'
+      end
+
+      it 'raises exception when index is not an Integer', skip_after: true do
+        selector = {index: 'foo'}
+        msg = 'expected Integer, got "foo":String'
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+    end
+
     context 'with multiple locators' do
       before(:each) do
         browser.goto(WatirSpec.url_for('tables.html'))

--- a/spec/watirspec/selector_builder/row_spec.rb
+++ b/spec/watirspec/selector_builder/row_spec.rb
@@ -61,6 +61,51 @@ describe Watir::Locators::Row::SelectorBuilder do
       end
     end
 
+    context 'with index' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('tables.html'))
+      end
+
+      it 'positive' do
+        @query_scope = browser.element(id: 'outer').locate
+        @selector = {index: 1}
+        @wd_locator = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+"./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[2]"}
+        @data_locator = 'middle row'
+      end
+
+      it 'negative' do
+        @query_scope = browser.element(id: 'outer').locate
+        @selector = {index: -3}
+        @wd_locator = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+"./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[last()-2]"}
+        @data_locator = 'first row'
+      end
+
+      it 'last' do
+        @query_scope = browser.element(id: 'outer').locate
+        @selector = {index: -1}
+        @wd_locator = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+"./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[last()]"}
+        @data_locator = 'last row'
+      end
+
+      it 'does not return index if it is zero' do
+        @query_scope = browser.element(id: 'outer').locate
+        @selector = {index: 0}
+        @wd_locator = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+"./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']"}
+        @data_locator = 'first row'
+      end
+
+      it 'raises exception when index is not an Integer', skip_after: true do
+        @query_scope = browser.element(id: 'outer').locate
+        selector = {index: 'foo'}
+        msg = 'expected Integer, got "foo":String'
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+    end
+
     context 'with multiple locators' do
       before(:each) do
         browser.goto(WatirSpec.url_for('tables.html'))

--- a/spec/watirspec/selector_builder/text_spec.rb
+++ b/spec/watirspec/selector_builder/text_spec.rb
@@ -85,6 +85,42 @@ describe Watir::Locators::TextField::SelectorBuilder do
       end
     end
 
+    context 'with index' do
+      before(:each) do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      end
+
+      it 'positive' do
+        @selector = {index: 4}
+        @wd_locator = {xpath: "(.//*[local-name()='input'][not(@type) or (#{negative_types})])[5]"}
+        @data_locator = 'dev'
+      end
+
+      it 'negative' do
+        @selector = {index: -3}
+        @wd_locator = {xpath: "(.//*[local-name()='input'][not(@type) or (#{negative_types})])[last()-2]"}
+        @data_locator = '42'
+      end
+
+      it 'last' do
+        @selector = {index: -1}
+        @wd_locator = {xpath: "(.//*[local-name()='input'][not(@type) or (#{negative_types})])[last()]"}
+        @data_locator = 'last text'
+      end
+
+      it 'does not return index if it is zero' do
+        @selector = {index: 0}
+        @wd_locator = {xpath: ".//*[local-name()='input'][not(@type) or (#{negative_types})]"}
+        @data_locator = 'input name'
+      end
+
+      it 'raises exception when index is not an Integer', skip_after: true do
+        selector = {index: 'foo'}
+        msg = 'expected Integer, got "foo":String'
+        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+      end
+    end
+
     context 'with text' do
       before(:each) { browser.goto(WatirSpec.url_for('forms_with_input_elements.html')) }
 


### PR DESCRIPTION
removes the `#use_index` methods and allows all XPath subclasses to leverage indexing by XPath.

(FYI this code is dependent on #807 which hasn't yet been merged, so this PR is based off of a branch with that commit, not master)