### PR TITLE
Fix failing tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,7 @@ gem 'webidl', path: File.expand_path('../webidl') if ENV['LOCAL_WEBIDL']
 
 gem 'selenium-webdriver', path: File.expand_path('../selenium/build/rb') if ENV['LOCAL_SELENIUM']
 
+gem 'ffi' if Gem.win_platform? # For selenium-webdriver on Windows
+
 # Specify your gem's dependencies in watir.gemspec
 gemspec

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,8 @@ version: "#{build}"
 build: off
 clone_depth: 100
 install:
-  - set PATH=C:\Ruby23\bin;%PATH%
+  - set PATH=C:\Ruby25\bin;%PATH%
+  - gem update --system
   - bundle install
 test_script:
   - bundle exec rake %RAKE_TASK%

--- a/lib/watir/after_hooks.rb
+++ b/lib/watir/after_hooks.rb
@@ -69,8 +69,8 @@ module Watir
       return unless @after_hooks.any? && !@browser.alert.exists?
 
       each { |after_hook| after_hook.call(@browser) }
-    rescue Selenium::WebDriver::Error::NoSuchWindowError => ex
-      Watir.logger.info "Could not execute After Hooks because browser window was closed #{ex}"
+    rescue Selenium::WebDriver::Error::NoSuchWindowError => e
+      Watir.logger.info "Could not execute After Hooks because browser window was closed #{e}"
     end
 
     #

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -759,6 +759,7 @@ module Watir
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/CyclomaticComplexity:
+    # rubocop:disable Lint/ShadowedException
     def element_call(precondition = nil, &block)
       caller = caller_locations(1, 1)[0].label
       already_locked = Wait.timer.locked?
@@ -799,6 +800,7 @@ module Watir
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
     # rubocop:enable Metrics/CyclomaticComplexity:
+    # rubocop:enable Lint/ShadowedException
 
     def check_condition(condition, caller)
       Watir.logger.debug "<- `Verifying precondition #{inspect}##{condition} for #{caller}`"

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -244,7 +244,7 @@ module Watir
     # Note that browser support may vary.
     #
     # @example
-    #   browser.div(id: "draggable").drag_and_drop_by 100, -200
+    #   browser.div(id: "draggable").drag_and_drop_by 100, 25
     #
     # @param [Integer] right_by
     # @param [Integer] down_by

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -768,9 +768,9 @@ module Watir
         check_condition(precondition, caller)
         Watir.logger.debug "-> `Executing #{inspect}##{caller}`"
         yield
-      rescue unknown_exception => ex
+      rescue unknown_exception => e
         element_call(:wait_for_exists, &block) if precondition.nil?
-        msg = ex.message
+        msg = e.message
         msg += '; Maybe look in an iframe?' if @query_scope.iframe.exists?
         custom_attributes = @locator.nil? ? [] : selector_builder.custom_attributes
         unless custom_attributes.empty?

--- a/lib/watir/generator/base/spec_extractor.rb
+++ b/lib/watir/generator/base/spec_extractor.rb
@@ -109,8 +109,8 @@ module Watir
             begin
               intf = fetch_interface(implementor_name).first
               intf.implements << fetch_interface(implementee_name).first
-            rescue InterfaceNotFound => ex
-              puts ex.message
+            rescue InterfaceNotFound => e
+              puts e.message
             end
           end
         end
@@ -123,8 +123,8 @@ module Watir
             begin
               intf = fetch_interface(includer_name).first
               intf.includes << fetch_interface(includee_name).first
-            rescue InterfaceNotFound => ex
-              puts ex.message
+            rescue InterfaceNotFound => e
+              puts e.message
             end
           end
         end

--- a/lib/watir/window.rb
+++ b/lib/watir/window.rb
@@ -226,6 +226,7 @@ module Watir
       nil
     end
 
+    # rubocop:disable Lint/ShadowedException
     def matches?(handle)
       @driver.switch_to.window(handle) do
         matches_title = @selector[:title].nil? || @browser.title =~ /#{@selector[:title]}/
@@ -237,6 +238,7 @@ module Watir
       # the window may disappear while we're iterating.
       false
     end
+    # rubocop:enable Lint/ShadowedException
 
     def wait_for_exists
       return assert_exists unless Watir.relaxed_locate?

