### PR TITLE
Fix links to Github Actions and Rubocop GH repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ bundle exec rake svg:update
 
 #### Github Actions
 
-Watir specs are run with [Github Actions](https://github.com/watir/watir/workflows).
+Watir specs are run with [Github Actions](https://github.com/watir/watir/tree/main/.github/workflows).
 
 Watir code is tested on Linux with latest versions of supported browsers and all active Ruby versions.
 
@@ -92,7 +92,7 @@ to ensure all paths in their code have tests associated with them.
 
 #### Rubocop
 
-Watir is using [Rubocop](https://github.com/rubocop-hq/rubocop) to ensure a consistent style across the
+Watir is using [Rubocop](https://github.com/rubocop/rubocop) to ensure a consistent style across the
 code base. It is run with our minimum supported Ruby version (2.3) 
 We have some [established exceptions](https://github.com/watir/watir/blob/main/.rubocop.yml) 
 that might need to be tweaked for new code submissions. This can be addressed in the PR as necessary.


### PR DESCRIPTION
This will fix broken link to Watir GitHub Actions and update link to Rubocop GitHub repo.

I was also thinking to replace broken links to svg image for all tests with separate link to svg image for each tests (Chrome Tests, Edge Tests, ...).

Code Climate, Coverage Status svg are also not correct.

Click on [established exceptions](https://github.com/watir/watir/blob/main/.rubocop.yml) does not load page. Could we replace link with file name?
 