### PR TITLE
Separate Selector Builder

### DIFF
--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -10,6 +10,8 @@ module Watir
     def initialize(query_scope, selector)
       @query_scope = query_scope
       @selector = selector
+
+      build
     end
 
     #
@@ -32,6 +34,10 @@ module Watir
     alias size count
 
     alias empty? none?
+
+    def build
+      build_locator.build
+    end
 
     #
     # Get the element at the given index or range.

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -96,11 +96,10 @@ module Watir
           selector = @selector.dup
           selector[:index] = idx unless idx.zero?
           element = element_class.new(@query_scope, selector)
-          element.cache = el
           if [HTMLElement, Input].include? element.class
-            construct_subtype(element, hash)
+            construct_subtype(element, hash).tap { |e| e.cache = el }
           else
-            element
+            element.tap { |e| e.cache = el }
           end
         end
     end
@@ -170,7 +169,7 @@ module Watir
     end
 
     def locate_all
-      build_locator.locate_all
+      locator.locate_all(selector_builder.built)
     end
 
     def element_class

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -11,7 +11,7 @@ module Watir
       @query_scope = query_scope
       @selector = selector
 
-      build
+      build unless @selector.key?(:element)
     end
 
     #
@@ -36,14 +36,14 @@ module Watir
     alias empty? none?
 
     def build
-      build_locator.build
+      selector_builder.build(@selector.dup)
     end
 
     #
     # Get the element at the given index or range.
     #
-    # Any call to an ElementCollection including an adjacent selector
-    # can not be lazy loaded because it must store correct type
+    # Any call to an ElementCollection that includes an adjacent selector
+    # can not be lazy loaded because it must store the correct type
     #
     # Ranges can not be lazy loaded
     #

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -737,7 +737,7 @@ module Watir
     end
 
     def locate_in_context
-      @element = build_locator.locate
+      @element = locator.locate(selector_builder.built)
     end
 
     private

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -15,7 +15,7 @@ module Watir
     include Locators::ClassHelpers
 
     attr_accessor :keyword
-    attr_reader :selector, :locator
+    attr_reader :selector
 
     #
     # temporarily add :id and :class_name manually since they're no longer specified in the HTML spec.
@@ -617,7 +617,7 @@ module Watir
     #
 
     def build
-      build_locator.build
+      selector_builder.build(@selector.dup)
     end
 
     #
@@ -803,7 +803,7 @@ module Watir
         element_call(:wait_for_exists, &block) if precondition.nil?
         msg = ex.message
         msg += '; Maybe look in an iframe?' if @query_scope.iframe.exists?
-        custom_attributes = @locator.nil? ? [] : @locator.selector_builder.custom_attributes
+        custom_attributes = @locator.nil? ? [] : selector_builder.custom_attributes
         unless custom_attributes.empty?
           msg += "; Watir treated #{custom_attributes} as a non-HTML compliant attribute, ensure that was intended"
         end

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -15,7 +15,7 @@ module Watir
     include Locators::ClassHelpers
 
     attr_accessor :keyword
-    attr_reader :selector
+    attr_reader :selector, :locator
 
     #
     # temporarily add :id and :class_name manually since they're no longer specified in the HTML spec.
@@ -40,6 +40,8 @@ module Watir
       end
 
       @selector = selector
+
+      build unless @element
     end
 
     #
@@ -613,6 +615,14 @@ module Watir
     #
     # @api private
     #
+
+    def build
+      build_locator.build
+    end
+
+    #
+    # @api private
+    #
     # Returns true if element has been previously located.
     #
     # @return [Boolean]
@@ -727,8 +737,7 @@ module Watir
     end
 
     def locate_in_context
-      @locator = build_locator
-      @element = @locator.locate
+      @element = build_locator.locate
     end
 
     private

--- a/lib/watir/elements/radio.rb
+++ b/lib/watir/elements/radio.rb
@@ -1,8 +1,8 @@
 module Watir
   class Radio < Input
