### PR TITLE
Replace deprecated usages of YAML.safe_load with 2 arguments

### DIFF
--- a/spec/watirspec/cookies_spec.rb
+++ b/spec/watirspec/cookies_spec.rb
@@ -142,7 +142,7 @@ describe 'Browser#cookies' do
         browser.cookies.clear
         browser.cookies.load file
         expected = browser.cookies.to_a
-        actual = YAML.safe_load(IO.read(file), [::Symbol])
+        actual = YAML.safe_load(IO.read(file), permitted_classes: [::Symbol])
 
         expected.each { |cookie| cookie.delete(:expires) }
         actual.each { |cookie| cookie.delete(:expires) }


### PR DESCRIPTION
The Ruby 3 specs are failing with the following error:

~~~~
  1) Browser#cookies cookie file #load loads cookies from file
     Failure/Error: actual = YAML.safe_load(IO.read(file), [::Symbol])

     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./spec/watirspec/cookies_spec.rb:145:in `block (4 levels) in <top (required)>'
~~~~

Calling YAML.safe_load with 2 arguments was deprecated in Ruby 2.x and is no longer available in Ruby 3.x. This change switches to using the named arguments.