### PR TITLE
Nested elements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,7 @@ Metrics/AbcSize:
     - 'lib/watir/locators/element/locator.rb'
     - 'lib/watir/generator/base/generator.rb'
     - 'lib/watir/generator/base/visitor.rb'
+    - 'spec/locator_spec_helper.rb'
 
 # TODO: fix with Watir 7
 # Configuration parameters: CountKeywordArgs.

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -155,11 +155,10 @@ module Watir
 
     def elements
       ensure_context
-      if @query_scope.is_a?(Browser)
-        locate_all
-      else
-        # This gives all of the standard Watir waiting behaviors to Collections
+      if selector_builder.built.key?(:scope)
         @query_scope.send(:element_call) { locate_all }
+      else
+        locate_all
       end
     end
 

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -797,7 +797,7 @@ module Watir
 
       begin
         check_condition(precondition, caller)
-        Watir.logger.info "-> `Executing #{inspect}##{caller}`"
+        Watir.logger.debug "-> `Executing #{inspect}##{caller}`"
         yield
       rescue unknown_exception => ex
         element_call(:wait_for_exists, &block) if precondition.nil?
@@ -822,7 +822,7 @@ module Watir
       rescue Selenium::WebDriver::Error::NoSuchWindowError
         raise NoMatchingWindowFoundException, 'browser window was closed'
       ensure
-        Watir.logger.info "<- `Completed #{inspect}##{caller}`"
+        Watir.logger.debug "<- `Completed #{inspect}##{caller}`"
         Wait.timer.reset! unless already_locked
       end
     end
@@ -832,14 +832,14 @@ module Watir
     # rubocop:enable Metrics/CyclomaticComplexity:
 
     def check_condition(condition, caller)
-      Watir.logger.info "<- `Verifying precondition #{inspect}##{condition} for #{caller}`"
+      Watir.logger.debug "<- `Verifying precondition #{inspect}##{condition} for #{caller}`"
       begin
         condition.nil? ? assert_exists : send(condition)
-        Watir.logger.info "<- `Verified precondition #{inspect}##{condition || 'assert_exists'}`"
+        Watir.logger.debug "<- `Verified precondition #{inspect}##{condition || 'assert_exists'}`"
       rescue unknown_exception
         raise unless condition.nil?
 
-        Watir.logger.info "<- `Unable to satisfy precondition #{inspect}##{condition}`"
+        Watir.logger.debug "<- `Unable to satisfy precondition #{inspect}##{condition}`"
         check_condition(:wait_for_exists, caller)
       end
     end

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -218,6 +218,7 @@ module Watir
       raise_no_value_found(str_or_rx)
     end
 
+    # TODO: Consider locating the Select List before throwing the exception
     def raise_no_value_found(str_or_rx)
       raise NoValueFoundException, "#{str_or_rx.inspect} not found in #{inspect}"
     end

--- a/lib/watir/locators/cell/selector_builder.rb
+++ b/lib/watir/locators/cell/selector_builder.rb
@@ -2,6 +2,9 @@ module Watir
   module Locators
     class Cell
       class SelectorBuilder < Element::SelectorBuilder
+        def use_scope?
+          false
+        end
       end
     end
   end

--- a/lib/watir/locators/element/matcher.rb
+++ b/lib/watir/locators/element/matcher.rb
@@ -41,15 +41,13 @@ module Watir
         def matching_elements(elements, values_to_match, filter: :first)
           if filter == :first
             idx = element_index(elements, values_to_match)
-            counter = 0
 
             # Lazy evaluation to avoid fetching values for elements that will be discarded
             matches = elements.lazy.select do |el|
-              counter += 1
               elements_match?(el, values_to_match)
             end
