### PR TITLE
deprecate #select_all in favor of using an Array with #select

### DIFF
--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -30,8 +30,11 @@ module Watir
     #
 
     def select(*str_or_rx)
-      results = str_or_rx.flatten.map { |v| select_by v }
-      results.first
+      if str_or_rx.size > 1 || str_or_rx.first.is_a?(Array)
+        str_or_rx.flatten.map { |v| select_all_by v }.first
+      else
+        str_or_rx.flatten.map { |v| select_by v }.first
+      end
     end
 
     #
@@ -43,6 +46,10 @@ module Watir
     #
 
     def select_all(*str_or_rx)
+      Watir.logger.deprecate('#select_all',
+                             '#select with an Array instance',
+                             ids: [:select_all])
+
       results = str_or_rx.flatten.map { |v| select_all_by v }
       results.first
     end
@@ -55,8 +62,11 @@ module Watir
     #
 
     def select!(*str_or_rx)
-      results = str_or_rx.flatten.map { |v| select_by!(v, :single) }
-      results.first
+      if str_or_rx.size > 1 || str_or_rx.first.is_a?(Array)
+        str_or_rx.flatten.map { |v| select_by! v, :multiple }.first
+      else
+        str_or_rx.flatten.map { |v| select_by! v, :single }.first
+      end
     end
 
     #
@@ -67,6 +77,10 @@ module Watir
     #
 
     def select_all!(*str_or_rx)
+      Watir.logger.deprecate('#select_all!',
+                             '#select! with an Array instance',
+                             ids: [:select_all])
+
       results = str_or_rx.flatten.map { |v| select_by!(v, :multiple) }
       results.first
     end
@@ -145,7 +159,8 @@ module Watir
       found = find_options(:value, str_or_rx)
 
       if found.size > 1
-        Watir.logger.deprecate 'Selecting Multiple Options with #select', '#select_all',
+        Watir.logger.deprecate 'Selecting multiple options with #select using a String or Regexp value',
+                               '#select with the desired values in an Array instance',
                                ids: [:select_by]
       end
       select_matching(found)

--- a/lib/watir/js_snippets.rb
+++ b/lib/watir/js_snippets.rb
@@ -6,7 +6,7 @@ module Watir
 
     def execute_js(function_name, *arguments)
       file = File.expand_path("../js_snippets/#{function_name}.js", __FILE__)
-      raise Exception::Error, "Can not excute script as #{function_name}.js does not exist" unless File.exist?(file)
+      raise Exception::Error, "Can not execute script as #{function_name}.js does not exist" unless File.exist?(file)
 
       js = File.read(file)
       script = "return (#{js}).apply(null, arguments)"

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -241,7 +241,9 @@ describe 'SelectList' do
 
       it 'selects an option with a Regexp' do
         browser.select_list(name: 'new_user_languages').clear
-        expect { browser.select_list(name: 'new_user_languages').select(/1|3/) }.to have_deprecated_select_by
+        expect {
+          browser.select_list(name: 'new_user_languages').select(/1|3/)
+        }.to have_deprecated_select_by
         expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish NO]
       end
     end
@@ -272,22 +274,10 @@ describe 'SelectList' do
       end
     end
 
-    it 'selects multiple options successiveley' do
+    it 'selects multiple options successively' do
       browser.select_list(name: 'new_user_languages').clear
       browser.select_list(name: 'new_user_languages').select('Danish')
       browser.select_list(name: 'new_user_languages').select('Swedish')
-      expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
-    end
-
-    it 'selects each item in an Array' do
-      browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select(%w[Danish Swedish])
-      expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
-    end
-
-    it 'selects each item in a parameter list' do
-      browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select('Danish', 'Swedish')
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
     end
 
@@ -353,6 +343,59 @@ describe 'SelectList' do
     it 'raises a TypeError if argument is not a String, Regexp or Numeric' do
       expect { browser.select_list(id: 'new_user_languages').select({}) }.to raise_error(TypeError)
     end
+
+    context 'multiple options' do
+      it 'in an Array' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select(%w[Danish Swedish])
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
+
+      it 'in a parameter list' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select('Danish', 'Swedish')
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
+
+      it 'based on text' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select([/ish/])
+        list = %w[Danish EN Swedish]
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'based on label and single regexp' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select([/NO|EN/])
+        list = %w[EN NO]
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'based on label and multiple regexp' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select([/NO/, /EN/])
+        list = %w[EN NO]
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'from an Array' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select([/ish/, /Latin/])
+        list = ['Danish', 'EN', 'Swedish', 'Azeri - Latin', 'Latin']
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'from multiple arguments' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select(/ish/, /Latin/)
+        list = ['Danish', 'EN', 'Swedish', 'Azeri - Latin', 'Latin']
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'returns the first matching value if there are multiple matches' do
+        expect(browser.select_list(name: 'new_user_languages').select([/ish/])).to eq 'Danish'
+      end
+    end
   end
 
   describe '#select!' do
@@ -403,18 +446,6 @@ describe 'SelectList' do
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
     end
 
