### PR TITLE
improve type check with constant instead of multiple conditionals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,10 @@ Lint/HandleExceptions:
   Exclude:
     - 'lib/watirspec.rb'
 
+Lint/UnifiedInteger:
+  Exclude:
+  - 'lib/watir/locators/element/selector_builder.rb'
+
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ script: bundle exec rake $RAKE_TASK
 _version:
   three: &three
     language: ruby
-    rvm: 2.3.7
+    rvm: 2.3.8
   four: &four
     language: ruby
-    rvm: 2.4.4
+    rvm: 2.4.5
   five: &five
     language: ruby
-    rvm: 2.5.1
+    rvm: 2.5.3
 
 _browsers:
   firefox: &firefox-latest

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -403,8 +403,8 @@ describe Watir::Locators::Element::Locator do
 
     describe 'errors' do
       it 'raises a TypeError if :index is not a Integer' do
-        expect { locate_one(tag_name: 'div', index: 'bar') }.to \
-          raise_error(TypeError, %(expected Integer, got "bar":String))
+        msg = /expected one of \[(Integer|Fixnum)\], got "bar":String/
+        expect { locate_one(tag_name: 'div', index: 'bar') }.to raise_error TypeError, msg
       end
 
       it 'raises a TypeError if selector value is not a String, Regexp or Boolean' do

--- a/spec/watirspec/element_hidden_spec.rb
+++ b/spec/watirspec/element_hidden_spec.rb
@@ -72,7 +72,7 @@ describe Watir::Locators::Element::Locator do
 
     it 'raises exception when value is not Boolean' do
       element = browser.body.element(visible: 'true')
-      msg = 'expected boolean, got "true":String'
+      msg = 'expected one of [TrueClass, FalseClass], got "true":String'
       expect { element.exists? }.to raise_exception(TypeError, msg)
     end
   end

--- a/spec/watirspec/elements/dl_spec.rb
+++ b/spec/watirspec/elements/dl_spec.rb
@@ -113,9 +113,9 @@ describe 'Dl' do
   describe '#to_hash' do
     it 'converts the dl to a Hash' do
       expect(browser.dl(id: 'experience-list').to_hash).to eq Hash[
-        'Experience'                   => '11 years',
-        'Education'                    => 'Master',
-        'Current industry'             => 'Architecture',
+        'Experience' => '11 years',
+        'Education' => 'Master',
+        'Current industry' => 'Architecture',
         'Previous industry experience' => 'Architecture'
       ]
     end

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -100,7 +100,7 @@ describe 'Element' do
 
     it 'raises exception unless value is a String or a RegExp' do
       browser.goto WatirSpec.url_for('non_control_elements.html')
-      msg = /expected string_or_regexp, got 7\:(Fixnum|Integer)/
+      msg = /expected one of \[String, Regexp\], got 7\:(Fixnum|Integer)/
       expect { browser.element(visible_text: 7).exists? }.to raise_exception(TypeError, msg)
     end
 

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -168,7 +168,7 @@ describe 'Link' do
 
     it 'raises exception unless value is a String or a RegExp' do
       browser.goto WatirSpec.url_for('non_control_elements.html')
-      msg = /expected string_or_regexp, got 7\:(Fixnum|Integer)/
+      msg = /expected one of \[String, Regexp\], got 7\:(Fixnum|Integer)/
       expect { browser.link(visible_text: 7).exists? }.to raise_exception(TypeError, msg)
     end
   end

--- a/spec/watirspec/selector_builder/button_spec.rb
+++ b/spec/watirspec/selector_builder/button_spec.rb
@@ -224,7 +224,7 @@ describe Watir::Locators::Button::SelectorBuilder do
 
       it 'raises exception when index is not an Integer', skip_after: true do
         selector = {index: 'foo'}
-        msg = 'expected Integer, got "foo":String'
+        msg = /expected one of \[(Integer|Fixnum)\], got "foo":String/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
     end

--- a/spec/watirspec/selector_builder/cell_spec.rb
+++ b/spec/watirspec/selector_builder/cell_spec.rb
@@ -64,7 +64,7 @@ describe Watir::Locators::Cell::SelectorBuilder do
 
       it 'raises exception when index is not an Integer', skip_after: true do
         selector = {index: 'foo'}
-        msg = 'expected Integer, got "foo":String'
+        msg = /expected one of \[(Integer|Fixnum)\], got "foo":String/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
     end