-            msg = "iterated through #{counter} elements to locate #{@selector.inspect}"
-            matches.take(idx + 1).to_a[idx].tap { Watir.logger.debug msg }
+            Watir.logger.debug "Iterating through #{elements.size} elements to locate #{@selector.inspect}"
+            matches.take(idx + 1).to_a[idx]
           else
             Watir.logger.debug "Iterating through #{elements.size} elements to locate all #{@selector.inspect}"
             elements.select { |el| elements_match?(el, values_to_match) }

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -32,7 +32,7 @@ module Watir
           @built = wd_locator(@selector.keys).nil? ? build_wd_selector(@selector) : @selector
           @built.delete(:index) if @built[:index]&.zero?
 
-          Watir.logger.debug "Converted #{inspected} to #{@built.inspect}"
+          Watir.logger.info "Converted #{inspected} to #{@built.inspect}"
           @built
         end
 

--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -17,6 +17,7 @@ module Watir
 
             index = @selector.delete(:index)
             @adjacent = @selector.delete(:adjacent)
+            @scope = @selector.delete(:scope)
 
             xpath = start_string
             xpath << adjacent_string
@@ -75,7 +76,8 @@ module Watir
           end
 
           def start_string
-            @adjacent ? './' : './/*'
+            start = @adjacent ? './' : './/*'
+            @scope ? "(#{@scope[:xpath]})[1]#{start.tr('.', '')}" : start
           end
 
           def adjacent_string

--- a/lib/watir/locators/row/selector_builder.rb
+++ b/lib/watir/locators/row/selector_builder.rb
@@ -6,6 +6,10 @@ module Watir
           scope_tag_name = @query_scope.selector[:tag_name] || @query_scope.tag_name
           Kernel.const_get("#{self.class.name}::XPath").new.build(selector, scope_tag_name)
         end
+
+        def use_scope?
+          false
+        end
       end
     end
   end

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -2,6 +2,7 @@ module LocatorSpecHelper
   def browser
     @browser ||= instance_double(Watir::Browser, wd: driver)
     allow(@browser).to receive(:browser).and_return(@browser)
+    allow(@browser).to receive(:is_a?).with(Watir::Browser).and_return(true)
     allow(@browser).to receive(:locator_namespace).and_return(@locator_namespace || Watir::Locators)
     @browser
   end
@@ -11,12 +12,18 @@ module LocatorSpecHelper
   end
 
   def selector_builder
-    return @selector_builder if @selector_builder
-
-    @locator ||= {xpath: ''}
+    @built ||= {xpath: ''}
     @selector_builder = instance_double(Watir::Locators::Element::SelectorBuilder)
-    allow(@selector_builder).to receive(:built).and_return(@locator)
+    allow(@selector_builder).to receive(:build).and_return(@built)
     @selector_builder
+  end
+
+  def attributes
+    @attributes ||=  Watir::HTMLElement.attribute_list
+  end
+
+  def query_scope
+    @query_scope ||= browser
   end
 
   def element_matcher
@@ -40,12 +47,16 @@ module LocatorSpecHelper
 
   def locate_one(selector = nil)
     selector ||= @locator || {}
-    locator.locate(ordered_hash(selector))
+    locator.locate ordered_hash(selector)
   end
 
   def locate_all(selector = nil)
     selector ||= @locator || {}
-    locator.locate_all(ordered_hash(selector))
+    locator.locate_all ordered_hash(selector)
+  end
+
+  def selector_build(selector)
+    selector_builder.build(selector)
   end
 
   def element(opts = {})
@@ -55,7 +66,9 @@ module LocatorSpecHelper
     el = instance_double(klass, opts)
 
     allow(el).to receive(:enabled?).and_return true
+    allow(el).to receive(:selector_builder).and_return(selector_builder)
     allow(el).to receive(:wd).and_return wd_element unless opts.key?(:wd)
+    allow(el).to receive(:selector).and_return(@selector || {})
     el
   end
 

--- a/spec/unit/selector_builder/anchor_spec.rb
+++ b/spec/unit/selector_builder/anchor_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../unit_helper'
 
 describe Watir::Locators::Anchor::SelectorBuilder do
-  let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:query_scope) { double Watir::Browser }
+  include LocatorSpecHelper
+
   let(:selector_builder) { described_class.new(attributes, query_scope) }
 
   describe '#build' do

