### PR TITLE
Shadow dom support

### DIFF
--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -99,5 +99,6 @@ require 'watir/elements/text_area'
 require 'watir/elements/text_field'
 require 'watir/elements/input'
 require 'watir/radio_set'
+require 'watir/shadow_root'
 
 require 'watir/aliases'

--- a/lib/watir.rb
+++ b/lib/watir.rb
@@ -1,6 +1,7 @@
 require 'selenium-webdriver'
 require 'time'
 
+require 'watir/search_context'
 require 'watir/scroll'
 require 'watir/wait'
 require 'watir/exception'

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -13,6 +13,7 @@ module Watir
     include JSExecution
     include Locators::ClassHelpers
     include Scrolling
+    include SearchContext
 
     attr_accessor :keyword
     attr_reader :selector
@@ -53,27 +54,6 @@ module Watir
 
       build unless @element
     end
-
-    #
-    # Returns true if element exists.
-    # Checking for staleness is deprecated
-    #
-    # @return [Boolean]
-    #
-
-    def exists?
-      if located? && stale?
-        reset!
-      elsif located?
-        return true
-      end
-
-      assert_exists
-      true
-    rescue UnknownObjectException, UnknownFrameException
-      false
-    end
-    alias exist? exists?
 
     def inspect
       string = "#<#{self.class}: "
@@ -497,7 +477,7 @@ module Watir
     #
 
     def shadow_root
-      ShadowRoot.new(self, {})
+      ShadowRoot.new(self)
     end
 
     #
@@ -684,18 +664,6 @@ module Watir
 
     protected
 
-    def wait_for_exists
-      return if located? # Performance shortcut
-
-      begin
-        @query_scope.wait_for_exists unless @query_scope.is_a? Browser
-        wait_until(element_reset: true, &:exists?)
-      rescue Wait::TimeoutError
-        msg = "timed out after #{Watir.default_timeout} seconds, waiting for #{inspect} to be located"
-        raise unknown_exception, msg
-      end
-    end
-
     def wait_for_present
       return true if present?
 
@@ -756,10 +724,6 @@ module Watir
 
     private
 
-    def unknown_exception
-      UnknownObjectException
-    end
-
     def raise_writable
       message = "element present and enabled, but timed out after #{Watir.default_timeout} seconds, " \
                 "waiting for #{inspect} to not be readonly"
@@ -790,61 +754,14 @@ module Watir
       raise TypeError, "expected Watir::Element, got #{obj.inspect}:#{obj.class}" unless obj.is_a? Element
     end
 
-    # TODO: - this will get addressed with Watir::Executor implementation
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/CyclomaticComplexity:
-    # rubocop:disable Metrics/PerceivedComplexity::
-    def element_call(precondition = nil, &block)
-      caller = caller_locations(1, 1)[0].label
-      already_locked = browser.timer.locked?
-      browser.timer = Wait::Timer.new(timeout: Watir.default_timeout) unless already_locked
-
-      begin
-        check_condition(precondition, caller)
-        Watir.logger.debug "-> `Executing #{inspect}##{caller}`"
-        yield
-      rescue unknown_exception => e
-        element_call(:wait_for_exists, &block) if precondition.nil?
-        msg = e.message
-        msg += '; Maybe look in an iframe?' if @query_scope.iframe.exists?
-        custom_attributes = !defined?(@locator) || @locator.nil? ? [] : selector_builder.custom_attributes
-        unless custom_attributes.empty?
-          msg += "; Watir treated #{custom_attributes} as a non-HTML compliant attribute, ensure that was intended"
-        end
-        raise unknown_exception, msg
-      rescue Selenium::WebDriver::Error::StaleElementReferenceError, Selenium::WebDriver::Error::NoSuchElementError
-        reset!
-        retry
-        # TODO: - InvalidElementStateError is deprecated, so no longer calling `raise_disabled`
-        # need a better way to handle this
-      rescue Selenium::WebDriver::Error::ElementNotInteractableError
-        raise_present unless browser.timer.remaining_time.positive?
-        raise_present unless %i[wait_for_present wait_for_enabled wait_for_writable].include?(precondition)
-        retry
-      rescue Selenium::WebDriver::Error::NoSuchWindowError
-        raise NoMatchingWindowFoundException, 'browser window was closed'
-      ensure
-        Watir.logger.debug "<- `Completed #{inspect}##{caller}`"
-        browser.timer.reset! unless already_locked
+    def custom_message
+      msg = ''
+      msg += '; Maybe look in an iframe?' if @query_scope.iframe.exists?
+      custom_attributes = !defined?(@locator) || @locator.nil? ? [] : selector_builder.custom_attributes
+      unless custom_attributes.empty?
+        msg += "; Watir treated #{custom_attributes} as a non-HTML compliant attribute, ensure that was intended"
       end
