### PR TITLE
frame switching changes the DOM and should therefore execute after hooks

### DIFF
--- a/lib/watir/browser.rb
+++ b/lib/watir/browser.rb
@@ -263,8 +263,11 @@ module Watir
     end
 
     def ensure_context
-      driver.switch_to.default_content unless @default_context
+      return if @default_context
+
+      driver.switch_to.default_content
       @default_context = true
+      after_hooks.run
     end
 
     #

--- a/lib/watir/elements/iframe.rb
+++ b/lib/watir/elements/iframe.rb
@@ -128,6 +128,7 @@ module Watir
     def switch!
       @driver.switch_to.frame @element
       @browser.default_context = false
+      @browser.after_hooks.run
     rescue Selenium::WebDriver::Error::NoSuchFrameError => e
       raise UnknownFrameException, e.message
     end

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -113,6 +113,28 @@ describe 'Browser::AfterHooks' do
       end
     end
 
+    it 'runs after_hooks after FramedDriver#switch!' do
+      browser.goto(WatirSpec.url_for('iframes.html'))
+      @page_after_hook = proc { @yield = browser.title == 'Iframes' }
+      browser.after_hooks.add @page_after_hook
+
+      browser.iframe.element(css: '#senderElement').exists?
+
+      expect(@yield).to be true
+    end
+
+    it 'runs after_hooks after Browser#ensure_context if not @default_context' do
+      browser.goto(WatirSpec.url_for('iframes.html'))
+      browser.iframe.element(css: '#senderElement').locate
+
+      @page_after_hook = proc { @yield = browser.title == 'Iframes' }
+      browser.after_hooks.add @page_after_hook
+
+      browser.locate
+
+      expect(@yield).to be true
+    end
+
     not_compliant_on :headless do
       it 'runs after_hooks after Alert#ok' do
         browser.goto(WatirSpec.url_for('alerts.html'))


### PR DESCRIPTION
I don't think After Hooks are very widely used, so I'm not sure how big of a difference this would make.

Anyone see any reason not to add this?

I need it for Watigiri since the DOM changes, so if we don't want to add it, I'll need to monkey patch that project.