--- a/spec/watirspec/selector_builder/element_spec.rb
+++ b/spec/watirspec/selector_builder/element_spec.rb
@@ -68,7 +68,7 @@ describe Watir::Locators::Element::SelectorBuilder do
 
       it 'raises exception when not a String', skip_after: true do
         selector = {xpath: 7}
-        msg = /expected String, got 7:(Fixnum|Integer)/
+        msg = /expected one of \[String\], got 7:(Fixnum|Integer)/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
 
@@ -114,7 +114,7 @@ describe Watir::Locators::Element::SelectorBuilder do
 
       it 'raises exception when not a String or Regexp', skip_after: true do
         selector = {tag_name: 7}
-        msg = /expected string_or_regexp_or_symbol, got 7:(Fixnum|Integer)/
+        msg = /expected one of \[String, Regexp, Symbol\], got 7:(Fixnum|Integer)/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
     end
@@ -195,7 +195,7 @@ describe Watir::Locators::Element::SelectorBuilder do
 
       it 'raises exception when Array values are not a String or Regexp', skip_after: true do
         selector = {class: [7]}
-        msg = /expected string_or_regexp, got 7:(Fixnum|Integer)/
+        msg = /expected one of \[String, Regexp, TrueClass, FalseClass\], got 7:(Fixnum|Integer)/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
 
@@ -304,7 +304,7 @@ describe Watir::Locators::Element::SelectorBuilder do
 
       it 'raises exception when text is not a String or Regexp', skip_after: true do
         selector = {text: 7}
-        msg = /expected string_or_regexp, got 7:(Fixnum|Integer)/
+        msg = /expected one of \[String, Regexp\], got 7:(Fixnum|Integer)/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
     end
@@ -339,7 +339,7 @@ describe Watir::Locators::Element::SelectorBuilder do
 
       it 'raises exception when index is not an Integer', skip_after: true do
         selector = {index: 'foo'}
-        msg = 'expected Integer, got "foo":String'
+        msg = /expected one of \[(Integer|Fixnum)\], got "foo":String/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
     end
@@ -372,7 +372,7 @@ describe Watir::Locators::Element::SelectorBuilder do
 
       it 'raises exception when not a Symbol', skip_after: true do
         selector = {adjacent: 'foo', index: 0}
-        msg = 'expected Symbol, got "foo":String'
+        msg = 'expected one of [Symbol], got "foo":String'
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
 
@@ -625,13 +625,13 @@ describe Watir::Locators::Element::SelectorBuilder do
 
       it 'raises exception when visible is not boolean', skip_after: true do
         selector = {visible: 'foo'}
-        msg = 'expected boolean, got "foo":String'
+        msg = 'expected one of [TrueClass, FalseClass], got "foo":String'
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
 
       it 'raises exception when visible text is not a String or Regexp', skip_after: true do
         selector = {visible_text: 7}
-        msg = /expected string_or_regexp, got 7:(Fixnum|Integer)/
+        msg = /expected one of \[String, Regexp\], got 7:(Fixnum|Integer)/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
     end

--- a/spec/watirspec/selector_builder/row_spec.rb
+++ b/spec/watirspec/selector_builder/row_spec.rb
@@ -101,7 +101,7 @@ describe Watir::Locators::Row::SelectorBuilder do
       it 'raises exception when index is not an Integer', skip_after: true do
         @query_scope = browser.element(id: 'outer').locate
         selector = {index: 'foo'}
-        msg = 'expected Integer, got "foo":String'
+        msg = /expected one of \[(Integer|Fixnum)\], got "foo":String/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
     end

--- a/spec/watirspec/selector_builder/text_spec.rb
+++ b/spec/watirspec/selector_builder/text_spec.rb
@@ -118,7 +118,7 @@ describe Watir::Locators::TextField::SelectorBuilder do
 
       it 'raises exception when index is not an Integer', skip_after: true do
         selector = {index: 'foo'}
-        msg = 'expected Integer, got "foo":String'
+        msg = /expected one of \[(Integer|Fixnum)\], got "foo":String/
         expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
       end
     end


### PR DESCRIPTION
This uses a Hash instead of a Case Statement. 
Also improves error messages, in my opinion.
Fixnum/Integer stuff can get removed when we deprecate 2.3

Also threw in update to run on latest Ruby point releases on Travis.