-    end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
-
-    def check_condition(condition, caller)
-      Watir.logger.debug "<- `Verifying precondition #{inspect}##{condition} for #{caller}`"
-      begin
-        condition.nil? ? assert_exists : send(condition)
-        Watir.logger.debug "<- `Verified precondition #{inspect}##{condition || 'assert_exists'}`"
-      rescue unknown_exception
-        raise unless condition.nil?
-
-        Watir.logger.debug "<- `Unable to satisfy precondition #{inspect}##{condition}`"
-        check_condition(:wait_for_exists, caller)
-      end
+      msg
     end
 
     def method_missing(meth, *args, &blk)

--- a/lib/watir/elements/element.rb
+++ b/lib/watir/elements/element.rb
@@ -491,6 +491,16 @@ module Watir
     end
 
     #
+    # Returns shadow root of element
+    #
+    # @return [Watir::ShadowRoot]
+    #
+
+    def shadow_root
+      ShadowRoot.new(self, {})
+    end
+
+    #
     # Returns true if this element is present and enabled on the page.
     #
     # @return [Boolean]

--- a/lib/watir/locators/element/selector_builder.rb
+++ b/lib/watir/locators/element/selector_builder.rb
@@ -29,7 +29,15 @@ module Watir
           inspected = selector.inspect
           scope = @query_scope unless @selector.key?(:scope) || @query_scope.is_a?(Watir::Browser)
 
-          @built = wd_locators.empty? ? build_wd_selector(@selector) : @selector
+          @built =
+              if scope.kind_of? Watir::ShadowRoot
+                raise ArgumentError, ":xpath not supported when locating elements from shadow root" if @selector[:xpath]
+
+                @selector[:css] ||= '*'
+                @selector
+              else
+                wd_locators.empty? ? build_wd_selector(@selector) : @selector
+              end
           @built.delete(:index) if @built[:index]&.zero?
           @built[:scope] = scope if scope
 
@@ -68,7 +76,7 @@ module Watir
         def merge_scope?
           return false unless (Watir::Locators::W3C_FINDERS + [:adjacent] & @selector.keys).empty?
 
-          return false if [Watir::Browser, Watir::IFrame].any? { |k| @query_scope.is_a?(k) }
+          return false if [Watir::Browser, Watir::IFrame, Watir::ShadowRoot].any? { |k| @query_scope.is_a?(k) }
 
           scope_invalid_locators = @query_scope.selector_builder.built.keys.reject { |key| key == wd_locator }
           scope_invalid_locators.empty?

