### PR TITLE
Shadow dom support

### DIFF
--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -99,5 +99,6 @@ require 'watir/elements/text_area'
 require 'watir/elements/text_field'
 require 'watir/elements/input'
 require 'watir/radio_set'
+require 'watir/shadow_root'
 
 require 'watir/aliases'

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -491,6 +491,16 @@ module Watir
     end
 
     #
+    # Returns shadow root of element
+    #
+    # @return [Watir::ShadowRoot]
+    #
+
+    def shadow_root
+      ShadowRoot.new(self, {})
+    end
+
+    #
     # Returns true if this element is present and enabled on the page.
     #
     # @return [Boolean]

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -29,7 +29,15 @@ module Watir
           inspected = selector.inspect
           scope = @query_scope unless @selector.key?(:scope) || @query_scope.is_a?(Watir::Browser)
 
-          @built = wd_locators.empty? ? build_wd_selector(@selector) : @selector
+          @built =
+              if scope.kind_of? Watir::ShadowRoot
+                raise ArgumentError, ":xpath not supported when locating elements from shadow root" if @selector[:xpath]
+
+                @selector[:css] ||= '*'
+                @selector
+              else
+                wd_locators.empty? ? build_wd_selector(@selector) : @selector
+              end
           @built.delete(:index) if @built[:index]&.zero?
           @built[:scope] = scope if scope
 
@@ -68,7 +76,7 @@ module Watir
         def merge_scope?
           return false unless (Watir::Locators::W3C_FINDERS + [:adjacent] & @selector.keys).empty?
 
-          return false if [Watir::Browser, Watir::IFrame].any? { |k| @query_scope.is_a?(k) }
+          return false if [Watir::Browser, Watir::IFrame, Watir::ShadowRoot].any? { |k| @query_scope.is_a?(k) }
 
           scope_invalid_locators = @query_scope.selector_builder.built.keys.reject { |key| key == wd_locator }
           scope_invalid_locators.empty?

--- a/lib/watir/shadow_root.rb
+++ b/lib/watir/shadow_root.rb
@@ -1,0 +1,12 @@
+module Watir
+  class ShadowRoot < HTMLElement
+    def locate_in_context
+      # TODO: Move to ShadowRoot::Locator?
+      @element = driver.execute_script('return arguments[0].shadowRoot;', @query_scope.wd)
+    end
+
+    def selector_string
+      "#{@query_scope.selector_string} --> shadow_root"
+    end
+  end
+end

--- a/lib/watir/shadow_root.rb
+++ b/lib/watir/shadow_root.rb
@@ -1,9 +1,17 @@
 module Watir
-  class ShadowRoot < HTMLElement
+  class ShadowRoot < Element
     def locate_in_context
-      # TODO: Move to ShadowRoot::Locator?
       @element = driver.execute_script('return arguments[0].shadowRoot;', @query_scope.wd)
     end
+
+    def stale_in_context?
+      # TODO: detect when stale
+      false
+    end
+
+    #
+    # @api private
+    #
 
     def selector_string
       "#{@query_scope.selector_string} --> shadow_root"

--- a/spec/watirspec/html/shadow_dom.html
+++ b/spec/watirspec/html/shadow_dom.html
@@ -1,33 +1,28 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <title>Shadow DOM</title>
-    </head>
-    <body>
-        <div id="non_host"></div>
-        <div id="shadow_host"></div>
-        <script>
-            let shadow = document.getElementById('shadow_host').attachShadow({mode: 'open'});
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Shadow DOM</title>
+  </head>
+  <body>
+    <div id="non_host"></div>
+    <div id="shadow_host"></div>
+    <a href="scroll.html">scroll.html</a>
+    <script>
+      let shadowRoot = document.getElementById('shadow_host').attachShadow({mode: 'open'});
+      shadowRoot.innerHTML = `
+              <span class="wrapper" id="shadow_dom_first_element"><span class="info">some text</span></span>
+              <div id="nested_shadow_host"></div>
+              <a href="scroll.html">scroll.html</a>
+              <input type="text" />
+              <input type="checkbox" />
+              <input type="file" />
+            `;
 