-    def initialize(query_scope, selector)
-      super
+    def build
       @selector[:label] = @selector.delete(:text) if @selector.key?(:text)
+      super
     end
 
     #

--- a/lib/watir/elements/radio.rb
+++ b/lib/watir/elements/radio.rb
@@ -51,6 +51,11 @@ module Watir
   class RadioCollection < InputCollection
     private
 
+    def build
+      @selector[:label] = @selector.delete(:text) if @selector.key?(:text)
+      super
+    end
+
     def element_class
       Radio
     end

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -64,18 +64,20 @@ module Watir
         element_class.to_s.split('::').last
       end
 
-      def build_locator
-        return @locator if @locator
-
+      def selector_builder
+        return @selector_builder if @selector_builder
         args = [element_class.attribute_list]
         if element_class == Watir::Row
           scope_tag_name = @query_scope.selector[:tag_name] || @query_scope.tag_name
           args << scope_tag_name
         end
-        selector_builder = selector_builder_class.new(*args)
 
-        element_matcher = element_matcher_class.new(@query_scope, @selector.dup)
-        @locator = locator_class.new(@query_scope, @selector.dup, selector_builder, element_matcher)
+        @selector_builder = selector_builder_class.new(*args)
+      end
+
+      def build_locator
+        @element_matcher ||= element_matcher_class.new(@query_scope, @selector.dup)
+        @locator ||= locator_class.new(@query_scope, @selector.dup, selector_builder, @element_matcher)
       end
     end
   end

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -65,19 +65,12 @@ module Watir
       end
 
       def selector_builder
-        return @selector_builder if @selector_builder
-        args = [element_class.attribute_list]
-        if element_class == Watir::Row
-          scope_tag_name = @query_scope.selector[:tag_name] || @query_scope.tag_name
-          args << scope_tag_name
-        end
-
-        @selector_builder = selector_builder_class.new(*args)
+        @selector_builder ||= selector_builder_class.new(element_class.attribute_list, @query_scope)
       end
 
-      def build_locator
+      def locator
         @element_matcher ||= element_matcher_class.new(@query_scope, @selector.dup)
-        @locator ||= locator_class.new(@query_scope, @selector.dup, selector_builder, @element_matcher)
+        @locator ||= locator_class.new(@element_matcher)
       end
     end
   end

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -59,14 +59,17 @@ module Watir
       end
 
       def build_locator
-        selector_builder = if element_class == Watir::Row
-                             scope_tag_name = @query_scope.selector[:tag_name]
-                             selector_builder_class.new(element_class.attribute_list, scope_tag_name)
-                           else
-                             selector_builder_class.new(element_class.attribute_list)
-                           end
+        return @locator if @locator
+
+        args = [element_class.attribute_list]
+        if element_class == Watir::Row
+          scope_tag_name = @query_scope.selector[:tag_name] || @query_scope.tag_name
+          args << scope_tag_name
+        end
+        selector_builder = selector_builder_class.new(*args)
+
         element_matcher = element_matcher_class.new(@query_scope, @selector.dup)
-        locator_class.new(@query_scope, @selector.dup, selector_builder, element_matcher)
+        @locator = locator_class.new(@query_scope, @selector.dup, selector_builder, element_matcher)
       end
     end
   end

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -26,6 +26,12 @@ require 'watir/locators/text_field/matcher'
 
 module Watir
   module Locators
+    W3C_FINDERS = %i[css
+                     link
+                     link_text
+                     partial_link_text
+                     xpath].freeze
+
     module ClassHelpers
       def locator_class
         class_from_string("#{browser.locator_namespace}::#{element_class_name}::Locator") ||

--- a/lib/watir/locators/element/locator.rb
+++ b/lib/watir/locators/element/locator.rb
@@ -4,20 +4,13 @@ module Watir
       class Locator
         include Exception
 
-        attr_reader :selector_builder, :element_matcher, :built
+        attr_reader :selector_builder, :element_matcher
 
         def initialize(query_scope, selector, selector_builder, element_matcher)
           @query_scope = query_scope
           @selector = selector
           @selector_builder = selector_builder
           @element_matcher = element_matcher
