### PR TITLE
provide standardized methods to get and set values for specific elements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,17 +19,12 @@ Lint/UnifiedInteger:
 
 # Default: 17
 Metrics/AbcSize:
-  Max: 20
+  Max: 22
   Exclude:
-    - 'lib/watir/capabilities.rb'
     - 'lib/watir/locators/element/selector_builder.rb'
-    - 'lib/watir/locators/element/selector_builder/regexp_disassembler.rb'
-    - 'lib/watir/locators/element/selector_builder/xpath.rb'
-    - 'lib/watir/locators/element/locator.rb'
+    - 'lib/watir/locators/element/selector_builder/*.rb'
     - 'lib/watir/generator/base/generator.rb'
-    - 'lib/watir/generator/base/visitor.rb'
     - 'spec/locator_spec_helper.rb'
-    - 'spec/watirspec_helper.rb'
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -816,6 +816,8 @@ module Watir
         @content_editable = true
         extend UserEditable
         send(meth, *args, &blk)
+      elsif method == :set
+        click(*args, &blk)
       else
         super
       end

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -164,6 +164,26 @@ module Watir
     end
 
     #
+    # Determines the correct action based on subtype and takes it.
+    # Default is to click element
+    #
+
+    def set(*args)
+      subtype = to_subtype
+      if subtype.is_a?(Radio) && [String, Regexp].include?(args.first.class)
+        RadioSet.new(@query_scope, selector).set(*args)
+      elsif subtype.class.included_modules.include?(UserEditable) || subtype.public_methods(false).include?(:set)
+        subtype.set(*args)
+      elsif @content_editable || content_editable?
+        @content_editable = true
+        extend UserEditable
+        set(*args)
+      elsif args.empty? || args.first
+        click(*args)
+      end
+    end
+
+    #
     # Simulates JavaScript click event on element.
     #
     # @example Click an element
@@ -816,8 +836,6 @@ module Watir
         @content_editable = true
         extend UserEditable
         send(meth, *args, &blk)
-      elsif method == :set
-        click(*args, &blk)
       else
         super
       end

--- a/lib/watir/elements/radio.rb
+++ b/lib/watir/elements/radio.rb
@@ -9,8 +9,8 @@ module Watir
     # Selects this radio button.
     #
 
-    def set
-      click unless set?
+    def set(bool = true)
+      click if bool && !set?
     end
     alias select set
 

--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -37,6 +37,7 @@ module Watir
         select_matching([found])
       end
     end
+    alias set select
 
     #
     # Uses JavaScript to select the option whose text matches the given string.

--- a/lib/watir/radio_set.rb
+++ b/lib/watir/radio_set.rb
@@ -139,6 +139,7 @@ module Watir
       end
       raise UnknownObjectException, "Unable to locate radio matching #{str_or_rx.inspect}"
     end
+    alias set select
 
     #
     # Returns true if any of the radio button label matches the given value.

--- a/spec/watirspec/elements/element_spec.rb
+++ b/spec/watirspec/elements/element_spec.rb
@@ -521,6 +521,93 @@ describe 'Element' do
     end
   end
 
