### PR TITLE
Use javascript to get tag_name for ElementCollection elements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,6 +75,7 @@ Metrics/ClassLength:
     - 'lib/watir/elements/element.rb'
     - 'lib/watir/elements/select.rb'
     - 'lib/watir/generator/base/spec_extractor.rb'
+    - 'lib/watir/element_collection.rb'
 
 Metrics/PerceivedComplexity:
   Max: 10

--- a/lib/watir/js_snippets/getElementTags.js
+++ b/lib/watir/js_snippets/getElementTags.js
@@ -1,0 +1,3 @@
+function(){
+    return arguments[0].map(function(e) {return e.localName});
+}

--- a/spec/watirspec/browser_spec.rb
+++ b/spec/watirspec/browser_spec.rb
@@ -102,7 +102,6 @@ describe 'Browser' do
     end
   end
 
-
   describe '#text' do
     it 'returns the text of the page' do
       browser.goto(WatirSpec.url_for('non_control_elements.html'))


### PR DESCRIPTION
This replaces #802, updated due to rebase conflicts

-----

When the `selector` does not contain `:tag_name`, we are currently querying the `tag_name` from the element. This causes `N` wire calls which, depending on how many elements there are, can take a while when testing remotely.

The idea is to us the javascript executor to retrieve all the tags once. In doing so, we do miss out on the added benefit of `element_call` which `#tag_name` uses, but that shouldn't be an issue as we have already located the elements.

The only concern I could think of was with elements going stale between retrieving them and then performing javascript on them, but this should be a rare scenario. This is mitigated by the rescue and retry. Theoretically there is a chance for an infinite loop on the retry, but the likelihood of that is near impossible in normal conditions.