-        end
-
-        def build
-          return if @selector.key?(:element)
-          return @built if @built
-
-          @built = selector_builder.build(@selector.dup)
         end
 
         def locate
@@ -36,8 +29,7 @@ module Watir
 
         def matching_elements(filter = :first)
           return @selector[:element] if @selector.key?(:element)
-
-          build
+          built = selector_builder.built
 
           return locate_element(*built.to_a.flatten, @query_scope.wd) if built.size == 1 && filter == :first
 

--- a/lib/watir/locators/element/matcher.rb
+++ b/lib/watir/locators/element/matcher.rb
@@ -4,7 +4,9 @@ module Watir
       class Matcher
         include Exception
 
-        def initialize(query_scope, selector)
+        attr_reader :query_scope, :selector
+
+        def initialize(query_scope, selector = {})
           @query_scope = query_scope
           @selector = selector
         end

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -3,7 +3,7 @@ module Watir
     class Element
       class SelectorBuilder
         include Exception
-        attr_reader :custom_attributes
+        attr_reader :custom_attributes, :built
 
         WILDCARD_ATTRIBUTE = /^(aria|data)_(.+)$/.freeze
         INTEGER_CLASS = Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4') ? Fixnum : Integer

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -16,13 +16,11 @@ module Watir
                                                                               visible_text: [String, Regexp],
                                                                               text: [String, Regexp]).freeze
 
-        W3C_FINDERS = %i[
-          css
-          link
-          link_text
-          partial_link_text
-          xpath
-        ].freeze
+        W3C_FINDERS = %i[css
+                         link
+                         link_text
+                         partial_link_text
+                         xpath].freeze
 
         def initialize(valid_attributes)
           @valid_attributes = valid_attributes
@@ -36,15 +34,15 @@ module Watir
           deprecated_locators
           normalize_selector
 
-          @built = wd_locators(@selector.keys).size.zero? ? build_wd_selector(@selector) : @selector
+          @built = wd_locator(@selector.keys).nil? ? build_wd_selector(@selector) : @selector
           @built.delete(:index) if @built[:index]&.zero?
 
           Watir.logger.debug "Converted #{inspected} to #{@built.inspect}"
           @built
         end
 
-        def wd_locators(keys)
-          W3C_FINDERS & keys
+        def wd_locator(keys)
+          (W3C_FINDERS & keys).first
         end
 
         def locator_filters(keys)

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -16,9 +16,10 @@ module Watir
                                                                               visible_text: [String, Regexp],
                                                                               text: [String, Regexp]).freeze
 
-        def initialize(valid_attributes)
+        def initialize(valid_attributes, query_scope)
           @valid_attributes = valid_attributes
           @custom_attributes = []
+          @query_scope = query_scope
         end
 
         def build(selector)

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -16,12 +16,6 @@ module Watir
                                                                               visible_text: [String, Regexp],
                                                                               text: [String, Regexp]).freeze
 
-        W3C_FINDERS = %i[css
-                         link
-                         link_text
-                         partial_link_text
-                         xpath].freeze
-
         def initialize(valid_attributes)
           @valid_attributes = valid_attributes
           @custom_attributes = []
@@ -42,17 +36,13 @@ module Watir
         end
 
         def wd_locator(keys)
-          (W3C_FINDERS & keys).first
-        end
-
-        def locator_filters(keys)
-          keys - W3C_FINDERS
+          (Watir::Locators::W3C_FINDERS & keys).first
         end
 
         private
 
         def normalize_selector
-          wd_locators = @selector.keys & W3C_FINDERS
+          wd_locators = @selector.keys & Watir::Locators::W3C_FINDERS
           raise LocatorException, "Can not locate element with #{wd_locators}" if wd_locators.size > 1
 
           if @selector.key?(:class) || @selector.key?(:class_name)