-    it 'selects each item in an Array' do
-      browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select!(%w[Danish Swedish])
-      expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
-    end
-
-    it 'selects each item in a parameter list' do
-      browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select!('Danish', 'Swedish')
-      expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
-    end
-
     it 'selects empty options' do
       browser.select_list(id: 'delete_user_username').select!('')
       expect(browser.select_list(id: 'delete_user_username').selected_options.map(&:text)).to eq ['']
@@ -456,80 +487,155 @@ describe 'SelectList' do
       browser.select_list(id: 'new_user_languages').clear
       expect { browser.select_list(id: 'new_user_languages').select!({}) }.to raise_error(TypeError)
     end
+
+    context 'multiple options' do
+      it 'in an Array' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select!(%w[Danish Swedish])
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
+
+      it 'in a parameter list' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select!('Danish', 'Swedish')
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[Danish Swedish]
+      end
+
+      it 'based on text' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select!([/ish/])
+        list = %w[Danish EN Swedish]
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'based on label and single regexp' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select!([/NO|EN/])
+        list = %w[EN NO]
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'based on label and multiple regexp' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select!([/NO/, /EN/])
+        list = %w[EN NO]
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'from an Array' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select!([/ish/, /Latin/])
+        list = ['Danish', 'EN', 'Swedish', 'Azeri - Latin', 'Latin']
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'from multiple arguments' do
+        browser.select_list(name: 'new_user_languages').clear
+        browser.select_list(name: 'new_user_languages').select!(/ish/, /Latin/)
+        list = ['Danish', 'EN', 'Swedish', 'Azeri - Latin', 'Latin']
+        expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
+      end
+
+      it 'returns the first matching value if there are multiple matches' do
+        expect(browser.select_list(name: 'new_user_languages').select!([/ish/])).to eq 'Danish'
+      end
+    end
   end
 
   describe '#select_all' do
     it 'selects multiple options based on text' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all(/ish/)
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all(/ish/)
+      }.to have_deprecated_select_all
       list = %w[Danish EN Swedish]
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'selects multiple options based on labels' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all(/NO|EN/)
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all(/NO|EN/)
+      }.to have_deprecated_select_all
       list = %w[EN NO]
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'selects all options in an Array' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all([/ish/, /Latin/])
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all([/ish/, /Latin/])
+      }.to have_deprecated_select_all
       list = ['Danish', 'EN', 'Swedish', 'Azeri - Latin', 'Latin']
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'selects all options in a parameter list' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all(/ish/, /Latin/)
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all(/ish/, /Latin/)
+      }.to have_deprecated_select_all
       list = ['Danish', 'EN', 'Swedish', 'Azeri - Latin', 'Latin']
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'returns the first matching value if there are multiple matches' do
-      expect(browser.select_list(name: 'new_user_languages').select_all(/ish/)).to eq 'Danish'
+      expect {
+        expect(browser.select_list(name: 'new_user_languages').select_all(/ish/)).to eq 'Danish'
+      }.to have_deprecated_select_all
     end
   end
 
   describe '#select_all!' do
     it 'selects multiple options based on value' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all!(/\d+/)
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all!(/\d+/)
+      }.to have_deprecated_select_all
       list = %w[Danish EN NO Russian]
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'selects multiple options based on text' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all!(/ish/)
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all!(/ish/)
+      }.to have_deprecated_select_all
       list = %w[Danish EN Swedish]
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'selects multiple options based on labels' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all!(/NO|EN/)
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all!(/NO|EN/)
+      }.to have_deprecated_select_all
       list = %w[EN NO]
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'selects all options in an Array' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all!([/ish/, /Latin/])
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all!([/ish/, /Latin/])
+      }.to have_deprecated_select_all
       list = ['Danish', 'EN', 'Swedish', 'Azeri - Latin', 'Latin']
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'selects all options in a parameter list' do
       browser.select_list(name: 'new_user_languages').clear
-      browser.select_list(name: 'new_user_languages').select_all!(/ish/, /Latin/)
+      expect {
+        browser.select_list(name: 'new_user_languages').select_all!(/ish/, /Latin/)
+      }.to have_deprecated_select_all
       list = ['Danish', 'EN', 'Swedish', 'Azeri - Latin', 'Latin']
       expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq list
     end
 
     it 'returns the first matching value if there are multiple matches' do
-      expect(browser.select_list(name: 'new_user_languages').select_all!(/ish/)).to eq 'Danish'
+      expect {
+        expect(browser.select_list(name: 'new_user_languages').select_all!(/ish/)).to eq 'Danish'
+      }.to have_deprecated_select_all
     end
   end
 end

--- a/spec/watirspec/support/rspec_matchers.rb
+++ b/spec/watirspec/support/rspec_matchers.rb
@@ -12,6 +12,7 @@ if defined?(RSpec)
                             stale_exists
                             stale_visible
                             stale_present
+                            select_all
                             select_by
                             value_button
                             wait_until_present


### PR DESCRIPTION
The plan going forward is to treat everything submitted to `Select#select` that is Array-like (multiple args count), to be treated as a `#select_all` that applies only to multiple selects.

There are a bunch of things to optimize still (ideas from #846 & #910), and this should provide the groundwork to do that. I think this is all I want to do in 6.x and then work on the rest with a "clean" slate in 7.x.