### PR TITLE
Fix Element#obscured? for scrolling non-interactive elements

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -514,7 +514,7 @@ module Watir
       element_call do
         return true unless present?
 
-        scroll_into_view
+        scroll.to
         execute_js(:elementObscured, self)
       end
     end

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -927,10 +927,16 @@ describe 'Element' do
       expect { btn.click }.not_to raise_exception
     end
 
-    it 'scrolls element into view before checking if obscured' do
+    it 'scrolls interactive element into view before checking if obscured' do
       btn = browser.button(id: 'requires_scrolling')
       expect(btn).not_to be_obscured
       expect { btn.click }.not_to raise_exception
+    end
+
+    it 'scrolls non-interactive element into view before checking if obscured' do
+      div = browser.div(id: 'requires_scrolling_container')
+      expect(div).not_to be_obscured
+      expect { div.click }.not_to raise_exception
     end
 
     it 'returns true if element cannot be scrolled into view' do

--- a/spec/watirspec/html/obscured.html
+++ b/spec/watirspec/html/obscured.html
@@ -29,6 +29,8 @@
 
     <button style="position: absolute; width: 0; height: 0; top: -500px; left: -500px; overflow: hidden" id="off_screen">off-screen</button>
     <button style="display: none;" id="hidden">hidden</button>
-    <button style="position: absolute; top: 5000px;" id="requires_scrolling">requires scrolling</button>
+    <div id="requires_scrolling_container">
+      <button style="position: absolute; top: 5000px;" id="requires_scrolling">requires scrolling</button>'
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Fixes #818 by using `scroll.to` instead of `scroll_into_view`.