--- a/lib/watir/locators/row/selector_builder.rb
+++ b/lib/watir/locators/row/selector_builder.rb
@@ -2,13 +2,9 @@ module Watir
   module Locators
     class Row
       class SelectorBuilder < Element::SelectorBuilder
-        def initialize(valid_attributes, scope_tag_name)
-          @scope_tag_name = scope_tag_name
-          super(valid_attributes)
-        end
-
         def build_wd_selector(selector)
-          Kernel.const_get("#{self.class.name}::XPath").new.build(selector, @scope_tag_name)
+          scope_tag_name = @query_scope.selector[:tag_name] || @query_scope.tag_name
+          Kernel.const_get("#{self.class.name}::XPath").new.build(selector, scope_tag_name)
         end
       end
     end

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -16,16 +16,18 @@ module LocatorSpecHelper
     @locator ||= {xpath: ''}
     @selector_builder = instance_double(Watir::Locators::Element::SelectorBuilder)
     allow(@selector_builder).to receive(:built).and_return(@locator)
-    allow(@selector_builder).to receive(:wd_locator).and_return(:xpath)
     @selector_builder
   end
 
   def element_matcher
     @element_matcher ||= instance_double(Watir::Locators::Element::Matcher)
+    allow(@element_matcher).to receive(:query_scope).and_return(browser)
+    allow(@element_matcher).to receive(:selector).and_return(@locator || {})
+    @element_matcher
   end
 
-  def locator(selector)
-    Watir::Locators::Element::Locator.new(browser, selector, selector_builder, element_matcher)
+  def locator
+    Watir::Locators::Element::Locator.new(element_matcher)
   end
 
   def expect_one(*args)
@@ -36,12 +38,14 @@ module LocatorSpecHelper
     expect(driver).to receive(:find_elements).with(*args)
   end
 
-  def locate_one(selector = {})
-    locator(ordered_hash(selector)).locate
+  def locate_one(selector = nil)
+    selector ||= @locator || {}
+    locator.locate(ordered_hash(selector))
   end
 
-  def locate_all(selector = {})
-    locator(ordered_hash(selector)).locate_all
+  def locate_all(selector = nil)
+    selector ||= @locator || {}
+    locator.locate_all(ordered_hash(selector))
   end
 
   def element(opts = {})

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -1,6 +1,9 @@
 module LocatorSpecHelper
   def browser
     @browser ||= instance_double(Watir::Browser, wd: driver)
+    allow(@browser).to receive(:browser).and_return(@browser)
+    allow(@browser).to receive(:locator_namespace).and_return(@locator_namespace || Watir::Locators)
+    @browser
   end
 
   def driver
@@ -13,7 +16,7 @@ module LocatorSpecHelper
     @locator ||= {xpath: ''}
     @selector_builder = instance_double(Watir::Locators::Element::SelectorBuilder)
     allow(@selector_builder).to receive(:build).and_return(@locator)
-    allow(@selector_builder).to receive(:wd_locators).and_return([:xpath])
+    allow(@selector_builder).to receive(:wd_locator).and_return(:xpath)
     @selector_builder
   end
 

--- a/spec/locator_spec_helper.rb
+++ b/spec/locator_spec_helper.rb
@@ -15,7 +15,7 @@ module LocatorSpecHelper
 
     @locator ||= {xpath: ''}
     @selector_builder = instance_double(Watir::Locators::Element::SelectorBuilder)
-    allow(@selector_builder).to receive(:build).and_return(@locator)
+    allow(@selector_builder).to receive(:built).and_return(@locator)
     allow(@selector_builder).to receive(:wd_locator).and_return(:xpath)
     @selector_builder
   end

--- a/spec/unit/element_locator_spec.rb
+++ b/spec/unit/element_locator_spec.rb
@@ -50,7 +50,7 @@ describe Watir::Locators::Element::Locator do
         stale_exception = Selenium::WebDriver::Error::StaleElementReferenceError
         expect(element_matcher).to receive(:match).and_raise(stale_exception).exactly(3).times
 