-            let wrapper = document.createElement('span');
-            wrapper.setAttribute('class', 'wrapper');
-            let info = document.createElement('span');
-            info.setAttribute('class', 'info');
-            info.textContent = 'some text';
-
-            let wrapper2 = document.createElement('div');
-            wrapper2.id = 'nested_shadow_host';
-
-            shadow.appendChild(wrapper);
-            wrapper.appendChild(info);
-            shadow.appendChild(wrapper2);
-
-            let nested_shadow = shadow.getElementById('nested_shadow_host').attachShadow({mode: 'open'});
-            let nested_wrapper = document.createElement('div');
-            nested_wrapper.id = 'nested_shadow_dom_first_element'
-            nested_wrapper.innerHTML = '<div>nested text</div>'
-            nested_shadow.appendChild(nested_wrapper)
-        </script>
-    </body>
+      let nestedShadowRoot = shadowRoot.getElementById('nested_shadow_host').attachShadow({mode: 'open'});
+      nestedShadowRoot.innerHTML = `
+              <div id="nested_shadow_dom_first_element"><div>nested text</div></div>
+            `;
+    </script>
+  </body>
 </html>

--- a/spec/watirspec/html/shadow_dom.html
+++ b/spec/watirspec/html/shadow_dom.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <title>Shadow DOM</title>
+    </head>
+    <body>
+        <div id="non_host"></div>
+        <div id="shadow_host"></div>
+        <script>
+            let shadow = document.getElementById('shadow_host').attachShadow({mode: 'open'});
+
+            let wrapper = document.createElement('span');
+            wrapper.setAttribute('class', 'wrapper');
+            let info = document.createElement('span');
+            info.setAttribute('class', 'info');
+            info.textContent = 'some text';
+
+            let wrapper2 = document.createElement('div');
+            wrapper2.id = 'nested_shadow_host';
+
+            shadow.appendChild(wrapper);
+            wrapper.appendChild(info);
+            shadow.appendChild(wrapper2);
+
+            let nested_shadow = shadow.getElementById('nested_shadow_host').attachShadow({mode: 'open'});
+            let nested_wrapper = document.createElement('div');
+            nested_wrapper.id = 'nested_shadow_dom_first_element'
+            nested_wrapper.innerHTML = '<div>nested text</div>'
+            nested_shadow.appendChild(nested_wrapper)
+        </script>
+    </body>
+</html>

--- a/spec/watirspec/shadow_root_spec.rb
+++ b/spec/watirspec/shadow_root_spec.rb
@@ -1,0 +1,61 @@
+require 'watirspec_helper'
+
+describe 'ShadowRoot' do
+  before :each do
+    browser.goto(WatirSpec.url_for('shadow_dom.html'))
+  end
+
+  describe '#exists?' do
+    it 'returns true when element has a shadow DOM' do
+      shadow_root = browser.div(id: 'shadow_host').shadow_root
+      expect(shadow_root).to exist
+    end
+
+    it 'returns false when element does not have a shadow DOM' do
+      missing_shadow_root = browser.div(id: 'non_host').shadow_root
+      expect(missing_shadow_root).not_to exist
+    end
+
+    it 'returns false when element does not exist' do
+      missing_shadow_root = browser.div(id: 'does_not_exist').shadow_root
+      expect(missing_shadow_root).not_to exist
+    end
+  end
+
+  it 'locates an individual element' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    expect(shadow_root.element.tag_name).to eq('span')
+  end
+
+ it 'locates a collection of elements' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    expect(shadow_root.elements.count).to eq(3)
+  end
+
+  it 'locates an individual element within a nested shadow DOM' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    nested_shadow_root = shadow_root.element(id: 'nested_shadow_host').shadow_root
+    expect(nested_shadow_root.element.id).to eq('nested_shadow_dom_first_element')
+  end
+
+  it 'locates a collection of elements within a nested shadow DOM' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    nested_shadow_root = shadow_root.element(id: 'nested_shadow_host').shadow_root
+    expect(nested_shadow_root.elements.count).to eq(2)
+  end
+
+  it 'raises ArgumentError when using :xpath to locate elements directly from the shadow root' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    expect { shadow_root.element(xpath: './/span').exists? }.to raise_exception(ArgumentError)
+  end
+
+  it 'allows using :xpath to locate elements with an element of a shadow root' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    expect(shadow_root.span.element(xpath: './/span')).to exist
+  end
+
+  it 'returns false when locating element in shadow root that does not exist' do
+    missing_shadow_root = browser.div(id: 'non_host').shadow_root
+    expect(missing_shadow_root.element).not_to exist
+  end
+end

--- a/spec/watirspec/shadow_root_spec.rb
+++ b/spec/watirspec/shadow_root_spec.rb
@@ -22,26 +22,35 @@ describe 'ShadowRoot' do
     end
   end
 
