### PR TITLE
merge watir-scroll code into watir 

### DIFF
--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -1,6 +1,7 @@
 require 'selenium-webdriver'
 require 'time'
 
+require 'watir/scroll'
 require 'watir/legacy_wait'
 require 'watir/wait'
 require 'watir/exception'

--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -9,6 +9,7 @@ module Watir
     include Waitable
     include Navigation
     include Exception
+    include Scrolling
 
     attr_writer :default_context, :original_window, :locator_namespace
     attr_reader :driver, :after_hooks

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -13,6 +13,7 @@ module Watir
     include Adjacent
     include JSExecution
     include Locators::ClassHelpers
+    include Scrolling
 
     attr_accessor :keyword
     attr_reader :selector

--- a/lib/watir/scroll.rb
+++ b/lib/watir/scroll.rb
@@ -1,0 +1,69 @@
+module Watir
+  module Scrolling
+    def scroll
+      Scroll.new(self)
+    end
+  end
+
+  class Scroll
+    def initialize(object)
+      @object = object
+    end
+
+    # Scrolls by offset.
+    # @param [Fixnum] left Horizontal offset
+    # @param [Fixnum] top Vertical offset
+    #
+    def by(left, top)
+      @object.browser.execute_script('window.scrollBy(arguments[0], arguments[1]);', Integer(left), Integer(top))
+      self
+    end
+
+    #
+    # Scrolls to specified location.
+    # @param [Symbol] param
+    #
+    def to(param = :top)
+      args = @object.is_a?(Watir::Element) ? element_scroll(param) : browser_scroll(param)
+      raise ArgumentError, "Don't know how to scroll #{@object} to: #{param}!" if args.nil?
+
+      @object.browser.execute_script(*args)
+      self
+    end
+
+    private
+
+    def element_scroll(param)
+      script = case param
+               when :top, :start
+                 'arguments[0].scrollIntoView();'
+               when :center
+                 <<-JS
+                   var bodyRect = document.body.getBoundingClientRect();
+                   var elementRect = arguments[0].getBoundingClientRect();
+                   var left = (elementRect.left - bodyRect.left) - (window.innerWidth / 2);
+                   var top = (elementRect.top - bodyRect.top) - (window.innerHeight / 2);
+                   window.scrollTo(left, top);
+                 JS
+               when :bottom, :end
+                 'arguments[0].scrollIntoView(false);'
+               else
+                 return nil
+               end
+      [script, @object]
+    end
+
+    def browser_scroll(param)
+      case param
+      when :top, :start
+        'window.scrollTo(0, 0);'
+      when :center
+        'window.scrollTo(window.outerWidth / 2, window.outerHeight / 2);'
+      when :bottom, :end
+        'window.scrollTo(0, document.body.scrollHeight);'
+      when Array
+        ['window.scrollTo(arguments[0], arguments[1]);', Integer(param[0]), Integer(param[1])]
+      end
+    end
+  end
+end

--- a/spec/watirspec/html/scroll.html
+++ b/spec/watirspec/html/scroll.html
@@ -1,0 +1,32 @@
+<html>
+  <head>
+    <script>
+      function isElementInViewport(el) {
+        var top = el.offsetTop;
+        var left = el.offsetLeft;
+        var width = el.offsetWidth;
+        var height = el.offsetHeight;
+
+        while (el.offsetParent) {
+          el = el.offsetParent;
+          top += el.offsetTop;
+          left += el.offsetLeft;
+        }
+
+        return (
+          top < (window.pageYOffset + window.innerHeight) &&
+          left < (window.pageXOffset + window.innerWidth) &&
+          (top + height) > window.pageYOffset &&
+          (left + width) > window.pageXOffset
+        );
+      }
+    </script>
+  </head>
+  <body>
+    <div style="height: 180%; position: relative;">
+      <button style="position: absolute;">Top</button>
+      <button style="position: absolute; top: 50%;">Center</button>
+      <button style="position: absolute; bottom: 0;">Bottom</button>
+    </div>
+  </body>
+</html>

