### PR TITLE
bring element into viewport before taking action on it with Selenium …

### DIFF
--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -204,7 +204,10 @@ module Watir
     #
 
     def double_click
-      element_call(:wait_for_present) { driver.action.double_click(@element).perform }
+      element_call(:wait_for_present) do
+        scroll.to
+        driver.action.double_click(@element).perform
+      end
       browser.after_hooks.run
     end
 
@@ -239,6 +242,7 @@ module Watir
 
     def right_click(*modifiers)
       element_call(:wait_for_present) do
+        scroll.to
         action = driver.action
         if modifiers.any?
           modifiers.each { |mod| action.key_down mod }
@@ -262,7 +266,10 @@ module Watir
     #
 
     def hover
-      element_call(:wait_for_present) { driver.action.move_to(@element).perform }
+      element_call(:wait_for_present) do
+        scroll.to
+        driver.action.move_to(@element).perform
+      end
     end
 
     #
@@ -279,6 +286,7 @@ module Watir
       assert_is_element other
 
       value = element_call(:wait_for_present) do
+        scroll.to
         driver.action
               .drag_and_drop(@element, other.wd)
               .perform
@@ -300,6 +308,7 @@ module Watir
 
     def drag_and_drop_by(right_by, down_by)
       element_call(:wait_for_present) do
+        scroll.to
         driver.action
               .drag_and_drop_by(@element, right_by, down_by)
               .perform

--- a/spec/watirspec/elements/div_spec.rb
+++ b/spec/watirspec/elements/div_spec.rb
@@ -195,6 +195,11 @@ describe 'Div' do
       browser.div(id: 'click-logger').right_click(:control, :alt)
       expect(event_log.first).to eq('control=true alt=true')
     end
+
+    it 'scrolls' do
+      browser.del(class: 'footer').double_click
+      puts 'yes?'
+    end
   end
 
   describe '#html' do


### PR DESCRIPTION
addresses #847 

tbh, I can't duplicate the out of bounds error, but this generally seems like a good thing to bring the element into the viewport before taking action on it with actions class.