-  it 'locates an individual element' do
+  it 'locates a nested element' do
     shadow_root = browser.div(id: 'shadow_host').shadow_root
-    expect(shadow_root.element.tag_name).to eq('span')
+    expect(shadow_root.element.id).to eq('shadow_dom_first_element')
+    expect(shadow_root.element(id: 'nested_shadow_host').id).to eq('nested_shadow_host')
+    expect(shadow_root.element(id: /nested_shadow_.+/).id).to eq('nested_shadow_host')
+    expect(shadow_root.element(css: 'div').id).to eq('nested_shadow_host')
+    expect(shadow_root.div.id).to eq('nested_shadow_host')
   end
 
- it 'locates a collection of elements' do
+ it 'locates a collection of nested elements' do
     shadow_root = browser.div(id: 'shadow_host').shadow_root
-    expect(shadow_root.elements.count).to eq(3)
+    expect(shadow_root.elements.count).to eq(7)
+    expect(shadow_root.elements(id: 'nested_shadow_host').map(&:id)).to eq(['nested_shadow_host'])
+    expect(shadow_root.elements(id: /nested_shadow_.+/).map(&:id)).to eq(['nested_shadow_host'])
+    expect(shadow_root.elements(css: 'div').map(&:id)).to eq(['nested_shadow_host'])
+    expect(shadow_root.divs.map(&:id)).to eq(['nested_shadow_host'])
   end
 
-  it 'locates an individual element within a nested shadow DOM' do
+  it 'locates a nested element within a nested shadow DOM' do
     shadow_root = browser.div(id: 'shadow_host').shadow_root
     nested_shadow_root = shadow_root.element(id: 'nested_shadow_host').shadow_root
     expect(nested_shadow_root.element.id).to eq('nested_shadow_dom_first_element')
   end
 
-  it 'locates a collection of elements within a nested shadow DOM' do
+  it 'locates a collection of nested elements within a nested shadow DOM' do
     shadow_root = browser.div(id: 'shadow_host').shadow_root
     nested_shadow_root = shadow_root.element(id: 'nested_shadow_host').shadow_root
     expect(nested_shadow_root.elements.count).to eq(2)
+    expect(nested_shadow_root.elements.map(&:id)).to include('nested_shadow_dom_first_element')
   end
 
   it 'raises ArgumentError when using :xpath to locate elements directly from the shadow root' do
@@ -57,5 +66,30 @@ describe 'ShadowRoot' do
   it 'returns false when locating element in shadow root that does not exist' do
     missing_shadow_root = browser.div(id: 'non_host').shadow_root
     expect(missing_shadow_root.element).not_to exist
+  end
+
+  it 'click elements within the shadow dom' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    shadow_root.link.click
+    expect(browser.url).to include('scroll.html')
+  end
+
+  it 'click! elements within the shadow dom' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    shadow_root.link.click!
+    expect(browser.url).to include('scroll.html')
+  end
+
+  it 'inputs form elements within the shadow dom' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+
+    shadow_root.text_field.set('abc')
+    expect(shadow_root.text_field.value).to eq('abc')
+
+    shadow_root.checkbox.set
+    expect(shadow_root.checkbox.set?).to eq(true)
+
+    shadow_root.file_field.set(File.expand_path(__FILE__))
+    expect(shadow_root.file_field.value).to include('shadow_root_spec.rb')
   end
 end


### PR DESCRIPTION
@titusfortner , given:

- The request for shadow DOM support has come up a couple of times and
- We don't know when browsers will add support

How do you feel about having a hacky and limited workaround in the mean time?

This draft branch shows that we can provide at least some support in the short term. There are at least a few limitations:
- Only Chrome is supported by this approach.
- `#click` doesn't work for elements in the shadow DOM, but `#click!` does.
- The performance of complicated locators in a large shadow DOMs may be poor. `:xpath` locators cannot be applied to the shadow root, which means our XPath selector builder cannot be used. As a hack (rather than having to build a CSS selector builder) was to apply a simple `css: '*'` and force all of the locators through the more expensive filtering approach.
- To get things working quickly, the `ShadowRoot` inherits from `Element`. This means that the `ShadowRoot` has a lot of methods that don't work and/or make sense.

Again the idea here is simply to try to help some people from being blocked. If you're okay with taking this short-term approach, I can clean up this code and further investigate any other limitations.