--- a/spec/watirspec/browser_spec.rb
+++ b/spec/watirspec/browser_spec.rb
@@ -157,8 +157,8 @@ describe 'Browser' do
           @original = WatirSpec.implementation.clone
 
           require 'watirspec/remote_server'
-          args = ["-Dwebdriver.chrome.driver=#{Webdrivers::Chromedriver.binary}",
-                  "-Dwebdriver.gecko.driver=#{Webdrivers::Geckodriver.binary}"]
+          args = ["-Dwebdriver.chrome.driver=#{Webdrivers::Chromedriver.driver_path}",
+                  "-Dwebdriver.gecko.driver=#{Webdrivers::Geckodriver.driver_path}"]
           WatirSpec::RemoteServer.new.start(4544, args: args)
           browser.close
         end

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -895,7 +895,7 @@ describe 'Element' do
         expect { btn.click }.to raise_exception(Selenium::WebDriver::Error::ElementClickInterceptedError)
       end
       compliant_on :chrome do
-        expect { btn.click }.to raise_exception(Selenium::WebDriver::Error::UnknownError)
+        expect { btn.click }.to raise_exception(Selenium::WebDriver::Error::ElementClickInterceptedError)
       end
       compliant_on :safari do
         expect { btn.click }.to raise_exception(Selenium::WebDriver::Error::WebDriverError)

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -62,10 +62,10 @@ if defined?(RSpec)
         begin
           actual.call
           false
-        rescue exception => ex
-          return true if message.nil? || ex.message.match(message)
+        rescue exception => e
+          return true if message.nil? || e.message.match(message)
 
-          raise exception, "expected '#{message}' to be included in: '#{ex.message}'"
+          raise exception, "expected '#{message}' to be included in: '#{e.message}'"
         ensure
           Watir.default_timeout = original_timeout
         end
@@ -88,10 +88,10 @@ if defined?(RSpec)
           start_time = ::Time.now
           actual.call
           false
-        rescue exception => ex
+        rescue exception => e
           finish_time = ::Time.now
-          unless message.nil? || ex.message.match(message)
-            raise exception, "expected '#{message}' to be included in: '#{ex.message}'"
+          unless message.nil? || e.message.match(message)
+            raise exception, "expected '#{message}' to be included in: '#{e.message}'"
           end
 
           @time_difference = finish_time - start_time

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -29,11 +29,9 @@ class LocalConfig
   def load_webdrivers
     case browser
     when :chrome
-      Webdrivers::Chromedriver.version = 2.44 if ENV['APPVEYOR']
       Webdrivers::Chromedriver.update
       Watir.logger.info "chromedriver version: #{Webdrivers::Chromedriver.current_version.version}"
     when :firefox
-      Webdrivers::Geckodriver.version = '0.20.1' if ENV['APPVEYOR']
       Webdrivers::Geckodriver.update
       Watir.logger.info "geckodriver version: #{Webdrivers::Geckodriver.current_version.version}"
     end
@@ -144,8 +142,8 @@ class RemoteConfig < LocalConfig
       require 'watirspec/remote_server'
 
       remote_server = WatirSpec::RemoteServer.new
-      args = ["-Dwebdriver.chrome.driver=#{Webdrivers::Chromedriver.binary}",
-              "-Dwebdriver.gecko.driver=#{Webdrivers::Geckodriver.binary}"]
+      args = ["-Dwebdriver.chrome.driver=#{Webdrivers::Chromedriver.driver_path}",
+              "-Dwebdriver.gecko.driver=#{Webdrivers::Geckodriver.driver_path}"]
       remote_server.start(4444, args: args)
       remote_server.server.webdriver_url
     end

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'selenium_statistics'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'simplecov-console'
-  s.add_development_dependency 'webdrivers', '~> 3.5.2'
+  s.add_development_dependency 'webdrivers', '~> 4.1.0'
   s.add_development_dependency 'webidl', '>= 0.2.2'
   s.add_development_dependency 'yard', '> 0.8.2.1'
   s.add_development_dependency 'yard-doctest', '~> 0.1.14'


### PR DESCRIPTION
Fix for various failures on Appveyor and Travis CI.

- Use Ruby 2.5 on Appveyor
- Upgrade to `webdrivers` v4.1.x
- Fix almost all rubocop offenses - 2 are still failing - I have disabled the `Lint/ShadowedException` cop for these as they probably require refactoring and I don't know enough to do it without help. Let me know if you would like to tackle these differently.