--- a/spec/unit/selector_builder/button_spec.rb
+++ b/spec/unit/selector_builder/button_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../unit_helper'
 
 describe Watir::Locators::Button::SelectorBuilder do
-  let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:query_scope) { double Watir::Browser }
+  include LocatorSpecHelper
+
   let(:selector_builder) { described_class.new(attributes, query_scope) }
   let(:uppercase) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸŽŠŒ' }
   let(:lowercase) { 'abcdefghijklmnopqrstuvwxyzàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿžšœ' }

--- a/spec/unit/selector_builder/cell_spec.rb
+++ b/spec/unit/selector_builder/cell_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../unit_helper'
 
 describe Watir::Locators::Cell::SelectorBuilder do
-  let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:query_scope) { double Watir::Browser }
+  include LocatorSpecHelper
+
   let(:selector_builder) { described_class.new(attributes, query_scope) }
 
   describe '#build' do

--- a/spec/unit/selector_builder/row_spec.rb
+++ b/spec/unit/selector_builder/row_spec.rb
@@ -1,118 +1,109 @@
 require_relative '../unit_helper'
 
 describe Watir::Locators::Row::SelectorBuilder do
-  let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:query_scope) { double Watir::HTMLElement }
-  let(:selector_builder) { described_class.new(attributes, query_scope) }
+  include LocatorSpecHelper
+
+  let(:row_selector_builder) { described_class.new(attributes, query_scope) }
+  let(:selector_built) { row_selector_builder.build(selector).reject { |key| key == :scope } }
+  let(:selector) { @selector || {} }
 
   describe '#build' do
-    before do
-      allow(query_scope).to receive(:selector).and_return({})
-    end
-
     context 'with query scopes' do
       it 'with only table query scope' do
-        @scope_tag_name = 'table'
-        allow(query_scope).to receive(:tag_name).and_return(@scope_tag_name)
-        selector = {}
+        @query_scope = element(tag_name: 'table')
+
         built = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']"}
 
-        expect(selector_builder.build(selector)).to eq built
+        expect(selector_built).to eq built
       end
 
       it 'with tbody query scope' do
-        @scope_tag_name = 'tbody'
-        allow(query_scope).to receive(:tag_name).and_return(@scope_tag_name)
-        selector = {}
+        @query_scope = element(tag_name: 'tbody')
         built = {xpath: "./*[local-name()='tr']"}
 
-        expect(selector_builder.build(selector)).to eq built
+        expect(selector_built).to eq built
       end
 
       it 'with thead query scope' do
-        @scope_tag_name = 'thead'
-        allow(query_scope).to receive(:tag_name).and_return(@scope_tag_name)
-        selector = {}
+        @query_scope = element(tag_name: 'thead')
         built = {xpath: "./*[local-name()='tr']"}
 
-        expect(selector_builder.build(selector)).to eq built
+        expect(selector_built).to eq built
       end
 
       it 'with tfoot query scope' do
-        @scope_tag_name = 'tfoot'
-        allow(query_scope).to receive(:tag_name).and_return(@scope_tag_name)
-        selector = {}
+        @query_scope = element(tag_name: 'tfoot')
         built = {xpath: "./*[local-name()='tr']"}
 
-        expect(selector_builder.build(selector)).to eq built
+        expect(selector_built).to eq built
       end
     end
 
     context 'when tag name is specified' do
       before do
-        allow(query_scope).to receive(:tag_name).and_return('table')
+        @query_scope = element(tag_name: 'table')
       end
 
       context 'with index' do
         it 'positive' do
-          selector = {index: 1}
+          @selector = {index: 1}
           built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[2]"}
 
-          expect(selector_builder.build(selector)).to eq built
+          expect(selector_built).to eq built
         end
 
         it 'negative' do
-          selector = {index: -3}
+          @selector = {index: -3}
           built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[last()-2]"}
 
-          expect(selector_builder.build(selector)).to eq built
+          expect(selector_built).to eq built
         end
 
         it 'last' do
