### PR TITLE
Fix Ruby Debug Mode Warnings

### DIFF
--- a/lib/watir/adjacent.rb
+++ b/lib/watir/adjacent.rb
@@ -117,7 +117,7 @@ module Watir
         el = Watir.element_class_for(opt[:tag_name] || '').new(self, opt)
         el.is_a?(Input) ? el.to_subtype : el
       elsif opt[:tag_name]
-        Object.const_get("#{Watir.element_class_for(opt[:tag_name])}Collection").new(self, opt)
+        Watir.const_get("#{Watir.element_class_for(opt[:tag_name])}Collection").new(self, opt)
       else
         HTMLElementCollection.new(self, opt)
       end

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -83,6 +83,7 @@ module Watir
       false
     end
     alias present? exists?
+    alias exist? exists?
 
     #
     # @api private

--- a/lib/watir/attribute_helper.rb
+++ b/lib/watir/attribute_helper.rb
@@ -46,6 +46,8 @@ module Watir
     #  @return [$1] value of $3 property
     #
     def attribute(type, method, attr)
+      return if method_defined?(method)
+
       typed_attributes[type] << [method, attr]
       define_attribute(type, method, attr)
     end

--- a/lib/watir/cookies.rb
+++ b/lib/watir/cookies.rb
@@ -106,6 +106,8 @@ module Watir
     end
 
     #
+    # TODO: Use :permitted_classes keyword when minimum supported Ruby is 2.6
+    #
     # Load cookies from file
     #
     # @example

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -192,7 +192,7 @@ module Watir
     end
 
     def element_class
-      Kernel.const_get(self.class.name.sub(/Collection$/, ''))
+      Watir.const_get(self.class.name.sub(/Collection$/, ''))
     end
 
     def construct_subtype(element, hash, tag_name)

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -12,6 +12,7 @@ module Watir
     def initialize(query_scope, selector)
       @query_scope = query_scope
       @selector = selector
+      @to_a = nil
 
       build unless @selector.key?(:element)
     end

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -673,7 +673,7 @@ module Watir
 
     def wait_for_enabled
       wait_for_exists
-      return unless [Input, Button, Select, Option].any? { |c| is_a? c } || @content_editable
+      return unless [Input, Button, Select, Option].any? { |c| is_a? c } || content_editable
       return if enabled?
 
       begin
@@ -754,6 +754,7 @@ module Watir
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity:
+    # rubocop:disable Metrics/PerceivedComplexity::
     def element_call(precondition = nil, &block)
       caller = caller_locations(1, 1)[0].label
       already_locked = browser.timer.locked?
@@ -767,7 +768,7 @@ module Watir
         element_call(:wait_for_exists, &block) if precondition.nil?
         msg = e.message
         msg += '; Maybe look in an iframe?' if @query_scope.iframe.exists?
-        custom_attributes = @locator.nil? ? [] : selector_builder.custom_attributes
+        custom_attributes = !defined?(@locator) || @locator.nil? ? [] : selector_builder.custom_attributes
         unless custom_attributes.empty?
           msg += "; Watir treated #{custom_attributes} as a non-HTML compliant attribute, ensure that was intended"
         end
@@ -790,8 +791,8 @@ module Watir
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
-
-    # rubocop:enable Metrics/CyclomaticComplexity:
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def check_condition(condition, caller)
       Watir.logger.debug "<- `Verifying precondition #{inspect}##{condition} for #{caller}`"

--- a/lib/watir/elements/option.rb
+++ b/lib/watir/elements/option.rb
@@ -34,16 +34,6 @@ module Watir
     end
 
     #
-    # Is this option selected?
-    #
-    # @return [Boolean]
-    #
-
-    def selected?
-      element_call { @element.selected? }
-    end
-
-    #
     # Returns the text of option.
     #
     # getAttribute atom pulls the text value if the label does not exist

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -99,18 +99,6 @@ module Watir
     end
 
     #
-    # Returns the value of the first selected option in the select list.
-    # Returns nil if no option is selected.
-    #
-    # @return [String, nil]
-    #
-
-    def value
-      option = selected_options.first
-      option&.value
-    end
-
-    #
     # Returns the text of the first selected option in the select list.
     # Returns nil if no option is selected.
     #

--- a/lib/watir/locators.rb
+++ b/lib/watir/locators.rb
@@ -51,9 +51,7 @@ module Watir
       end
 
       def class_from_string(string)
-        Kernel.const_get(string)
-      rescue NameError
-        nil
+        Watir.const_get(string) if Watir.const_defined?(string)
       end
 
       def element_class_name

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -119,7 +119,7 @@ module Watir
 
         # Extensions implement this method when creating a different selector builder
         def implementation_class
-          Kernel.const_get("#{self.class.name}::XPath")
+          Watir.const_get("#{self.class.name}::XPath")
         end
 
         def build_wd_selector(selector)

--- a/lib/watir/logger.rb
+++ b/lib/watir/logger.rb
@@ -25,7 +25,7 @@ module Watir
                    :warn?,
                    :error, :error?,
                    :fatal, :fatal?,
-                   :level
+                   :level, :level=
 
     def initialize(progname = 'Watir')
       @logger = create_logger($stdout)
@@ -48,22 +48,6 @@ module Watir
       msg = ids.empty? ? '' : "[#{ids.map!(&:to_s).map(&:inspect).join(', ')}] "
       msg += message
       @logger.warn(msg, &block) unless (@ignored & ids).any?
