### PR TITLE
Element#right_click now accepts modifiers.

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -196,15 +196,34 @@ module Watir
     end
 
     #
-    # Right clicks the element.
-    # Note that browser support may vary.
+    # Right clicks the element, optionally while pressing the given modifier keys.
+    # Note that support for holding a modifier key is currently experimental,
+    # and may not work at all. Also, the browser support may vary.
     #
     # @example
     #   browser.element(name: "new_user_button").right_click
     #
+    # @example Right click an element with shift key pressed
+    #   browser.element(name: "new_user_button").right_click(:shift)
+    #
+    # @example Click an element with several modifier keys pressed
+    #   browser.element(name: "new_user_button").right_click(:shift, :alt)
+    #
+    # @param [:shift, :alt, :control, :command, :meta] modifiers to press while right clicking.
+    #
 
-    def right_click
-      element_call(:wait_for_present) { driver.action.context_click(@element).perform }
+    def right_click(*modifiers)
+      element_call(:wait_for_present) do
+        action = driver.action
+        if modifiers.any?
+          modifiers.each { |mod| action.key_down mod }
+          action.context_click(@element).perform
+          modifiers.each { |mod| action.key_up mod }
+        else
+          action.context_click(@element).perform
+        end
+      end
+
       browser.after_hooks.run
     end
 

--- a/lib/watirspec/runner.rb
+++ b/lib/watirspec/runner.rb
@@ -10,6 +10,10 @@ module WatirSpec
       def messages
         browser.div(id: 'messages').divs.map(&:text)
       end
+
+      def event_log
+        browser.div(id: 'log').wait_until(&:present?).ps.map(&:text)
+      end
     end
 
     module_function

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -222,6 +222,12 @@ describe 'Div' do
         browser.div(id: 'click').right_click
         expect(messages.first).to eq 'right-clicked'
       end
+
+      it 'accepts modifiers' do
+        browser.goto(WatirSpec.url_for('right_click.html'))
+        browser.div(id: 'click-logger').right_click(:shift, :alt)
+        expect(event_log.first).to eq('shift=true alt=true')
+      end
     end
   end
 

--- a/spec/watirspec/html/right_click.html
+++ b/spec/watirspec/html/right_click.html
@@ -3,9 +3,21 @@
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
     <title>Right Click Test</title>
     <script src="javascript/helpers.js" type="text/javascript" charset="utf-8"></script>
+    <script src="javascript/jquery-1.7.1.min.js" type="text/javascript" charset="utf-8"></script>
   </head>
+  <script>
+    $(document).ready(function() {
+      $(document).on("contextmenu", "#click-logger", function(evt){
+        $("#log").append("<p>shift=" + evt.shiftKey + " alt=" + evt.altKey + "</p>");
+        return false;
+      });
+    });
+  </script>
   <body>
     <div id="messages"></div>
     <div id="click" oncontextmenu='WatirSpec.addMessage("right-clicked"); return false'>Right click!</div>
+    <br />
+    <div id="click-logger">Right click with modifiers!</div>
+    <div id="log"></div>
   </body>
 </html>


### PR DESCRIPTION
This fulfills a requirement that I have to test certain "special fields" that display debug info when a right click with `:control` is performed.

**Example**
`browser.element(id: 'my-el').right_click(:shift, :alt)`

@titusfortner and I had a discussion on this a while ago, and we had agreed that since `#click` accepts modifiers, `#right_click` could as well.