### PR TITLE
changed desired implementation of select lists

### DIFF
--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -14,6 +14,10 @@ require 'watir/locators/button/matcher'
 require 'watir/locators/cell/selector_builder'
 require 'watir/locators/cell/selector_builder/xpath'
 
+require 'watir/locators/option/matcher'
+require 'watir/locators/option/selector_builder'
+require 'watir/locators/option/selector_builder/xpath'
+
 require 'watir/locators/row/selector_builder'
 require 'watir/locators/row/selector_builder/xpath'
 

--- a/lib/watir/locators/option/matcher.rb
+++ b/lib/watir/locators/option/matcher.rb
@@ -1,0 +1,24 @@
+module Watir
+  module Locators
+    class Option
+      class Matcher < Element::Matcher
+        def fetch_value(element, how)
+          case how
+          when :any
+            [element.attribute(:value),
+             execute_js(:getTextContent, element),
+             element.attribute(:label)]
+          else
+            super
+          end
+        end
+
+        def matches_values?(found, expected)
+          return super unless found.is_a?(Array)
+
+          found.find { |possible| matches_values?(possible, expected) }
+        end
+      end
+    end
+  end
+end

--- a/lib/watir/locators/option/selector_builder.rb
+++ b/lib/watir/locators/option/selector_builder.rb
@@ -1,0 +1,8 @@
+module Watir
+  module Locators
+    class Option
+      class SelectorBuilder < Element::SelectorBuilder
+      end
+    end
+  end
+end

--- a/lib/watir/locators/option/selector_builder/xpath.rb
+++ b/lib/watir/locators/option/selector_builder/xpath.rb
@@ -1,0 +1,37 @@
+module Watir
+  module Locators
+    class Option
+      class SelectorBuilder
+        class XPath < Element::SelectorBuilder::XPath
+          private
+
+          def attribute_string
+            result = if @selector.key?(:any)
+                       to_match = @selector.delete :any
+                       value = process_attribute(:value, to_match)
+                       text = process_attribute(:text, to_match)
+                       label = process_attribute(:label, to_match)
+                       "[#{value} or #{text} or #{label}]"
+                     else
+                       ''
+                     end
+
+            attributes = @selector.keys.map { |key|
+              process_attribute(key, @selector.delete(key))
+            }.flatten.compact
+            attribute_values = attributes.empty? ? '' : "[#{attributes.join(' and ')}]"
+            "#{result}#{attribute_values}"
+          end
+
+          def add_to_matching(key, regexp, results = nil)
+            return unless results.nil? || requires_matching?(results, regexp)
+
+            return super unless %i[value text label].include? key
+
+            @built[:any] = regexp
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -244,77 +244,93 @@ describe 'SelectList' do
     end
   end
 
-  describe '#select' do
-    context 'when finding by value' do
-      it 'selects an option with a String' do
-        browser.select_list(name: 'new_user_languages').clear
-        browser.select_list(name: 'new_user_languages').select('2')
-        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[EN]
+  describe '#select method' do
+    context 'working with multiple select list' do
+      before do
+        @select_list = browser.select_list(name: 'new_user_languages')
+        @select_list.clear
       end
 
-      it 'selects an option with a Regexp' do
-        browser.select_list(name: 'new_user_languages').clear
-        browser.select_list(name: 'new_user_languages').select(/2|3/)
-        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[EN]
-      end
-    end
+      context 'when finding by value' do
+        it 'selects an option with a String' do
+          @select_list.select('2')
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
 
-    context 'when finding by text' do
-      it 'selects an option with a String' do
-        browser.select_list(name: 'new_user_country').select('Denmark')
-        expect(browser.select_list(name: 'new_user_country').selected_options.map(&:text)).to eq ['Denmark']
-      end
+        it 'selects an option with a Number' do
+          @select_list.select(2)
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
 
-      it 'selects an option with a Regexp' do
-        browser.select_list(name: 'new_user_country').select(/Denmark/)
-        expect(browser.select_list(name: 'new_user_country').selected_options.map(&:text)).to eq ['Denmark']
-      end
-    end
-
-    context 'when finding by label' do
-      it 'selects an option with a String' do
-        browser.select_list(name: 'new_user_languages').clear
-        browser.select_list(name: 'new_user_languages').select('NO')
-        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq ['NO']
+        it 'selects an option with a Regexp' do
+          @select_list.select(/2|3/)
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
       end
 