-        msg = 'Unable to locate element from {} due to changing page'
+        msg = 'Unable to locate element from {:xpath=>".//div", :id=>"foo"} due to changing page'
         expect { locate_one }.to raise_exception Watir::Exception::LocatorException, msg
       end
     end
@@ -73,7 +73,7 @@ describe Watir::Locators::Element::Locator do
       stale_exception = Selenium::WebDriver::Error::StaleElementReferenceError
       expect(element_matcher).to receive(:match).and_raise(stale_exception).exactly(3).times
 
-      msg = 'Unable to locate element collection from {} due to changing page'
+      msg = 'Unable to locate element collection from {:xpath=>".//div", :id=>"foo"} due to changing page'
       expect { locate_all }.to raise_exception Watir::Exception::LocatorException, msg
     end
 

--- a/spec/unit/match_elements/element_spec.rb
+++ b/spec/unit/match_elements/element_spec.rb
@@ -3,7 +3,7 @@ require_relative '../unit_helper'
 describe Watir::Locators::Element::Matcher do
   include LocatorSpecHelper
 
-  let(:query_scope) { @query_scope || instance_double(Watir::Browser) }
+  let(:query_scope) { @query_scope || browser }
   let(:values_to_match) { @values_to_match || {} }
   let(:matcher) { described_class.new(query_scope, values_to_match) }
 

--- a/spec/unit/match_elements/element_spec.rb
+++ b/spec/unit/match_elements/element_spec.rb
@@ -5,7 +5,7 @@ describe Watir::Locators::Element::Matcher do
 
   let(:query_scope) { @query_scope || browser }
   let(:values_to_match) { @values_to_match || {} }
-  let(:matcher) { described_class.new(query_scope, values_to_match) }
+  let(:matcher) { described_class.new(query_scope) }
 
   describe '#match' do
     context 'a label element' do

--- a/spec/unit/selector_builder/anchor_spec.rb
+++ b/spec/unit/selector_builder/anchor_spec.rb
@@ -2,7 +2,8 @@ require_relative '../unit_helper'
 
 describe Watir::Locators::Anchor::SelectorBuilder do
   let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:selector_builder) { described_class.new(attributes) }
+  let(:query_scope) { double Watir::Browser }
+  let(:selector_builder) { described_class.new(attributes, query_scope) }
 
   describe '#build' do
     it 'without only tag name' do

--- a/spec/unit/selector_builder/button_spec.rb
+++ b/spec/unit/selector_builder/button_spec.rb
@@ -2,7 +2,8 @@ require_relative '../unit_helper'
 
 describe Watir::Locators::Button::SelectorBuilder do
   let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:selector_builder) { described_class.new(attributes) }
+  let(:query_scope) { double Watir::Browser }
+  let(:selector_builder) { described_class.new(attributes, query_scope) }
   let(:uppercase) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸŽŠŒ' }
   let(:lowercase) { 'abcdefghijklmnopqrstuvwxyzàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿžšœ' }
   let(:default_types) do

--- a/spec/unit/selector_builder/cell_spec.rb
+++ b/spec/unit/selector_builder/cell_spec.rb
@@ -2,7 +2,8 @@ require_relative '../unit_helper'
 
 describe Watir::Locators::Cell::SelectorBuilder do
   let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:selector_builder) { described_class.new(attributes) }
+  let(:query_scope) { double Watir::Browser }
+  let(:selector_builder) { described_class.new(attributes, query_scope) }
 
   describe '#build' do
     it 'without any arguments' do

--- a/spec/unit/selector_builder/element_spec.rb
+++ b/spec/unit/selector_builder/element_spec.rb
@@ -2,7 +2,8 @@ require_relative '../unit_helper'
 
 describe Watir::Locators::Element::SelectorBuilder do
   let(:attributes) { @attributes || Watir::HTMLElement.attribute_list }
-  let(:selector_builder) { described_class.new(attributes) }
+  let(:query_scope) { instance_double Watir::Browser }
+  let(:selector_builder) { described_class.new(attributes, query_scope) }
 
   describe '#build' do
     it 'without any arguments' do

