### PR TITLE
Locating element by partial text only considers direct child text nodes

### DIFF
--- a/lib/watir/locators/element/selector_builder/xpath.rb
+++ b/lib/watir/locators/element/selector_builder/xpath.rb
@@ -211,7 +211,7 @@ module Watir
             when :text
               'normalize-space()'
             when :contains_text
-              'text()'
+              'normalize-space()'
             when ::Symbol
               lhs = "@#{key.to_s.tr('_', '-')}"
               downcase ? XpathSupport.downcase(lhs) : lhs

--- a/spec/unit/selector_builder/button_spec.rb
+++ b/spec/unit/selector_builder/button_spec.rb
@@ -75,35 +75,35 @@ describe Watir::Locators::Button::SelectorBuilder do
 
       it 'locates value of input element with simple Regexp' do
         selector = {text: /Button/}
-        built = {xpath: ".//*[(local-name()='button' and contains(text(), 'Button')) or " \
+        built = {xpath: ".//*[(local-name()='button' and contains(normalize-space(), 'Button')) or " \
 "(local-name()='input' and (#{default_types}) and contains(@value, 'Button'))]"}
         expect(selector_builder.build(selector)).to eq built
       end
 
       it 'locates text of button element with simple Regexp' do
         selector = {text: /Button 2/}
-        built = {xpath: ".//*[(local-name()='button' and contains(text(), 'Button 2')) or " \
+        built = {xpath: ".//*[(local-name()='button' and contains(normalize-space(), 'Button 2')) or " \
 "(local-name()='input' and (#{default_types}) and contains(@value, 'Button 2'))]"}
         expect(selector_builder.build(selector)).to eq built
       end
 
       it 'Simple Regexp for text' do
         selector = {text: /n 2/}
-        built = {xpath: ".//*[(local-name()='button' and contains(text(), 'n 2')) or " \
+        built = {xpath: ".//*[(local-name()='button' and contains(normalize-space(), 'n 2')) or " \
 "(local-name()='input' and (#{default_types}) and contains(@value, 'n 2'))]"}
         expect(selector_builder.build(selector)).to eq built
       end
 
       it 'Simple Regexp for value' do
         selector = {text: /Prev/}
-        built = {xpath: ".//*[(local-name()='button' and contains(text(), 'Prev')) or " \
+        built = {xpath: ".//*[(local-name()='button' and contains(normalize-space(), 'Prev')) or " \
 "(local-name()='input' and (#{default_types}) and contains(@value, 'Prev'))]"}
         expect(selector_builder.build(selector)).to eq built
       end
 
       it 'returns complex Regexp to the locator' do
         selector = {text: /^foo$/}
-        built = {xpath: ".//*[(local-name()='button' and contains(text(), 'foo')) or " \
+        built = {xpath: ".//*[(local-name()='button' and contains(normalize-space(), 'foo')) or " \
 "(local-name()='input' and (#{default_types}) and contains(@value, 'foo'))]", text: /^foo$/}
         expect(selector_builder.build(selector)).to eq built
       end
@@ -127,14 +127,14 @@ describe Watir::Locators::Button::SelectorBuilder do
       it 'input element value with simple Regexp' do
         selector = {value: /Prev/}
         built = {xpath: ".//*[(local-name()='button') or (local-name()='input' and (#{default_types}))]" \
-"[contains(text(), 'Prev') or contains(@value, 'Prev')]"}
+"[contains(normalize-space(), 'Prev') or contains(@value, 'Prev')]"}
         expect(selector_builder.build(selector)).to eq built
       end
 
       it 'button element value with simple Regexp' do
         selector = {value: /on_2/}
         built = {xpath: ".//*[(local-name()='button') or (local-name()='input' and (#{default_types}))]" \
-"[contains(text(), 'on_2') or contains(@value, 'on_2')]"}
+"[contains(normalize-space(), 'on_2') or contains(@value, 'on_2')]"}
         expect(selector_builder.build(selector)).to eq built
       end
 
@@ -148,14 +148,14 @@ describe Watir::Locators::Button::SelectorBuilder do
       it 'button element text with simple Regexp' do
         selector = {value: /ton 2/}
         built = {xpath: ".//*[(local-name()='button') or (local-name()='input' and (#{default_types}))]" \
-"[contains(text(), 'ton 2') or contains(@value, 'ton 2')]"}
+"[contains(normalize-space(), 'ton 2') or contains(@value, 'ton 2')]"}
         expect(selector_builder.build(selector)).to eq built
       end
 
       it 'returns complex Regexp to the locator' do
         selector = {value: /^foo$/}
         built = {xpath: ".//*[(local-name()='button') or (local-name()='input' and (#{default_types}))]" \
-"[contains(text(), 'foo') or contains(@value, 'foo')]", value: /^foo$/}
+"[contains(normalize-space(), 'foo') or contains(@value, 'foo')]", value: /^foo$/}
         expect(selector_builder.build(selector)).to eq built
       end
     end

--- a/spec/watirspec/elements/button_spec.rb
+++ b/spec/watirspec/elements/button_spec.rb
@@ -37,6 +37,8 @@ describe 'Button' do
       expect(browser.button(text: /Button 2/)).to exist
       expect(browser.button(value: 'Button 2')).to exist
       expect(browser.button(value: /Button 2/)).to exist
+      expect(browser.button(value: 'Button 4 With Child Text')).to exist
+      expect(browser.button(value: /Button 4 With Child Text/)).to exist
     end
 
     it 'returns true if the button exists (how = :caption)' do

--- a/spec/watirspec/elements/buttons_spec.rb
+++ b/spec/watirspec/elements/buttons_spec.rb
@@ -13,7 +13,7 @@ describe 'Buttons' do
 
   describe '#length' do
     it 'returns the number of buttons' do
-      expect(browser.buttons.length).to eq 10
+      expect(browser.buttons.length).to eq 11
     end
   end
 

--- a/spec/watirspec/html/forms_with_input_elements.html
+++ b/spec/watirspec/html/forms_with_input_elements.html
@@ -133,6 +133,7 @@
             <input type="BuTTon" name="new_user_button_preview" id="new_user_button_preview" alt="Create a new user" value="Preview" data-locator="preview"/>
             <button name="new_user_button_2" type="submit" value="button_2" data-locator="Benjamin">Button 2</button>
             <button name="new_user_button_3" value="button_3" data-locator="No Type">Button 3</button>
+            <button name="new_user_button_4" value="button_4" data-locator="child text">  Button 4  <span>  With  Child  Text  </span>  </button>
             <input type="image" class="image" name="new_user_image" src="images/button.png" alt="Submittable button" data-locator="submittable button"/>
             <input type="submit" name="new_user_submit_disabled" id="disabled_button" value="Disabled" disabled="disabled" data-locator="disabled" />
             <input type="checkbox" name="new_user_submit_disabled" id="toggle_button_checkbox" onclick="var elem = document.getElementById('disabled_button'); elem.disabled = !elem.disabled" />


### PR DESCRIPTION
Fixes #866 

Note that in the SelectorBuilder::XPath that :text and :contains_text are now the same - ie comparing to `normalize-space()`. From what I could see, there's no reason that they should ever be different. However, for now, to minimize changes, I have left them separate.