### PR TITLE
Window switch

### DIFF
--- a/lib/watir/has_window.rb
+++ b/lib/watir/has_window.rb
@@ -51,6 +51,26 @@ module Watir
       @original_window ||= window
     end
 
+    #
+    # Waits for and returns second window if present
+    # See Window#use
+    #
+    # @example
+    #   browser.switch_window
+    #
+    # @return [Window]
+    #
+
+    def switch_window
+      current_window = window
+      wins = windows
+      wait_until { (wins = windows) && wins.size > 1 } if wins.size == 1
+      raise StandardError, 'Unable to determine which window to switch to' if wins.size > 2
+
+      wins.find { |w| w != current_window }.use
+      window
+    end
+
     private
 
     def filter_windows(selector, windows)

--- a/spec/watirspec/html/window_switching.html
+++ b/spec/watirspec/html/window_switching.html
@@ -2,11 +2,21 @@
 <html>
   <head>
     <title>window switching</title>
+    <script>
+        function windowOpenDelayed(timeout) {
+            setTimeout(function() {
+                window.open("closeable.html");
+            }, timeout);
+        }
+    </script>
   </head>
 
   <body>
     <p>
       Click <a id="open" href="#" onclick='window.open("closeable.html")'>here</a> to open a new window.
+    </p>
+    <p>
+      Click <a id="delayed" href="#" onclick=windowOpenDelayed(1000)>here</a> to open a new window after a delay.
     </p>
   </body>
 </html>

--- a/spec/watirspec/window_switching_spec.rb
+++ b/spec/watirspec/window_switching_spec.rb
@@ -92,6 +92,40 @@ describe 'Browser' do
       expect { browser.window(handle: 'bar').use }.to raise_no_matching_window_exception
     end
   end
+
+  describe '#switch_window' do
+    it 'switches to second window' do
+      original_window = browser.window
+      browser.switch_window
+      new_window = browser.window
+
+      expect(original_window).to_not eq new_window
+      expect(browser.windows).to include(original_window, new_window)
+    end
+
+    it 'returns an instance of Window' do
+      expect(browser.switch_window).to be_a(Watir::Window)
+    end
+
+    it 'times out if there is no second window' do
+      browser.windows.reject(&:current?).each(&:close)
+      message = /waiting for true condition on (.*) title="window switching">$/
+      expect { browser.switch_window }.to raise_timeout_exception(message)
+    end
+
+    it 'provides previous window value to #original_window' do
+      browser.switch_window
+      expect(browser.original_window).to_not be_nil
+    end
+
+    it 'waits for second window' do
+      browser.windows.reject(&:current?).each(&:close)
+      expect {
+        browser.a(id: 'delayed').click
+        browser.switch_window
+      }.to execute_when_satisfied(min: 1)
+    end
+  end
 end
 
 describe 'Window' do


### PR DESCRIPTION
#848 reminded me that I don't like the current window switching code.

First, when working with safari driver recently I definitively came across a case where a newly opened window was indexed first in `#window_handles` call, so this really needs to get deprecated. 

If we aren't using indexes, then we need a way for people to avoid having to know title or url, since 90% of the time, users who are working with windows are only going to be dealing with two windows at most; they really just want: "give me the other one."

Right now, and no longer effective: `browser.windows.last.use`
Only option with current code: `browser.window(title_or_url_opt).use`
Proposed: `browser.switch_window`

This then allows us to get back to: `browser.original_window.use`

I have code for allowing switch_window to accept parameters, but it would essentially be the same thing as #use, so I'm on the fence as to whether it should be included.
```
browser.switch_window(title_or_url_opt)
# vs
browser.window(title_or_url_opt).use
```