--- a/spec/watirspec/scroll_spec.rb
+++ b/spec/watirspec/scroll_spec.rb
@@ -1,0 +1,106 @@
+require 'watirspec_helper'
+
+describe Watir::Scrolling do
+  before(:each) do
+    browser.goto(WatirSpec.url_for('scroll.html'))
+  end
+
+  def visible?(element)
+    browser.execute_script('return isElementInViewport(arguments[0]);', element)
+  end
+
+  context 'when scrolling Browser' do
+    describe '#to' do
+      it 'scrolls to the top of the page' do
+        browser.scroll.to :bottom
+        browser.scroll.to :top
+        expect(visible?(browser.button(text: 'Top'))).to eq(true)
+        expect(visible?(browser.button(text: 'Center'))).to eq(true)
+        expect(visible?(browser.button(text: 'Bottom'))).to eq(false)
+      end
+
+      it 'scrolls to the center of the page' do
+        browser.scroll.to :center
+        expect(visible?(browser.button(text: 'Top'))).to eq(false)
+        expect(visible?(browser.button(text: 'Center'))).to eq(true)
+        expect(visible?(browser.button(text: 'Bottom'))).to eq(false)
+      end
+
+      it 'scrolls to the bottom of the page' do
+        browser.scroll.to :bottom
+        expect(visible?(browser.button(text: 'Top'))).to eq(false)
+        expect(visible?(browser.button(text: 'Center'))).to eq(true)
+        expect(visible?(browser.button(text: 'Bottom'))).to eq(true)
+      end
+
+      it 'scrolls to coordinates' do
+        button = browser.button(text: 'Bottom')
+        browser.scroll.to [button.wd.location.x, button.wd.location.y]
+        expect(visible?(button)).to eq(true)
+      end
+
+      it 'raises error when scroll point is not vaild' do
+        expect { browser.scroll.to(:blah) }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe '#by' do
+      it 'offset' do
+        browser.scroll.to :bottom
+        browser.scroll.by(-10_000, -10_000)
+
+        expect(visible?(browser.button(text: 'Top'))).to eq(true)
+        expect(visible?(browser.button(text: 'Center'))).to eq(true)
+        expect(visible?(browser.button(text: 'Bottom'))).to eq(false)
+      end
+    end
+  end
+
+  context 'when scrolling Element' do
+    describe '#to' do
+      it 'scrolls to element (top)' do
+        browser.button(text: 'Center').scroll.to
+        expect(visible?(browser.button(text: 'Top'))).to eq(false)
+        expect(visible?(browser.button(text: 'Center'))).to eq(true)
+        expect(visible?(browser.button(text: 'Bottom'))).to eq(true)
+      end
+
+      it 'scrolls to element (center)' do
+        browser.button(text: 'Center').scroll.to :center
+        expect(visible?(browser.button(text: 'Top'))).to eq(false)
+        expect(visible?(browser.button(text: 'Center'))).to eq(true)
+        expect(visible?(browser.button(text: 'Bottom'))).to eq(false)
+      end
+
+      it 'scrolls to element (bottom)' do
+        browser.button(text: 'Center').scroll.to :bottom
+        expect(visible?(browser.button(text: 'Top'))).to eq(true)
+        expect(visible?(browser.button(text: 'Center'))).to eq(true)
+        expect(visible?(browser.button(text: 'Bottom'))).to eq(false)
+      end
+
+      it 'scrolls to element multiple times' do
+        2.times do
+          browser.button(text: 'Center').scroll.to(:center)
+          expect(visible?(browser.button(text: 'Top'))).to eq(false)
+        end
+      end
+
+      it 'raises error when scroll param is not vaild' do
+        expect { browser.button(text: 'Top').scroll.to(:blah) }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe '#by' do
+      it 'offset' do
+        browser.scroll.to :bottom
+        button = browser.button(text: 'Bottom')
+        button.scroll.by(-10_000, -10_000) # simulate scrolling to top
+
+        expect(visible?(browser.button(text: 'Top'))).to eq(true)
+        expect(visible?(browser.button(text: 'Center'))).to eq(true)
+        expect(visible?(browser.button(text: 'Bottom'))).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Is it ok that I'm not namespacing it inside Element & Browser? Do we expect people to have done:

```
element = browser.element
scroll = Watir::Element::Scroll.new(element)
scroll.to
```

This implementation also allows `browser.scroll.to` to scroll to the top rather than raising an `ArgumentError`

Finally, I spent some time checking that this works efficiently in the context of a frame since the existing gem calls `element.browser.execute_script` instead of just `element.execute_script`. But at least with the new code to `wait_until(&:exist?)` on elements passed in as arguments to `#execute_script`, this is the most efficient way to do it.

If there are any additional issues with this let me know.

This will allow us to deal with #818