+  describe '#set' do
+    it 'clicks an element by default that does not define #set' do
+      browser.goto(WatirSpec.url_for('non_control_elements.html'))
+      browser.element(id: 'best_language').set
+      expect(browser.div(id: 'best_language').text).to eq 'Ruby!'
+    end
+
+    bug 'Element has been located but Safari does not recognize it', :safari do
+      it 'clicks an element that does not define #set with provided modifiers' do
+        browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+        browser.a.set(:shift)
+        browser.wait_until { |b| b.windows.size > 1 }
+        expect(browser.windows.size).to eq 2
+      ensure
+        browser.windows.reject(&:current?).each(&:close)
+      end
+    end
+
+    it 'does not click an element that does not define #set when passed false' do
+      browser.goto(WatirSpec.url_for('non_control_elements.html'))
+      browser.element(id: 'best_language').set(false)
+      expect(browser.div(id: 'best_language').text).not_to eq 'Ruby!'
+    end
+
+    it 'clicks a Button' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      browser.button(id: 'delete_user_submit').set
+      browser.wait_until { |b| !b.url.include? 'forms_with_input_elements.html' }
+      expect(browser.text).to include('Semantic table')
+    end
+
+    it 'sends keys to text element' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      browser.element(id: 'new_user_email').set('Bye Cruel World')
+      expect(browser.text_field(id: 'new_user_email').value).to eq 'Bye Cruel World'
+    end
+
+    it 'sends keys to text area' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      browser.element(id: 'delete_user_comment').set('Hello Cruel World')
+      expect(browser.textarea(id: 'delete_user_comment').value).to eq 'Hello Cruel World'
+    end
+
+    it 'checks a checkbox' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      browser.element(id: 'new_user_interests_cars').set
+      expect(browser.checkbox(id: 'new_user_interests_cars')).to be_set
+    end
+
+    it 'unchecks a checkbox' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      browser.element(id: 'new_user_interests_books').set(false)
+      expect(browser.checkbox(id: 'new_user_interests_books')).to_not be_set
+    end
+
+    it 'clicks a Radio' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      browser.radio(id: 'new_user_newsletter_no').set
+      expect(browser.radio(id: 'new_user_newsletter_no')).to be_set
+      expect(messages.size).to eq 1
+    end
+
+    it 'does not click a Radio when false or already clicked' do
+      browser.goto(WatirSpec.url_for('forms_with_input_elements.html'))
+      browser.element(id: 'new_user_newsletter_no').set(false)
+      browser.element(id: 'new_user_newsletter_yes').set(true)
+      expect(messages.size).to eq 0
+    end
+
+    it 'uploads a file' do
+      browser.element(name: 'new_user_portrait').set __FILE__
+
+      expect(browser.file_field(name: 'new_user_portrait').value).to include(File.basename(__FILE__))
+    end
+
+    it 'selects an option' do
+      browser.select_list(name: 'new_user_languages').clear
+      browser.element(name: 'new_user_languages').set('2')
+      expect(browser.select_list(name: 'new_user_languages').selected_options.map(&:text)).to eq %w[EN]
+    end
+
+    it 'sends keys to content editable element' do
+      browser.element(id: 'contenteditable').set('Bar')
+      expect(browser.div(id: 'contenteditable').text).to eq 'Bar'
+    end
+  end
+
   describe '#flash' do
     let(:h2) { browser.h2(text: 'Add user') }
     let(:h1) { browser.h1(text: 'User administration') }


### PR DESCRIPTION
What do we think about this as the solution to #405 ?
Don't need to wait on #846 since all desired behavior is now supported in 6.19

Summary of Behavior:
----------
Checkbox:
`#set` —> boolean argument for whether it should be selected; clicks if not matching
`#get` —> boolean return for if selected

Radio:
`#set` —> boolean argument for whether it should be selected; clicks if true & not already selected
`#get` —> boolean return for if selected

RadioSet:
`#set` —> String or Regexp argument; first button with matching value or label is selected
`#get` —> String return with the attribute value for the selected Radio button

Text & TextArea:
`#set` —> String or Regexp argument; Clears & Sends Keys (current behavior)
`#get` —> String return with the property value of the element

Select
`#set` —> String or Regexp or Array argument; selects first or all matching values/labels (current behavior of #select)
`#get` —> String return of the attribute value for the selected option

Element (if subtype not specified in the element definition)
`#set` -->
* Calls to_subtype and uses one of the above behaviors if appropriate
    * note if it is a Radio, it determines if the argument is a String/Regexp or a Boolean to determine if it uses Radio or RadioSet behavior 
* If "content-editable" attribute set, sets user editable and clear/send_keys (current behavior)
* Does not click element if provided argument is “false”
* Otherwise clicks element with provided modifiers

`#get` --> 
* Calls to_subtype and uses one of the above behaviors if appropriate
* Radio button always returns boolean (never RadioSet behavior)
* Otherwise returns text value (including for content-editable elements since `value` returns null, oddly)