### PR TITLE
implement FileField#upload as alias of #set

### DIFF
--- a/lib/watir/elements/file_field.rb
+++ b/lib/watir/elements/file_field.rb
@@ -12,6 +12,7 @@ module Watir
 
       self.value = path
     end
+    alias upload set
 
     #
     # Sets the file field to the given path

--- a/spec/watirspec/elements/filefield_spec.rb
+++ b/spec/watirspec/elements/filefield_spec.rb
@@ -95,13 +95,11 @@ describe 'FileField' do
     it 'is able to set a file path in the field and click the upload button and fire the onchange event' do
       browser.goto WatirSpec.url_for('forms_with_input_elements.html')
 
-      path = File.expand_path(__FILE__)
       element = browser.file_field(name: 'new_user_portrait')
+      element.upload __FILE__
 
-      element.set path
-
-      expect(element.value).to include(File.basename(path)) # only some browser will return the full path
-      expect(messages.first).to include(File.basename(path))
+      expect(element.value).to include(File.basename(__FILE__)) # only some browser will return the full path
+      expect(messages.first).to include(File.basename(__FILE__))
 
       browser.button(name: 'new_user_submit').click
     end


### PR DESCRIPTION
So, `__FILE__` is giving me a full path, is there a reason we had `File.expand_path` before? I'm not even sure `#expand_path` is actually correct for what we wanted, anyway?

Also, I very much like the idea of `browser.file_field.upload(file)` (instead of just `#set`)

Clarity inspired by #855 