### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/watir.gemspec
+++ b/watir.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   DESCRIPTION_MESSAGE
 
   s.license = 'MIT'
-  s.rubyforge_project = 'watir'
 
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.