--- a/lib/watir/search_context.rb
+++ b/lib/watir/search_context.rb
@@ -1,0 +1,98 @@
+module Watir
+  module SearchContext
+    #
+    # Returns true if element exists.
+    # Checking for staleness is deprecated
+    #
+    # @return [Boolean]
+    #
+
+    def exists?
+      if located? && stale?
+        reset!
+      elsif located?
+        return true
+      end
+
+      assert_exists
+      true
+    rescue Exception::UnknownObjectException, Exception::UnknownFrameException
+      false
+    end
+    alias exist? exists?
+
+    def assert_exists
+      locate unless located?
+      return if located?
+
+      raise unknown_exception, "unable to locate: #{inspect}"
+    end
+
+    def wait_for_exists
+      return if located? # Performance shortcut
+
+      begin
+        @query_scope.wait_for_exists unless @query_scope.is_a? Browser
+        wait_until(element_reset: true, &:exists?)
+      rescue Wait::TimeoutError
+        msg = "timed out after #{Watir.default_timeout} seconds, waiting for #{inspect} to be located"
+        raise unknown_exception, msg
+      end
+    end
+
+    # TODO: - this will get addressed with Watir::Executor implementation
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity:
+    # rubocop:disable Metrics/PerceivedComplexity::
+    def element_call(precondition = nil, &block)
+      caller = caller_locations(1, 1)[0].label
+      already_locked = browser.timer.locked?
+      browser.timer = Wait::Timer.new(timeout: Watir.default_timeout) unless already_locked
+
+      begin
+        check_condition(precondition, caller)
+        Watir.logger.debug "-> `Executing #{inspect}##{caller}`"
+        yield
+      rescue unknown_exception => e
+        element_call(:wait_for_exists, &block) if precondition.nil?
+        raise unknown_exception, e.message + custom_message
+      rescue Selenium::WebDriver::Error::StaleElementReferenceError, Selenium::WebDriver::Error::NoSuchElementError
+        reset!
+        retry
+        # TODO: - InvalidElementStateError is deprecated, so no longer calling `raise_disabled`
+        # need a better way to handle this
+      rescue Selenium::WebDriver::Error::ElementNotInteractableError
+        raise_present unless browser.timer.remaining_time.positive?
+        raise_present unless %i[wait_for_present wait_for_enabled wait_for_writable].include?(precondition)
+        retry
+      rescue Selenium::WebDriver::Error::NoSuchWindowError
+        raise Exception::NoMatchingWindowFoundException, 'browser window was closed'
+      ensure
+        Watir.logger.debug "<- `Completed #{inspect}##{caller}`"
+        browser.timer.reset! unless already_locked
+      end
+    end
+    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
+
+    def check_condition(condition, caller)
+      Watir.logger.debug "<- `Verifying precondition #{inspect}##{condition} for #{caller}`"
+      begin
+        condition.nil? ? assert_exists : send(condition)
+        Watir.logger.debug "<- `Verified precondition #{inspect}##{condition || 'assert_exists'}`"
+      rescue unknown_exception
+        raise unless condition.nil?
+
+        Watir.logger.debug "<- `Unable to satisfy precondition #{inspect}##{condition}`"
+        check_condition(:wait_for_exists, caller)
+      end
+    end
+
+    def unknown_exception
+      Exception::UnknownObjectException
+    end
+  end
+end

--- a/lib/watir/shadow_root.rb
+++ b/lib/watir/shadow_root.rb
@@ -1,0 +1,20 @@
+module Watir
+  class ShadowRoot < Element
+    def locate_in_context
+      @element = driver.execute_script('return arguments[0].shadowRoot;', @query_scope.wd)
+    end
+
+    def stale_in_context?
+      # TODO: detect when stale
+      false
+    end
+
+    #
+    # @api private
+    #
+
+    def selector_string
+      "#{@query_scope.selector_string} --> shadow_root"
+    end
+  end
+end

--- a/lib/watir/shadow_root.rb
+++ b/lib/watir/shadow_root.rb
@@ -1,12 +1,46 @@
 module Watir
-  class ShadowRoot < Element
-    def locate_in_context
-      @element = driver.execute_script('return arguments[0].shadowRoot;', @query_scope.wd)
+  class ShadowRoot
+    include Container
+    include Exception
+    include SearchContext
+    include Waitable
+
+    def initialize(element)
+      @query_scope = element
     end
 
-    def stale_in_context?
-      # TODO: detect when stale
+    def browser
+      @query_scope.browser
+    end
+
+    def located?
+      !!@shadow_root
+    end
+
+    def wd
+      assert_exists
+      @shadow_root
+    end
+
+    def execute_script(script, *args, function_name: nil)
+      browser.execute_script(script, *args, function_name: function_name)
+    end
+
+    def stale?
+      @shadow_root.find_elements(css: 'checking_stale_shadow_root')
       false
+    rescue Selenium::WebDriver::Error::DetachedShadowRootError
+      true
+    end
+
+    def reset!
+      @shadow_root = nil
+    end
+
+    def locate
+      @shadow_root = @query_scope.wd.shadow_root
+    rescue Selenium::WebDriver::Error::NoSuchShadowRootError
+      nil
     end
 
     #
@@ -15,6 +49,10 @@ module Watir
 
     def selector_string
       "#{@query_scope.selector_string} --> shadow_root"
+    end
+
+    def custom_message
+      ''
     end
   end
 end