-    end
-
-    #
-    # For Ruby < 2.4 compatibility
-    # Based on https://github.com/ruby/ruby/blob/ruby_2_3/lib/logger.rb#L250
-    #
-
-    def level=(severity)
-      if severity.is_a?(Integer)
-        @logger.level = severity
-      else
-        levels = %w[debug info warn error fatal unknown]
-        raise ArgumentError, "invalid log level: #{severity}" unless levels.include? severity.to_s.downcase
-
-        @logger.level = severity.to_s.upcase
-      end
     end
 
     #

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -4,7 +4,7 @@ module Watir
     include Exception
     include Enumerable
 
-    delegate %i[exists? present? visible? browser] => :source
+    delegate %i[exist? exists? present? visible? browser] => :source
 
     attr_reader :source, :frame
 

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -201,7 +201,7 @@ module Watir
     end
     alias eql? ==
 
-    # Ruby 2.4+ complains about using #delegate to do this
+    # Delegating to Private Methods
     %i[assert_exists element_call].each do |method|
       define_method(method) do |*args, &blk|
         source.send(method, *args, &blk)

--- a/lib/watir/user_editable.rb
+++ b/lib/watir/user_editable.rb
@@ -21,13 +21,17 @@ module Watir
     # @param [String, Symbol] args
     #
 
+    def content_editable
+      defined?(@content_editable) && content_editable?
+    end
+
     def set!(*args)
       msg = '#set! does not support special keys, use #set instead'
       raise ArgumentError, msg if args.any? { |v| v.is_a?(::Symbol) }
 
       input_value = args.join
       set input_value[0]
-      return content_editable_set!(*args) if @content_editable
+      return content_editable_set!(*args) if content_editable
 
       element_call { execute_js(:setValue, @element, input_value[0..-2]) }
       append(input_value[-1])
@@ -43,7 +47,7 @@ module Watir
     #
 
     def append(*args)
-      raise NotImplementedError, '#append method is not supported with contenteditable element' if @content_editable
+      raise NotImplementedError, '#append method is not supported with contenteditable element' if content_editable
 
       send_keys(*args)
     end

--- a/lib/watir/wait/timer.rb
+++ b/lib/watir/wait/timer.rb
@@ -2,7 +2,7 @@ module Watir
   module Wait
     class Timer
       def initialize(timeout: nil)
-        @end_time = current_time + timeout if timeout
+        @end_time = timeout ? current_time + timeout : nil
         @remaining_time = @end_time - current_time if @end_time
       end
 

--- a/lib/watirspec/implementation.rb
+++ b/lib/watirspec/implementation.rb
@@ -7,10 +7,8 @@ module WatirSpec
       @guard_proc = nil
     end
 
-    def initialize_copy(orig)
-      super
-      # Backward compatibility < Ruby 2.4
-      @browser_args = browser_args.map { |arg| arg.is_a?(Symbol) ? arg : arg.dup }
+    def initialize_copy(_orig)
+      @browser_args = browser_args.map(&:dup)
     end
 
     def browser_class

--- a/lib/watirspec/runner.rb
+++ b/lib/watirspec/runner.rb
@@ -33,7 +33,7 @@ module WatirSpec
     end
 
     def execute_if_necessary
-      execute if !@executed && @execute
+      execute if (!defined?(@executed) || !@executed) && @execute
     end
 
     def configure

--- a/lib/watirspec/server.rb
+++ b/lib/watirspec/server.rb
@@ -24,7 +24,7 @@ module WatirSpec
       private
 
       def running?
-        @running
+        defined?(@running) && @running
       end
 
       def run_server

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -50,6 +50,8 @@ describe 'Browser::AfterHooks' do
   end
 
   describe '#run' do
+    before { @yield = nil }
+
     after(:each) do
       browser.original_window.use
       browser.after_hooks.delete @page_after_hook

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -83,10 +83,10 @@ describe 'SelectList' do
 
     it 'returns the value of the selected options' do
       browser.select_list(name: 'new_user_languages').select('1')
-      expect(browser.select_list(name: 'new_user_languages').value).to eq "1"
+      expect(browser.select_list(name: 'new_user_languages').value).to eq '1'
       browser.select_list(name: 'new_user_languages').clear
       browser.select_list(name: 'new_user_languages').select('NO')
-      expect(browser.select_list(name: 'new_user_languages').value).to eq "3"
+      expect(browser.select_list(name: 'new_user_languages').value).to eq '3'
     end
 
     it "raises UnknownObjectException if the select list doesn't exist" do

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -81,6 +81,14 @@ describe 'SelectList' do
       expect(browser.select_list(index: 0).value).to eq '3'
     end
 
+    it 'returns the value of the selected options' do
+      browser.select_list(name: 'new_user_languages').select('1')
+      expect(browser.select_list(name: 'new_user_languages').value).to eq "1"
+      browser.select_list(name: 'new_user_languages').clear
+      browser.select_list(name: 'new_user_languages').select('NO')
+      expect(browser.select_list(name: 'new_user_languages').value).to eq "3"
+    end
+
     it "raises UnknownObjectException if the select list doesn't exist" do
       expect { browser.select_list(index: 1337).value }.to raise_unknown_object_exception
     end

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -102,7 +102,7 @@ if defined?(RSpec)
 
   RSpec::Matchers.define :exist do |*args|
     match do |actual|
-      actual.exists?(*args)
+      actual.exist?(*args)
     end
 
     failure_message do |obj|


### PR DESCRIPTION
Edit: Moved this into draft status because I don't want to remove the methods in the first commit. At the very least they need to be implemented with `WebElement#property` instead of `WebElement#attribute`.

Based on #906 
Fixes #898 

`Option#selected?` and `Select#value` are essentially re-defining a call to an existing attribute method. We either keep the redefinition for better documentation purposes, or we get the verbose mode warning.

The YAML warning can't be fixed until we no longer support ruby 2.5

I aliased a few `#exist?` to `#exists?` so that the RSpec matcher wouldn't complain, and I don't see a downside to it.