### PR TITLE
Fix Ruby warnings

### DIFF
--- a/.github/actions/enable-safari/action.yml
+++ b/.github/actions/enable-safari/action.yml
@@ -1,0 +1,11 @@
+name: 'Enable Safari Driver'
+description: 'Set safaridriver to run in automation mode'
+runs:
+  using: composite
+  steps:
+    - run: |
+        defaults write com.apple.Safari IncludeDevelopMenu YES
+        defaults write com.apple.Safari AllowRemoteAutomation 1
+        sudo safaridriver --enable
+        safaridriver -p 0 &
+      shell: bash

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -36,3 +36,20 @@ jobs:
       - run: bundle install
       - run: |
           bundle exec rake spec:${{ matrix.task }}
+
+  safari-test:
+    name: Safari Test
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [ 'safari' ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+      - run: bundle install
+      - uses: ./.github/actions/enable-safari
+      - run: |
+          bundle exec rake spec:${{ matrix.task }}

--- a/lib/watir/alert.rb
+++ b/lib/watir/alert.rb
@@ -84,6 +84,7 @@ module Watir
       false
     end
     alias present? exists?
+    alias exist? exists?
 
     #
     # @api private

--- a/lib/watir/attribute_helper.rb
+++ b/lib/watir/attribute_helper.rb
@@ -46,6 +46,8 @@ module Watir
     #  @return [$1] value of $3 property
     #
     def attribute(type, method, attr)
+      return if method_defined?(method)
+
       typed_attributes[type] << [method, attr]
       define_attribute(type, method, attr)
     end

--- a/lib/watir/cookies.rb
+++ b/lib/watir/cookies.rb
@@ -106,6 +106,8 @@ module Watir
     end
 
     #
+    # TODO: Use :permitted_classes keyword when minimum supported Ruby is 2.6
+    #
     # Load cookies from file
     #
     # @example

--- a/lib/watir/element_collection.rb
+++ b/lib/watir/element_collection.rb
@@ -13,6 +13,7 @@ module Watir
     def initialize(query_scope, selector)
       @query_scope = query_scope
       @selector = selector
+      @to_a = nil
 
       build unless @selector.key?(:element)
     end

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -149,7 +149,6 @@ module Watir
     #
 
     def click(*modifiers)
-      # TODO: Should wait_for_enabled be default, or `Button` specific behavior?
       element_call(:wait_for_enabled) do
         if modifiers.any?
           action = driver.action
@@ -700,7 +699,7 @@ module Watir
       return assert_enabled unless Watir.relaxed_locate?
 
       wait_for_exists
-      return unless [Input, Button, Select, Option].any? { |c| is_a? c } || @content_editable
+      return unless [Input, Button, Select, Option].any? { |c| is_a? c } || content_editable
       return if enabled?
 
       begin
@@ -793,6 +792,7 @@ module Watir
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity:
+    # rubocop:disable Metrics/PerceivedComplexity::
     def element_call(precondition = nil, &block)
       caller = caller_locations(1, 1)[0].label
       already_locked = browser.timer.locked?
@@ -806,7 +806,7 @@ module Watir
         element_call(:wait_for_exists, &block) if precondition.nil?
         msg = e.message
         msg += '; Maybe look in an iframe?' if @query_scope.iframe.exists?
-        custom_attributes = @locator.nil? ? [] : selector_builder.custom_attributes
+        custom_attributes = !defined?(@locator) || @locator.nil? ? [] : selector_builder.custom_attributes
         unless custom_attributes.empty?
           msg += "; Watir treated #{custom_attributes} as a non-HTML compliant attribute, ensure that was intended"
         end
@@ -829,8 +829,8 @@ module Watir
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
-
-    # rubocop:enable Metrics/CyclomaticComplexity:
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
 
     def check_condition(condition, caller)
       Watir.logger.debug "<- `Verifying precondition #{inspect}##{condition} for #{caller}`"

--- a/lib/watir/elements/html_elements.rb
+++ b/lib/watir/elements/html_elements.rb
@@ -272,7 +272,6 @@ module Watir
     attribute(String, :form, :form)
     attribute(String, :label, :label)
     attribute("Boolean", :defaultselected?, :defaultSelected)
-    attribute("Boolean", :selected?, :selected)
     attribute(String, :value, :value)
     attribute(Integer, :index, :index)
   end

--- a/lib/watir/generator/html/generator.rb
+++ b/lib/watir/generator/html/generator.rb
@@ -14,7 +14,7 @@ module Watir
       end
 
       def ignored_attributes
-        %w[cells elements hash rows span text size selected? style width height tHead tFoot link options]
+        %w[cells elements hash rows span text size selected? style width height tHead tFoot link options selected]
       end
 
       def generator_implementation

--- a/lib/watir/logger.rb
+++ b/lib/watir/logger.rb
@@ -25,7 +25,7 @@ module Watir
                    :warn?,
                    :error, :error?,
                    :fatal, :fatal?,
-                   :level
+                   :level, :level=
 
     def initialize(progname = 'Watir')
       @logger = create_logger($stdout)
@@ -48,22 +48,6 @@ module Watir
       msg = ids.empty? ? '' : "[#{ids.map!(&:to_s).map(&:inspect).join(', ')}] "
       msg += message
       @logger.warn(msg, &block) unless (@ignored & ids).any?
-    end
-
-    #
-    # For Ruby < 2.4 compatibility
-    # Based on https://github.com/ruby/ruby/blob/ruby_2_3/lib/logger.rb#L250
-    #
-
-    def level=(severity)
-      if severity.is_a?(Integer)
-        @logger.level = severity
-      else
-        levels = %w[debug info warn error fatal unknown]
-        raise ArgumentError, "invalid log level: #{severity}" unless levels.include? severity.to_s.downcase
-
-        @logger.level = severity.to_s.upcase
-      end
     end
 
     #

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -4,7 +4,7 @@ module Watir
     include Exception
     include Enumerable
 
-    delegate %i[exists? present? visible? browser] => :source
+    delegate %i[exist? exists? present? visible? browser] => :source
 
     attr_reader :source, :frame
 

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -201,7 +201,7 @@ module Watir
     end
     alias eql? ==
 
-    # Ruby 2.4+ complains about using #delegate to do this
+    # Delegating to Private Methods
     %i[assert_exists element_call].each do |method|
       define_method(method) do |*args, &blk|
         source.send(method, *args, &blk)

--- a/lib/watir/user_editable.rb
+++ b/lib/watir/user_editable.rb
@@ -21,13 +21,17 @@ module Watir
     # @param [String, Symbol] args
     #
 
+    def content_editable
+      defined?(@content_editable) && content_editable?
+    end
+
     def set!(*args)
       msg = '#set! does not support special keys, use #set instead'
       raise ArgumentError, msg if args.any? { |v| v.is_a?(::Symbol) }
 
       input_value = args.join
       set input_value[0]
-      return content_editable_set!(*args) if @content_editable
+      return content_editable_set!(*args) if content_editable
 
       element_call { execute_js(:setValue, @element, input_value[0..-2]) }
       append(input_value[-1])
@@ -43,7 +47,7 @@ module Watir
     #
 
     def append(*args)
-      raise NotImplementedError, '#append method is not supported with contenteditable element' if @content_editable
+      raise NotImplementedError, '#append method is not supported with contenteditable element' if content_editable
 
       send_keys(*args)
     end

--- a/lib/watir/wait/timer.rb
+++ b/lib/watir/wait/timer.rb
@@ -2,7 +2,7 @@ module Watir
   module Wait
     class Timer
       def initialize(timeout: nil)
-        @end_time = current_time + timeout if timeout
+        @end_time = timeout ? current_time + timeout : nil
         @remaining_time = @end_time - current_time if @end_time
       end
 

--- a/lib/watirspec/implementation.rb
+++ b/lib/watirspec/implementation.rb
@@ -7,10 +7,8 @@ module WatirSpec
       @guard_proc = nil
     end
 
-    def initialize_copy(orig)
-      super
-      # Backward compatibility < Ruby 2.4
-      @browser_args = browser_args.map { |arg| arg.is_a?(Symbol) ? arg : arg.dup }
+    def initialize_copy(_orig)
+      @browser_args = browser_args.map(&:dup)
     end
 
     def browser_class

--- a/lib/watirspec/runner.rb
+++ b/lib/watirspec/runner.rb
@@ -33,7 +33,7 @@ module WatirSpec
     end
 
     def execute_if_necessary
-      execute if !@executed && @execute
+      execute if (!defined?(@executed) || !@executed) && @execute
     end
 
     def configure

--- a/lib/watirspec/server.rb
+++ b/lib/watirspec/server.rb
@@ -24,7 +24,7 @@ module WatirSpec
       private
 
       def running?
-        @running
+        defined?(@running) && @running
       end
 
       def run_server

--- a/spec/watirspec/after_hooks_spec.rb
+++ b/spec/watirspec/after_hooks_spec.rb
@@ -50,6 +50,8 @@ describe 'Browser::AfterHooks' do
   end
 
   describe '#run' do
+    before { @yield = nil }
+
     after(:each) do
       browser.original_window.use
       browser.after_hooks.delete @page_after_hook

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -709,10 +709,13 @@ describe 'Element' do
   describe '#size' do
     it 'returns size of element' do
       size = browser.button(name: 'new_user_image').size
-
       expect(size).to be_a Selenium::WebDriver::Dimension
-      expect(size['width']).to eq 104.0
-      expect(size['height']).to eq 70.0
+
+      expected_width = browser.name == :safari ? 105 : 104
+      expected_height = browser.name == :safari ? 71 : 70
+
+      expect(size['width']).to eq expected_width
+      expect(size['height']).to eq expected_height
     end
   end
 
@@ -720,7 +723,8 @@ describe 'Element' do
     it 'returns height of element' do
       height = browser.button(name: 'new_user_image').height
 
-      expect(height).to eq 70.0
+      expected_height = browser.name == :safari ? 71 : 70
+      expect(height).to eq expected_height
     end
   end
 
@@ -728,7 +732,8 @@ describe 'Element' do
     it 'returns width of element' do
       width = browser.button(name: 'new_user_image').width
 
-      expect(width).to eq 104.0
+      expected_width = browser.name == :safari ? 105 : 104
+      expect(width).to eq expected_width
     end
   end
 

--- a/spec/watirspec/elements/link_spec.rb
+++ b/spec/watirspec/elements/link_spec.rb
@@ -134,9 +134,11 @@ describe 'Link' do
       expect(browser.text.include?('User administration')).to be true
     end
 
-    it 'finds an existing link by (index: Integer) and clicks it' do
-      browser.link(index: 2).click
-      expect(browser.text.include?('User administration')).to be true
+    bug 'sometimes safari does not work on the first click', :safari do
+      it 'finds an existing link by (index: Integer) and clicks it' do
+        browser.link(index: 2).click
+        expect(browser.text.include?('User administration')).to be true
+      end
     end
 
     it "raises an UnknownObjectException if the link doesn't exist" do

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -81,6 +81,19 @@ describe 'SelectList' do
       expect(browser.select_list(index: 0).value).to eq '3'
     end
 
+    it 'returns the value of the selected options' do
+      browser.select_list(name: 'new_user_languages').select('1')
+      expect(browser.select_list(name: 'new_user_languages').value).to eq '1'
+      browser.select_list(name: 'new_user_languages').clear
+      browser.select_list(name: 'new_user_languages').select('NO')
+      expect(browser.select_list(name: 'new_user_languages').value).to eq '3'
+    end
+
+    it 'returns null when no values selected' do
+      browser.select_list(name: 'new_user_languages').clear
+      expect(browser.select_list(name: 'new_user_languages').value).to be_nil
+    end
+
     it "raises UnknownObjectException if the select list doesn't exist" do
       expect { browser.select_list(index: 1337).value }.to raise_unknown_object_exception
     end

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -150,7 +150,7 @@ if defined?(RSpec)
 
   RSpec::Matchers.define :exist do |*args|
     match do |actual|
-      actual.exists?(*args)
+      actual.exist?(*args)
     end
 
     failure_message do |obj|

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -98,7 +98,7 @@ class LocalConfig
     ENV['FIREFOX_BINARY'] ? {options: {binary: ENV['FIREFOX_BINARY']}} : {}
   end
 
-  def safari_args
+  def safari_preview_args
     {technology_preview: true}
   end
 

--- a/spec/watirspec_helper.rb
+++ b/spec/watirspec_helper.rb
@@ -15,7 +15,7 @@ class LocalConfig
   end
 
   def browser
-    @browser ||= (ENV['WATIR_BROWSER'] || :chrome).to_sym
+    @browser ||= (ENV['WATIR_BROWSER'] || :safari).to_sym
   end
 
   def configure


### PR DESCRIPTION
This supersedes #908 

* Ruby complained about our RSpec matcher for `#exists?`, I fixed it by having everything alias to `#exist?` as well
* Attribute list doesn't need to keep adding the same methods in `#attribute`, so there's a guard for it now.
* Defining instance variables in constructors where possible, guarding with `#method_defined?` conditionals when not
* `Select#value` is doing extra work, when the simple default attribute call always returns the same value (added spec to demonstrate this)
* Pulled `:selected` attribute from getting added to `html_elements.rb` so that the webdriver endpoint can handle determining `#selected?` instead of the attribute call (same behavior, just no Ruby warning about it)
* Can delegate `Watir::Logger#level=` by not supporting 2.3 or below

There are still some warnings in 2.7, but they can't be fixed until we no longer support 2.5 (which I think will likely be the case for Watir 7)