### PR TITLE
deprecate using a label locator with an invalid element type to find …

### DIFF
--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -100,7 +100,10 @@ module Watir
         end
 
         def should_use_label_element?
-          !valid_attribute?(:label)
+          return false if valid_attribute?(:label) # This is only Option, OptGroup & Track
+
+          deprecate_label_location(@selector[:tag_name])
+          true
         end
 
         def normalize_locator(how, what)
@@ -177,6 +180,17 @@ module Watir
 
             raise LocatorException, "Can not use #{locator} locator to find a #{tag} element"
           end
+        end
+
+        def deprecate_label_location(tag_name)
+          return unless tag_name.nil? || !%w[input button meter select textarea].include?(tag_name)
+
+          type = tag_name.nil? ? 'generic' : tag_name
+
+          msg = "Using a :label locator with a #{type} element to find an element based on the values of a " \
+'corresponding label element'
+          replacement_msg = 'a specific and appropriate element type'
+          Watir.logger.deprecate(msg, replacement_msg, ids: [:label_location])
         end
       end
     end

--- a/spec/unit/selector_builder/element_spec.rb
+++ b/spec/unit/selector_builder/element_spec.rb
@@ -334,24 +334,42 @@ describe Watir::Locators::Element::SelectorBuilder do
     end
 
     context 'with labels' do
+      it 'has deprecated using invalid element types' do
+        expect {
+          selector_builder.build(label: 'anything')
+        }.to have_deprecated_label_location
+
+        expect {
+          selector_builder.build(label: 'anything', tag_name: 'div')
+        }.to have_deprecated_label_location
+      end
+
+      it 'does not have deprecated valide element types' do
+        %w[input button meter select textarea].each do |tag|
+          expect {
+            selector_builder.build(tag_name: tag, label: 'anything')
+          }.to_not have_deprecated_label_location
+        end
+      end
+
       it 'locates the element associated with the label element located by the text of the provided label key' do
-        selector = {label: 'Cars'}
-        built = {xpath: ".//*[@id=//label[normalize-space()='Cars']/@for "\
+        selector = {label: 'Cars', tag_name: 'input'}
+        built = {xpath: ".//*[local-name()='input'][@id=//label[normalize-space()='Cars']/@for "\
 "or parent::label[normalize-space()='Cars']]"}
 
         expect(selector_builder.build(selector)).to eq built
       end
 
       it 'returns a label_element if complex' do
-        selector = {label: /Ca|rs/}
-        built = {xpath: './/*', label_element: /Ca|rs/}
+        selector = {label: /Ca|rs/, tag_name: 'input'}
+        built = {xpath: ".//*[local-name()='input']", label_element: /Ca|rs/}
 
         expect(selector_builder.build(selector)).to eq built
       end
 
       it 'returns a visible_label_element if complex' do
-        selector = {visible_label: /Ca|rs/}
-        built = {xpath: './/*', visible_label_element: /Ca|rs/}
+        selector = {visible_label: /Ca|rs/, tag_name: 'input'}
+        built = {xpath: ".//*[local-name()='input']", visible_label_element: /Ca|rs/}
 
         expect(selector_builder.build(selector)).to eq built
       end

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -5,6 +5,7 @@ if defined?(RSpec)
                             class_array
                             use_capabilities
                             visible_text
+                            label_location
                             link_text
                             text_regexp
                             stale_exists


### PR DESCRIPTION
I'm not sure why we are allowing for any element to use the `:label` locator so long as it isn't a valid attribute. This should be restricted to the elements that support it.

Not sure what the actual fixed implementation will look like, I figured hard coding an array with the allowed element tags would be sufficient for the deprecation notice.