-      it 'selects an option with a Regexp' do
-        browser.select_list(name: 'new_user_languages').clear
-        browser.select_list(name: 'new_user_languages').select(/^N/)
-        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq ['NO']
+      context 'when finding by text' do
+        it 'selects an option with a String' do
+          @select_list.select('Norwegian')
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
+
+        it 'selects an option with a Regexp' do
+          @select_list.select(/wegia/)
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
       end
-    end
 
-    it 'selects multiple options successively' do
-      browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select('Danish')
-      browser.select_list(name: 'new_user_languages').select('Swedish')
-      expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
-    end
+      context 'when finding by label' do
+        it 'selects an option with a String' do
+          @select_list.select('NO')
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
 
-    bug 'Safari is returning click intercepted error', :safari do
-      it 'selects empty options' do
-        browser.select_list(id: 'delete_user_username').select('')
-        expect(browser.select_list(id: 'delete_user_username').selected_options.map(&:text)).to eq ['']
+        it 'selects an option with a Regexp' do
+          @select_list.select(/^N/)
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
       end
-    end
 
-    it 'returns the value selected' do
-      expect(browser.select_list(name: 'new_user_languages').select('Danish')).to eq 'Danish'
-    end
+      it 'selects multiple options successively' do
+        @select_list.select('Danish')
+        @select_list.select('Swedish')
+        expect(@select_list.selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
 
-    it 'fires onchange event when selecting an item' do
-      browser.select_list(id: 'new_user_languages').select('Danish')
-      expect(messages).to eq ['changed language']
-    end
+      it 'selects each item in an Array' do
+        @select_list.select(%w[Danish Swedish])
+        expect(@select_list.selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
 
-    it "doesn't fire onchange event when selecting an already selected item" do
-      browser.select_list(id: 'new_user_languages').clear # removes the two pre-selected options
-      browser.select_list(id: 'new_user_languages').select('English')
-      expect(messages.size).to eq 3
+      it 'selects each item in a parameter list' do
+        @select_list.select('Danish', 'Swedish')
+        expect(@select_list.selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
 
-      browser.select_list(id: 'new_user_languages').select('English')
-      expect(messages.size).to eq 3
+      bug 'Safari is returning click intercepted error', :safari do
+        it 'selects empty options' do
+          browser.select_list(id: 'delete_user_username').select('')
+          expect(browser.select_list(id: 'delete_user_username').selected_options.map(&:text)).to eq ['']
+        end
+      end
+
+      it 'returns the value selected' do
+        expect(@select_list.select('Danish')).to eq 'Danish'
+      end
+
+      it 'fires onchange event when selecting or deselecting an item' do
+        @select_list.select('Danish')
+        expect(messages).to eq ['changed language', 'changed language', 'changed language']
+      end
+
+      it "doesn't fire onchange event when selecting an already selected item" do
+        @select_list.select('English')
+        expect(messages.size).to eq 3
+
+        @select_list.select('English')
+        expect(messages.size).to eq 3
+      end
     end
 
     bug 'Safari is returning click intercepted error', :safari do
@@ -408,61 +424,77 @@ describe 'SelectList' do
   end
 
   describe '#select!' do
-    context 'when finding by value' do
-      it 'selects an option with a String' do
-        browser.select_list(name: 'new_user_languages').clear
-        browser.select_list(name: 'new_user_languages').select!('2')
-        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[EN]
+    context 'working with multiple select list' do
+      before do
+        @select_list = browser.select_list(name: 'new_user_languages')
+        @select_list.clear
       end
 
-      it 'selects an option with a Regex' do
-        browser.select_list(name: 'new_user_languages').clear
-        browser.select_list(name: 'new_user_languages').select!(/2/)
-        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[EN]
-      end
-    end
+      context 'when finding by value' do
+        it 'selects an option with a String' do
+          @select_list.select!('2')
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
 
-    context 'when finding by text' do
-      it 'selects an option with a String' do
-        browser.select_list(name: 'new_user_country').select!('Denmark')
-        expect(browser.select_list(name: 'new_user_country').selected_options.map(&:text)).to eq ['Denmark']
-      end
+        it 'selects an option with a Number' do
+          @select_list.select!(2)
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
 
-      it 'selects an option with a Regexp' do
-        browser.select_list(name: 'new_user_country').select!(/Denmark/)
-        expect(browser.select_list(name: 'new_user_country').selected_options.map(&:text)).to eq ['Denmark']
-      end
-    end
-
-    context 'when finding by label' do
-      it 'selects an option with a String' do
-        browser.select_list(name: 'new_user_languages').clear
-        browser.select_list(name: 'new_user_languages').select!('NO')
-        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq ['NO']
+        it 'selects an option with a Regexp' do
+          @select_list.select!(/2|3/)
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
       end
 
-      it 'selects an option with a Regexp' do
-        browser.select_list(name: 'new_user_languages').clear
-        browser.select_list(name: 'new_user_languages').select!(/NO/)
-        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq ['NO']
+      context 'when finding by text' do
+        it 'selects an option with a String' do
+          @select_list.select!('Danish')
+          expect(@select_list.selected_options.first.value).to eq '1'
+        end
+
+        it 'selects an option with a Regexp' do
+          @select_list.select!(/ani/)
+          expect(@select_list.selected_options.first.value).to eq '1'
+        end
       end
-    end
 
-    it 'selects multiple items successively' do
-      browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select!('Danish')
-      browser.select_list(name: 'new_user_languages').select!('Swedish')
-      expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
-    end
+      context 'when finding by label' do
+        it 'selects an option with a String' do
+          @select_list.select!('NO')
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
 
-    it 'selects empty options' do
-      browser.select_list(id: 'delete_user_username').select!('')
-      expect(browser.select_list(id: 'delete_user_username').selected_options.map(&:text)).to eq ['']
-    end
+        it 'selects an option with a Regexp' do
+          @select_list.select!(/^N/)
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
+      end
 
-    it 'returns the value selected' do
-      browser.select_list(name: 'new_user_languages').clear
-      expect(browser.select_list(name: 'new_user_languages').select!('Danish')).to eq 'Danish'
+      it 'selects multiple options successively' do
+        @select_list.select!('Danish')
+        @select_list.select!('Swedish')
+        expect(@select_list.selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
+
+      it 'selects each item in an Array' do
+        @select_list.select!(%w[Danish Swedish])
+        expect(@select_list.selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
+
+      it 'selects each item in a parameter list' do
+        @select_list.select!('Danish', 'Swedish')
+        expect(@select_list.selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
+
+      it 'selects empty options' do
+        browser.select_list(id: 'delete_user_username').select!('')
+        expect(browser.select_list(id: 'delete_user_username').selected_options.map(&:text)).to eq ['']
+      end
+
+      it 'returns the value selected' do
+        expect(@select_list.select!('Danish')).to eq 'Danish'
+      end
     end
 
     it 'selects options with a single-quoted value' do
@@ -486,14 +518,12 @@ describe 'SelectList' do
 
     bug 'Safari is returning object enabled instead of disabled', :safari do
       it 'raises ObjectDisabledException if the option is disabled' do
-        browser.select_list(id: 'new_user_languages').clear
-        expect { browser.select_list(id: 'new_user_languages').select!('Russian') }
+        expect { browser.select_list(name: 'new_user_languages').select!('Russian') }
           .to raise_object_disabled_exception
       end
     end
 
     it 'raises a TypeError if argument is not a String, Regexp or Numeric' do
-      browser.select_list(id: 'new_user_languages').clear
       expect { browser.select_list(id: 'new_user_languages').select!({}) }.to raise_error(TypeError)
     end
 

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -266,6 +266,21 @@ describe 'SelectList' do
           @select_list.select(/2|3/)
           expect(@select_list.selected_options.first.text).to eq 'EN'
         end
+
+        it 'uses keyword with a String' do
+          @select_list.select(value: '2')
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
+
+        it 'uses keyword with a Number' do
+          @select_list.select(value: 2)
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
+
+        it 'uses keyword with a Regexp' do
+          @select_list.select(value: /2|3/)
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
       end
 
       context 'when finding by text' do
@@ -278,6 +293,16 @@ describe 'SelectList' do
           @select_list.select(/wegia/)
           expect(@select_list.selected_options.first.value).to eq '3'
         end
+
+        it 'uses keyword with a String' do
+          @select_list.select(text: 'Norwegian')
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
+
+        it 'uses keyword with a Regexp' do
+          @select_list.select(text: /wegia/)
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
       end
 
       context 'when finding by label' do
@@ -288,6 +313,16 @@ describe 'SelectList' do
 
         it 'selects an option with a Regexp' do
           @select_list.select(/^N/)
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
+
+        it 'uses keyword with a String' do
+          @select_list.select(label: 'NO')
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
+
+        it 'uses keyword with a Regexp' do
+          @select_list.select(label: /^N/)
           expect(@select_list.selected_options.first.value).to eq '3'
         end
       end
@@ -366,7 +401,7 @@ describe 'SelectList' do
     end
 
     it 'raises a TypeError if argument is not a String, Regexp or Numeric' do
-      expect { browser.select_list(id: 'new_user_languages').select({}) }.to raise_error(TypeError)
+      expect { browser.select_list(id: 'new_user_languages').select(true) }.to raise_error(TypeError)
     end
 
     context 'multiple options' do
@@ -445,6 +480,21 @@ describe 'SelectList' do
           @select_list.select!(/2|3/)
           expect(@select_list.selected_options.first.text).to eq 'EN'
         end
+
+        it 'uses keyword with a String' do
+          @select_list.select!(value: '2')
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
+
+        it 'uses keyword with a Number' do
+          @select_list.select!(value: 2)
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
+
+        it 'uses keyword with a Regexp' do
+          @select_list.select!(value: /2|3/)
+          expect(@select_list.selected_options.first.text).to eq 'EN'
+        end
       end
 
       context 'when finding by text' do
@@ -457,6 +507,16 @@ describe 'SelectList' do
           @select_list.select!(/ani/)
           expect(@select_list.selected_options.first.value).to eq '1'
         end
+
+        it 'uses keyword with a String' do
+          @select_list.select!(text: 'Danish')
+          expect(@select_list.selected_options.first.value).to eq '1'
+        end
+
+        it 'uses keyword with a Regexp' do
+          @select_list.select!(text: /ani/)
+          expect(@select_list.selected_options.first.value).to eq '1'
+        end
       end
 
       context 'when finding by label' do
@@ -467,6 +527,16 @@ describe 'SelectList' do
 
         it 'selects an option with a Regexp' do
           @select_list.select!(/^N/)
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
+
+        it 'uses keyword with a String' do
+          @select_list.select!(label: 'NO')
+          expect(@select_list.selected_options.first.value).to eq '3'
+        end
+
+        it 'uses keyword with a Regexp' do
+          @select_list.select!(label: /^N/)
           expect(@select_list.selected_options.first.value).to eq '3'
         end
       end
@@ -524,7 +594,7 @@ describe 'SelectList' do
     end
 
     it 'raises a TypeError if argument is not a String, Regexp or Numeric' do
-      expect { browser.select_list(id: 'new_user_languages').select!({}) }.to raise_error(TypeError)
+      expect { browser.select_list(id: 'new_user_languages').select!(true) }.to raise_error(TypeError)
     end
 
     context 'multiple options' do


### PR DESCRIPTION
Update: After further consideration of the code, I don't want to support multiple arguments here. If you need multiple selections, put it in an Array; if you need one selection, put it in the single parameter and it will probably do what you want. If you need to specify it, use one of the keywords. We also need to decide if this goes in 6.18 or 7.0.

--------
After looking at what code I wanted in Watir 7, and the performance of the wire calls to obtain it, I realized that we don't need `Select#select_all`, which I created forever ago in July 2017. My apologies to everyone who updated their code to use it.

I'm not sure why we aren't checking the label for `#include?`

This is the proposed API:

```ruby
# Automatically does what you likely want
browser.select(select_locator).select(value)
browser.select(select_locator).select(text)
browser.select(select_locator).select(label)

# If you need to specify a specific thing to look for (or desperately need to save wire calls)
browser.select(select_locator).select(value: value)
browser.select(select_locator).select(text: text)
browser.select(select_locator).select(label: label)

# To select multiple matching on multi-select lists, you need to put it in an array, or multiple params
browser.select(select_locator).select([/opt/])
browser.select(select_locator).select(option1, option2)
browser.select(select_locator).select([option1, option2]])
browser.select(select_locator).select(value:[value1, value2])
browser.select(select_locator).select(text: [text1, text2])
browser.select(select_locator).select(label: [label1, label2])
```