--- a/spec/unit/selector_builder/row_spec.rb
+++ b/spec/unit/selector_builder/row_spec.rb
@@ -2,13 +2,18 @@ require_relative '../unit_helper'
 
 describe Watir::Locators::Row::SelectorBuilder do
   let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:scope_tag_name) { @scope_tag_name || 'table' }
-  let(:selector_builder) { described_class.new(attributes, scope_tag_name) }
+  let(:query_scope) { double Watir::HTMLElement }
+  let(:selector_builder) { described_class.new(attributes, query_scope) }
 
   describe '#build' do
+    before do
+      allow(query_scope).to receive(:selector).and_return({})
+    end
+
     context 'with query scopes' do
       it 'with only table query scope' do
         @scope_tag_name = 'table'
+        allow(query_scope).to receive(:tag_name).and_return(@scope_tag_name)
         selector = {}
         built = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']"}
@@ -18,6 +23,7 @@ describe Watir::Locators::Row::SelectorBuilder do
 
       it 'with tbody query scope' do
         @scope_tag_name = 'tbody'
+        allow(query_scope).to receive(:tag_name).and_return(@scope_tag_name)
         selector = {}
         built = {xpath: "./*[local-name()='tr']"}
 
@@ -26,6 +32,7 @@ describe Watir::Locators::Row::SelectorBuilder do
 
       it 'with thead query scope' do
         @scope_tag_name = 'thead'
+        allow(query_scope).to receive(:tag_name).and_return(@scope_tag_name)
         selector = {}
         built = {xpath: "./*[local-name()='tr']"}
 
@@ -34,6 +41,7 @@ describe Watir::Locators::Row::SelectorBuilder do
 
       it 'with tfoot query scope' do
         @scope_tag_name = 'tfoot'
+        allow(query_scope).to receive(:tag_name).and_return(@scope_tag_name)
         selector = {}
         built = {xpath: "./*[local-name()='tr']"}
 
@@ -41,65 +49,71 @@ describe Watir::Locators::Row::SelectorBuilder do
       end
     end
 
-    context 'with index' do
-      it 'positive' do
-        selector = {index: 1}
-        built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+    context 'when tag name is specified' do
+      before do
+        allow(query_scope).to receive(:tag_name).and_return('table')
+      end
+
+      context 'with index' do
+        it 'positive' do
+          selector = {index: 1}
+          built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[2]"}
 
-        expect(selector_builder.build(selector)).to eq built
-      end
+          expect(selector_builder.build(selector)).to eq built
+        end
 
-      it 'negative' do
-        selector = {index: -3}
-        built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+        it 'negative' do
+          selector = {index: -3}
+          built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[last()-2]"}
 
-        expect(selector_builder.build(selector)).to eq built
-      end
+          expect(selector_builder.build(selector)).to eq built
+        end
 
-      it 'last' do
-        selector = {index: -1}
-        built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+        it 'last' do
+          selector = {index: -1}
+          built = {xpath: "(./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr'])[last()]"}
 
-        expect(selector_builder.build(selector)).to eq built
-      end
+          expect(selector_builder.build(selector)).to eq built
+        end
 
-      it 'does not return index if it is zero' do
-        selector = {index: 0}
-        built = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+        it 'does not return index if it is zero' do
+          selector = {index: 0}
+          built = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']"}
 
-        expect(selector_builder.build(selector)).to eq built
+          expect(selector_builder.build(selector)).to eq built
+        end
+
+        it 'raises exception when index is not an Integer', skip_after: true do
+          selector = {index: 'foo'}
+          msg = /expected one of \[(Integer|Fixnum)\], got "foo":String/
+          expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
+        end
       end
 