--- a/spec/watirspec/html/shadow_dom.html
+++ b/spec/watirspec/html/shadow_dom.html
@@ -11,7 +11,7 @@
     <script>
       let shadowRoot = document.getElementById('shadow_host').attachShadow({mode: 'open'});
       shadowRoot.innerHTML = `
-              <span class="wrapper" id="shadow_dom_first_element"><span class="info">some text</span></span>
+              <span class="wrapper" id="shadow_content"><span class="info">some text</span></span>
               <div id="nested_shadow_host"></div>
               <a href="scroll.html">scroll.html</a>
               <input type="text" />
@@ -21,7 +21,7 @@
 
       let nestedShadowRoot = shadowRoot.getElementById('nested_shadow_host').attachShadow({mode: 'open'});
       nestedShadowRoot.innerHTML = `
-              <div id="nested_shadow_dom_first_element"><div>nested text</div></div>
+              <div id="nested_shadow_content"><div>nested text</div></div>
             `;
     </script>
   </body>

--- a/spec/watirspec/html/shadow_dom.html
+++ b/spec/watirspec/html/shadow_dom.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Shadow DOM</title>
+  </head>
+  <body>
+    <div id="non_host"></div>
+    <div id="shadow_host"></div>
+    <a href="scroll.html">scroll.html</a>
+    <script>
+      let shadowRoot = document.getElementById('shadow_host').attachShadow({mode: 'open'});
+      shadowRoot.innerHTML = `
+              <span class="wrapper" id="shadow_dom_first_element"><span class="info">some text</span></span>
+              <div id="nested_shadow_host"></div>
+              <a href="scroll.html">scroll.html</a>
+              <input type="text" />
+              <input type="checkbox" />
+              <input type="file" />
+            `;
+
+      let nestedShadowRoot = shadowRoot.getElementById('nested_shadow_host').attachShadow({mode: 'open'});
+      nestedShadowRoot.innerHTML = `
+              <div id="nested_shadow_dom_first_element"><div>nested text</div></div>
+            `;
+    </script>
+  </body>
+</html>

--- a/spec/watirspec/shadow_root_spec.rb
+++ b/spec/watirspec/shadow_root_spec.rb
@@ -1,0 +1,95 @@
+require 'watirspec_helper'
+
+describe 'ShadowRoot' do
+  before :each do
+    browser.goto(WatirSpec.url_for('shadow_dom.html'))
+  end
+
+  describe '#exists?' do
+    it 'returns true when element has a shadow DOM' do
+      shadow_root = browser.div(id: 'shadow_host').shadow_root
+      expect(shadow_root).to exist
+    end
+
+    it 'returns false when element does not have a shadow DOM' do
+      missing_shadow_root = browser.div(id: 'non_host').shadow_root
+      expect(missing_shadow_root).not_to exist
+    end
+
+    it 'returns false when element does not exist' do
+      missing_shadow_root = browser.div(id: 'does_not_exist').shadow_root
+      expect(missing_shadow_root).not_to exist
+    end
+  end
+
+  it 'locates a nested element' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    expect(shadow_root.element.id).to eq('shadow_dom_first_element')
+    expect(shadow_root.element(id: 'nested_shadow_host').id).to eq('nested_shadow_host')
+    expect(shadow_root.element(id: /nested_shadow_.+/).id).to eq('nested_shadow_host')
+    expect(shadow_root.element(css: 'div').id).to eq('nested_shadow_host')
+    expect(shadow_root.div.id).to eq('nested_shadow_host')
+  end
+
+ it 'locates a collection of nested elements' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    expect(shadow_root.elements.count).to eq(7)
+    expect(shadow_root.elements(id: 'nested_shadow_host').map(&:id)).to eq(['nested_shadow_host'])
+    expect(shadow_root.elements(id: /nested_shadow_.+/).map(&:id)).to eq(['nested_shadow_host'])
+    expect(shadow_root.elements(css: 'div').map(&:id)).to eq(['nested_shadow_host'])
+    expect(shadow_root.divs.map(&:id)).to eq(['nested_shadow_host'])
+  end
+
+  it 'locates a nested element within a nested shadow DOM' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    nested_shadow_root = shadow_root.element(id: 'nested_shadow_host').shadow_root
+    expect(nested_shadow_root.element.id).to eq('nested_shadow_dom_first_element')
+  end
+
+  it 'locates a collection of nested elements within a nested shadow DOM' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    nested_shadow_root = shadow_root.element(id: 'nested_shadow_host').shadow_root
+    expect(nested_shadow_root.elements.count).to eq(2)
+    expect(nested_shadow_root.elements.map(&:id)).to include('nested_shadow_dom_first_element')
+  end
+
+  it 'raises ArgumentError when using :xpath to locate elements directly from the shadow root' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    expect { shadow_root.element(xpath: './/span').exists? }.to raise_exception(ArgumentError)
+  end
+
+  it 'allows using :xpath to locate elements with an element of a shadow root' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    expect(shadow_root.span.element(xpath: './/span')).to exist
+  end
+
+  it 'returns false when locating element in shadow root that does not exist' do
+    missing_shadow_root = browser.div(id: 'non_host').shadow_root
+    expect(missing_shadow_root.element).not_to exist
+  end
+
+  it 'click elements within the shadow dom' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    shadow_root.link.click
+    expect(browser.url).to include('scroll.html')
+  end
+
+  it 'click! elements within the shadow dom' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+    shadow_root.link.click!
+    expect(browser.url).to include('scroll.html')
+  end
+
+  it 'inputs form elements within the shadow dom' do
+    shadow_root = browser.div(id: 'shadow_host').shadow_root
+
+    shadow_root.text_field.set('abc')
+    expect(shadow_root.text_field.value).to eq('abc')
+
+    shadow_root.checkbox.set
+    expect(shadow_root.checkbox.set?).to eq(true)
+
+    shadow_root.file_field.set(File.expand_path(__FILE__))
+    expect(shadow_root.file_field.value).to include('shadow_root_spec.rb')
+  end
+end

--- a/spec/watirspec/shadow_root_spec.rb
+++ b/spec/watirspec/shadow_root_spec.rb
@@ -24,7 +24,7 @@ describe 'ShadowRoot' do
 
   it 'locates a nested element' do
     shadow_root = browser.div(id: 'shadow_host').shadow_root
-    expect(shadow_root.element.id).to eq('shadow_dom_first_element')
+    expect(shadow_root.element.id).to eq('shadow_content')
     expect(shadow_root.element(id: 'nested_shadow_host').id).to eq('nested_shadow_host')
     expect(shadow_root.element(id: /nested_shadow_.+/).id).to eq('nested_shadow_host')
     expect(shadow_root.element(css: 'div').id).to eq('nested_shadow_host')
@@ -43,14 +43,14 @@ describe 'ShadowRoot' do
   it 'locates a nested element within a nested shadow DOM' do
     shadow_root = browser.div(id: 'shadow_host').shadow_root
     nested_shadow_root = shadow_root.element(id: 'nested_shadow_host').shadow_root
-    expect(nested_shadow_root.element.id).to eq('nested_shadow_dom_first_element')
+    expect(nested_shadow_root.element.id).to eq('nested_shadow_content')
   end
 
   it 'locates a collection of nested elements within a nested shadow DOM' do
     shadow_root = browser.div(id: 'shadow_host').shadow_root
     nested_shadow_root = shadow_root.element(id: 'nested_shadow_host').shadow_root
     expect(nested_shadow_root.elements.count).to eq(2)
-    expect(nested_shadow_root.elements.map(&:id)).to include('nested_shadow_dom_first_element')
+    expect(nested_shadow_root.elements.map(&:id)).to include('nested_shadow_content')
   end
 
   it 'raises ArgumentError when using :xpath to locate elements directly from the shadow root' do


### PR DESCRIPTION
This is a continuation of the code from #943

It's implemented with the Selenium methods, so right now it only works with Chrome v96.
Selenium shadow root is really no different from what you get back from execute script, so we could even rescue `rescue Selenium::WebDriver::Error::UnknownCommandError` and use the script to get a shadow root object.

The other major difference is that since a Shadow Root isn't an element, a lot of the methods in Element don't apply. As such, it doesn't really make sense to have it inherit from Element. So I've pulled out the methods applicable to ShadowRoot and Element and put them into a new module `SearchContext`.

Really I wish I already had a command executor in place, and I'm not sure how I feel about this code, hence the Draft PR.