-          selector = {index: -1}
+          @selector = {index: -1}
           built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[last()]"}
 
-          expect(selector_builder.build(selector)).to eq built
+          expect(selector_built).to eq built
         end
 
         it 'does not return index if it is zero' do
-          selector = {index: 0}
+          @selector = {index: 0}
           built = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']"}
 
-          expect(selector_builder.build(selector)).to eq built
+          expect(selector_built).to eq built
         end
 
         it 'raises exception when index is not an Integer', skip_after: true do
-          selector = {index: 'foo'}
+          @selector = {index: 'foo'}
           msg = /expected one of \[(Integer|Fixnum)\], got "foo":String/
-          expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+          expect { selector_built }.to raise_exception TypeError, msg
         end
       end
 
       context 'with multiple locators' do
         it 'attribute and class' do
-          selector = {id: 'gregory', class: /brick/}
+          @selector = {id: 'gregory', class: /brick/}
           built = {xpath: "./*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
 "./*[local-name()='tbody']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
 "./*[local-name()='tfoot']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory']"}
 
-          expect(selector_builder.build(selector)).to eq built
+          expect(selector_built).to eq built
         end
       end
 
       context 'returns locators that can not be directly translated' do
         it 'any text value' do
-          selector = {text: 'Gregory'}
+          @selector = {text: 'Gregory'}
           built = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']", text: 'Gregory'}
 
-          expect(selector_builder.build(selector)).to eq built
+          expect(selector_built).to eq built
         end
       end
     end

--- a/spec/unit/selector_builder/text_field_spec.rb
+++ b/spec/unit/selector_builder/text_field_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../unit_helper'
 
 describe Watir::Locators::TextField::SelectorBuilder do
-  let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:query_scope) { double Watir::Browser }
+  include LocatorSpecHelper
+
   let(:selector_builder) { described_class.new(attributes, query_scope) }
   let(:uppercase) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸŽŠŒ' }
   let(:lowercase) { 'abcdefghijklmnopqrstuvwxyzàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿžšœ' }

--- a/spec/unit/selector_builder/textarea_spec.rb
+++ b/spec/unit/selector_builder/textarea_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../unit_helper'
 
 describe Watir::Locators::TextArea::SelectorBuilder do
-  let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:query_scope) { double Watir::Browser }
+  include LocatorSpecHelper
+
   let(:selector_builder) { described_class.new(attributes, query_scope) }
 
   describe '#build' do

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -346,7 +346,7 @@ describe 'SelectList' do
     end
 
     it "raises NoValueFoundException if the option doesn't exist" do
-      message = /#<Watir::Select: located: true; {:name=>"new_user_country", :tag_name=>"select"}>/
+      message = /#<Watir::Select: located: false; {:name=>"new_user_country", :tag_name=>"select"}>/
       expect { browser.select_list(name: 'new_user_country').select('missing_option') }
         .to raise_no_value_found_exception message
       expect { browser.select_list(name: 'new_user_country').select(/missing_option/) }

--- a/spec/watirspec/relaxed_locate_spec.rb
+++ b/spec/watirspec/relaxed_locate_spec.rb
@@ -77,7 +77,7 @@ describe 'Watir#relaxed_locate?' do
       end
 
       it 'waits for parent element to be present before locating a collection' do
-        els = browser.element(id: 'not_there').elements(id: 'doesnt_matter')
+        els = browser.element(id: /not|there/).elements(id: 'doesnt_matter')
         expect { els.to_a }.to wait_and_raise_unknown_object_exception
       end
     end


### PR DESCRIPTION
Ok, so this is where things start getting interesting...

`#cache=` is supposed to allow for distinguishing between
1. > This element is defined as a wrapping of a Selenium Element and can not be relocated
2. > This element can be relocated by the provided Selector, but the Selenium Element is already located, so we add it as cached.

This PR builds the selector when Element is initialized rather than when it is located.
This allows us to determine on initialization if a single XPath can be created for nested elements, and allows us to bypass recursion during location.