### PR TITLE
DateField and DateTimeField - Accept inputs that behave like Date

### DIFF
--- a/lib/watir/elements/date_field.rb
+++ b/lib/watir/elements/date_field.rb
@@ -9,8 +9,8 @@ module Watir
     def set!(date)
       date = Date.parse date if date.is_a?(String)
 
-      message = "DateField##{__callee__} only accepts instances of Date or Time"
-      raise ArgumentError, message unless [Date, ::Time].include?(date.class)
+      message = "DateField##{__callee__} only accepts instances that respond to #strftime"
+      raise ArgumentError, message unless date.respond_to?(:strftime)
 
       date_string = date.strftime('%Y-%m-%d')
       element_call(:wait_for_writable) do

--- a/lib/watir/elements/date_time_field.rb
+++ b/lib/watir/elements/date_time_field.rb
@@ -9,8 +9,8 @@ module Watir
     def set!(date)
       date = ::Time.parse date if date.is_a?(String)
 
-      message = "DateTimeField##{__callee__} only accepts instances of DateTime or Time"
-      raise ArgumentError, message unless [DateTime, ::Time].include?(date.class)
+      message = "DateTimeField##{__callee__} only accepts instances that respond to #strftime"
+      raise ArgumentError, message unless date.respond_to?(:strftime)
 
       date_time_string = date.strftime('%Y-%m-%dT%H:%M')
       element_call(:wait_for_writable) do

--- a/spec/watirspec/elements/date_field_spec.rb
+++ b/spec/watirspec/elements/date_field_spec.rb
@@ -124,10 +124,27 @@ module Watir
 
     # Manipulation methods
     describe '#value=' do
-      it 'sets the value of the element' do
+      it 'sets the value of the element to a Date' do
         date = browser.date_field(id: 'html5_date')
         date.value = Date.today
         expect(Date.parse(date.value)).to eq Date.today
+      end
+
+      it 'sets the value of the element to a Time' do
+        date = browser.date_field(id: 'html5_date')
+        date.value = ::Time.now
+        expect(Date.parse(date.value)).to eq Date.today
+      end
+
+      it 'sets the value of the element to an arbitrary class that responds to #strftime' do
+        instance_like_date = ::Object.new
+        def instance_like_date.strftime(_)
+          '2022-10-11'
+        end
+
+        date = browser.date_field(id: 'html5_date')
+        date.value = instance_like_date
+        expect(date.value).to eq '2022-10-11'
       end
 
       it 'sets the value when accessed through the enclosing Form' do

--- a/spec/watirspec/elements/date_time_field_spec.rb
+++ b/spec/watirspec/elements/date_time_field_spec.rb
@@ -124,12 +124,31 @@ module Watir
 
     # Manipulation methods
     describe '#value=' do
-      it 'sets the value of the element' do
+      it 'sets the value of the element to a Time' do
         date_time = ::Time.now
         date_time_field = browser.date_time_field(id: 'html5_datetime-local')
         date_time_field.value = date_time
         expect(::Time.parse(date_time_field.value).strftime('%Y-%m-%dT%H:%M'))
           .to eq date_time.strftime('%Y-%m-%dT%H:%M')
+      end
+
+      it 'sets the value of the element to a DateTime' do
+        date_time = DateTime.now
+        date_time_field = browser.date_time_field(id: 'html5_datetime-local')
+        date_time_field.value = date_time
+        expect(::Time.parse(date_time_field.value).strftime('%Y-%m-%dT%H:%M'))
+          .to eq date_time.strftime('%Y-%m-%dT%H:%M')
+      end
+
+      it 'sets the value of the element to an arbitrary class that responds to #strftime' do
+        date_time = ::Object.new
+        def date_time.strftime(_)
+          '2022-10-11T12:13'
+        end
+
+        date_time_field = browser.date_time_field(id: 'html5_datetime-local')
+        date_time_field.value = date_time
+        expect(date_time_field.value).to eq '2022-10-11T12:13'
       end
 
       it 'sets the value when accessed through the enclosing Form' do


### PR DESCRIPTION
Setting a `DateField` or `DateTimeField` currently requires a `String`, `Date` or `Time`. This can be too strict. 

For example, it prevents using ActiveSupport with time zones:

~~~~
require 'active_support/time'

Time.zone = 'Stockholm'
browser.date_field.set(2.months.ago)
#=> ArgumentError (DateField#set only accepts instances of Date or Time)
~~~~

This PR proposes accepting any object that responds to `#strftime`.