### PR TITLE
Select List #selected? should evaluate the same way as #select

### DIFF
--- a/lib/watir/elements/select.rb
+++ b/lib/watir/elements/select.rb
@@ -65,16 +65,10 @@ module Watir
     # @return [Boolean]
     #
 
-    def selected?(str_or_rx)
-      by_text = options(text: str_or_rx)
-      return true if by_text.find(&:selected?)
+    def selected?(*str_or_rx, text: nil, value: nil, label: nil)
+      key, value = parse_select_args(str_or_rx, text, value, label)
 
-      by_label = options(label: str_or_rx)
-      return true if by_label.find(&:selected?)
-
-      return false unless (by_text.size + by_label.size).zero?
-
-      raise(UnknownObjectException, "Unable to locate option matching #{str_or_rx.inspect}")
+      find_option(key, value.first).selected?
     end
 
     #

--- a/spec/watirspec/elements/select_list_spec.rb
+++ b/spec/watirspec/elements/select_list_spec.rb
@@ -220,27 +220,63 @@ describe 'SelectList' do
   end
 
   describe '#selected?' do
-    it 'returns true if the given option is selected by text' do
-      browser.select_list(name: 'new_user_country').select('Denmark')
+    it 'evaluates true by text' do
+      browser.select_list(name: 'new_user_country').select('1')
       expect(browser.select_list(name: 'new_user_country')).to be_selected('Denmark')
     end
 
-    it 'returns false if the given option is not selected by text' do
+    it 'evaluates false by text' do
       expect(browser.select_list(name: 'new_user_country')).to_not be_selected('Sweden')
     end
 
-    it 'returns true if the given option is selected by label' do
+    it 'evaluates true exclusively by text' do
+      browser.select_list(name: 'new_user_country').select('1')
+      expect(browser.select_list(name: 'new_user_country')).to be_selected(text: 'Denmark')
+    end
+
+    it 'evaluates false exclusively by text' do
+      expect(browser.select_list(name: 'new_user_country')).to_not be_selected(text: 'Sweden')
+    end
+
+    it 'evaluates true by label' do
       browser.select_list(name: 'new_user_country').select('Germany')
       expect(browser.select_list(name: 'new_user_country')).to be_selected('Germany')
     end
 
-    it 'returns false if the given option is not selected by label' do
+    it 'evaluates false by label' do
       expect(browser.select_list(name: 'new_user_country')).to_not be_selected('Germany')
     end
 
-    it "raises UnknownObjectException if the option doesn't exist" do
+    it 'evaluates true exclusively by label' do
+      browser.select_list(name: 'new_user_country').select('Germany')
+      expect(browser.select_list(name: 'new_user_country')).to be_selected(label: 'Germany')
+    end
+
+    it 'evaluates false exclusively by label' do
+      expect(browser.select_list(name: 'new_user_country')).to_not be_selected(label: 'Germany')
+    end
+
+    it 'evaluates true by value' do
+      browser.select_list(name: 'new_user_country').select('USA')
+      expect(browser.select_list(name: 'new_user_country')).to be_selected('5')
+    end
+
+    it 'evaluates false by value' do
+      expect(browser.select_list(name: 'new_user_country')).to_not be_selected('5')
+    end
+
+    it 'evaluates true exclusively by value' do
+      browser.select_list(name: 'new_user_country').select('USA')
+      expect(browser.select_list(name: 'new_user_country')).to be_selected(value: '5')
+    end
+
+    it 'evaluates false exclusively by value' do
+      expect(browser.select_list(name: 'new_user_country')).to_not be_selected(value: '5')
+    end
+
+    it "raises NoValueFoundException if the option doesn't exist" do
       expect { browser.select_list(name: 'new_user_country').selected?('missing_option') }
-        .to raise_unknown_object_exception
+        .to raise_no_value_found_exception
     end
   end
 


### PR DESCRIPTION
While writing documentation I realized that `#selected?` should be able to take the same parameters as `#select`
Doesn't make sense to be able to select options by value, but not to verify options by value. Same thing by allowing users to chooses a specific evaluation if they need.