### PR TITLE
Less strict version check for `regexp_parser` gem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Less strict version check for `regexp_parser` gem
+
 ### 6.17.0 (2020-08-27)
 * Require Ruby > 2.5
 * Implement Logger#selenium= to set selenium level from Watir

--- a/watir.gemspec
+++ b/watir.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency 'selenium-webdriver', '~> 3.6'
-  s.add_runtime_dependency 'regexp_parser', '~>1.2'
+  s.add_runtime_dependency 'regexp_parser', '>= 1.2', '< 3'
 
   s.add_development_dependency 'activesupport', '~> 4.0', '>= 4.1.11' # for pluralization during code generation
   s.add_development_dependency 'coveralls'


### PR DESCRIPTION
Current version of rubocop require `regexp_parser` >= 2.0
https://github.com/rubocop-hq/rubocop/blob/master/rubocop.gemspec#L36
Couldn't user both latest watir gem and latest rubocop