### PR TITLE
Point website to https://watir.github.io/ meanwhile

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Watir Powered By Selenium!
 This README is for people interested in writing code for Watir or gems in the Watir ecosystem
 that leverage private-api Watir code.
 
-For our users, everything you'll need is on the [Watir website](http://watir.com):
+For our users, everything you'll need is on the [Watir website](https://watir.github.io/):
 examples, news, guides, additional resources, support information and more.
 
 ## Procedure for Patches/Pull Requests


### PR DESCRIPTION
The domain is owned by someone else and the web has been down for more than a month, it's better to change the url until the website is restored.

solves #977 #975 #974