-      it 'raises exception when index is not an Integer', skip_after: true do
-        selector = {index: 'foo'}
-        msg = /expected one of \[(Integer|Fixnum)\], got "foo":String/
-        expect { selector_builder.build(selector) }.to raise_exception TypeError, msg
-      end
-    end
-
-    context 'with multiple locators' do
-      it 'attribute and class' do
-        selector = {id: 'gregory', class: /brick/}
-        built = {xpath: "./*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
+      context 'with multiple locators' do
+        it 'attribute and class' do
+          selector = {id: 'gregory', class: /brick/}
+          built = {xpath: "./*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
 "./*[local-name()='tbody']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory'] | " \
 "./*[local-name()='tfoot']/*[local-name()='tr'][contains(@class, 'brick')][@id='gregory']"}
 
-        expect(selector_builder.build(selector)).to eq built
+          expect(selector_builder.build(selector)).to eq built
+        end
       end
-    end
 
-    context 'returns locators that can not be directly translated' do
-      it 'any text value' do
-        selector = {text: 'Gregory'}
-        built = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
+      context 'returns locators that can not be directly translated' do
+        it 'any text value' do
+          selector = {text: 'Gregory'}
+          built = {xpath: "./*[local-name()='tr'] | ./*[local-name()='tbody']/*[local-name()='tr'] | " \
 "./*[local-name()='thead']/*[local-name()='tr'] | ./*[local-name()='tfoot']/*[local-name()='tr']", text: 'Gregory'}
 
-        expect(selector_builder.build(selector)).to eq built
+          expect(selector_builder.build(selector)).to eq built
+        end
       end
     end
   end

--- a/spec/unit/selector_builder/text_field_spec.rb
+++ b/spec/unit/selector_builder/text_field_spec.rb
@@ -2,7 +2,8 @@ require_relative '../unit_helper'
 
 describe Watir::Locators::TextField::SelectorBuilder do
   let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:selector_builder) { described_class.new(attributes) }
+  let(:query_scope) { double Watir::Browser }
+  let(:selector_builder) { described_class.new(attributes, query_scope) }
   let(:uppercase) { 'ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞŸŽŠŒ' }
   let(:lowercase) { 'abcdefghijklmnopqrstuvwxyzàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿžšœ' }
   let(:negative_types) do

--- a/spec/unit/selector_builder/textarea_spec.rb
+++ b/spec/unit/selector_builder/textarea_spec.rb
@@ -2,7 +2,8 @@ require_relative '../unit_helper'
 
 describe Watir::Locators::TextArea::SelectorBuilder do
   let(:attributes) { Watir::HTMLElement.attribute_list }
-  let(:selector_builder) { described_class.new(attributes) }
+  let(:query_scope) { double Watir::Browser }
+  let(:selector_builder) { described_class.new(attributes, query_scope) }
 
   describe '#build' do
     context 'Always returns value argument' do

--- a/spec/watirspec/element_hidden_spec.rb
+++ b/spec/watirspec/element_hidden_spec.rb
@@ -71,9 +71,8 @@ describe Watir::Locators::Element::Locator do
     end
 
     it 'raises exception when value is not Boolean' do
-      element = browser.body.element(visible: 'true')
       msg = 'expected one of [TrueClass, FalseClass], got "true":String'
-      expect { element.exists? }.to raise_exception(TypeError, msg)
+      expect { browser.body.element(visible: 'true') }.to raise_exception(TypeError, msg)
     end
   end
 end


### PR DESCRIPTION
This builds the selector when `Element` is instantiated rather than when `#locate` is called. It removes all `SelectorBuilder` references from `Locator` class.

Element initialize => selector -> SelectorBuilder#build -> built

Element#locate_in_context => built -> Locator#locate -> @element
ElementCollection#locate => built -> Locator#locate_all -> [@element, ...]

Now, we do have the `selector` & `built` values at the time of `SelectorBuilder` & `Locator` initialization, but I currently prefer to explicitly pass them in with `#build` and `#locate` for clarity. I'm open to changing this if people think it makes more sense otherwise.

`@selector` value is still getting passed into the `Locator` and `Matcher` classes primarily for error messages right now.

This code will be a necessary prerequisite for #822 